### PR TITLE
Sync with upstream

### DIFF
--- a/parax/pipeline_stage.py
+++ b/parax/pipeline_stage.py
@@ -163,7 +163,8 @@ class XlaPipelineStage(PipelineStage):
         options.parameter_is_tupled_arguments = tuple_args
         compiled = backend.compile(xla_computation, compile_options=options)
         result_handlers = map(partial(xla.aval_to_result_handler, device), out_avals)
-        return partial(xla._execute_compiled, compiled, out_avals, result_handlers)
+        kept_var_idx = range(len(self.invars))
+        return partial(xla._execute_compiled, compiled, out_avals, result_handlers, kept_var_idx)
 
 
 @dataclass

--- a/parax/shard_parallel.py
+++ b/parax/shard_parallel.py
@@ -17,7 +17,6 @@ from jax.api_util import (
     flatten_fun_nokwargs,
     argnums_partial,
 )
-from jax.config import flags, config, bool_env
 from jax.core import ShapedArray
 from jax.experimental.maps import mesh
 from jax.experimental.pjit import pjit


### PR DESCRIPTION
To avoid the divergence of our codebase and tensorflow/jax mainline, we want to regularly rebase our repos to the tensorflow/jax mainline. This brings several advantages:
1. Get latest updates from mainline. Google is activaly improving Jax and XLA GPU backend.
2. Make future maintaince easier. If we do not sync with mainline for a long time, we would never be able to sync with mainline again due to too many conflicts.

Currently, I plan to rebase our repos (tensorflow-parax and jax-parax)  once a month. Note that rebase will rewrite the history of our repos, so we have to sync our local repos carefully after rebase.

This PR fixes some bugs of `parax` repo after rebase.

# Sync local repos
I force-pushed the rebased code base to tensorflow-parax and jax-parax, so you have to force-update your local repos.

### Sync tensorflow-parax
```bash
cd tensorflow-parax
git checkout master
git fetch origin master
git reset --hard origin/master
```
### Sync jax-parax
```bash
cd jax-parax
git checkout master
git fetch origin master
git reset --hard origin/master
```