### PR TITLE
Include pipeline parallelism in the Megatron-LM benchmark

### DIFF
--- a/benchmark/megatron/benchmark_gpt_bert.py
+++ b/benchmark/megatron/benchmark_gpt_bert.py
@@ -2,14 +2,16 @@ import argparse
 
 from util import run_cmd
 
-# B = batch_size, S = seq_len, H = hidden_size, L = num_layers, V = vocab_size,
-# #head = num_heads, DP = dp_size, TMP = tensor_mp_size, DPI = ddp_implementation,
-# CK = checkpoint_activations
+# B = global_batch_size, S = seq_len,
+# H = hidden_size, L = num_layers, V = vocab_size, #head = num_heads,
+# DP = data_parallel, TP = tensor_model_parallel, PP = pipeline_model_parallel,
+# NB = num_micro_batches
+# DI = ddp_implementation, CK = checkpoint_activations
 
 benchmark_suite_1_gpu = [
-    # B,  S,    H,    L,  #head,     V,     DP, TMP, DPI, CK
-    (16,  512,  1024, 24, 1024//64,  32000, 1,  1,   1,   0),
-    (8,   1024, 1536, 16, 1536//96,  32000, 1,  1,   1,   0),
+    # B,  S,    H,    L,  #head,     V,     DP, TP, PP, NB, DI, CK
+    (16,  512,  1024, 24, 1024//64,  32000, 1,  1,  1,  1,  1,  0),
+    (8,   1024, 1536, 16, 1536//96,  32000, 1,  1,  1,  1,  1,  0),
 ]
 
 benchmark_suite_4_gpu = [
@@ -17,15 +19,20 @@ benchmark_suite_4_gpu = [
 ]
 
 benchmark_suite_8_gpu = [
-    # B,  S,    H,    L,  #head,     V,     DP, TMP, DPI, CK
-    (128, 512,  1024, 24, 1024//64,  32000, 8,  1,   1,   0),
-    (8,   1024, 4096, 20, 4096//128, 32000, 1,  8,   1,   0),
+    # B,  S,    H,    L,  #head,     V,     DP, TP, PP, NB, DI, CK
+    (128, 512,  1024, 24, 1024//64,  32000, 8,  1,  1,  1,  1,  0),
+    (256, 512,  1024, 24, 1024//64,  32000, 8,  1,  1,  2,  1,  0),
+    (8,   1024, 4096, 20, 4096//128, 32000, 1,  8,  1,  1,  1,  0),
+    (16,  1024, 4096, 20, 4096//128, 32000, 1,  8,  1,  2,  1,  0),
+    (256, 1024, 4096, 20, 4096//128, 32000, 1,  8,  1,  32, 1,  0),
 ]
 
 benchmark_suite_16_gpu = [
-    # B,  S,    H,    L,  #head,     V,     DP, TMP, DPI, CK
-    (256, 512,  1024, 24, 1024//64,  32000, 16, 1,   1,   0),
-    (16,  1024, 4096, 20, 4096//128, 32000, 2,  8,   1,   0),
+    # B,  S,    H,    L,  #head,     V,     DP, TP, PP, NB, DI, CK
+    (256, 512,  1024, 24, 1024//64,  32000, 16, 1,  1,  1,  1,  0),
+    (512, 512,  1024, 24, 1024//64,  32000, 16, 1,  1,  2,  1,  0),
+    (16,  1024, 4096, 20, 4096//128, 32000, 2,  8,  1,  1,  1,  0),
+    (256, 1024, 4096, 20, 4096//128, 32000, 2,  8,  1,  16, 1,  0),
 ]
 
 

--- a/benchmark/megatron/benchmark_gpt_bert_one_case.py
+++ b/benchmark/megatron/benchmark_gpt_bert_one_case.py
@@ -120,17 +120,19 @@ def get_bert_functions():
 
 def benchmark_gpt_bert_one_case(benchmark_case):
     # Model configs
-    model_type, batch_size, seq_len, hidden_size, num_layers, num_heads, \
-        vocab_size, dp_size, tensor_mp_size, ddp_impl, checkpoint_activations \
-        = benchmark_case
+    model_type, global_batch_size, seq_len, hidden_size, num_layers, num_heads,\
+        vocab_size, dp_size, tensor_mp_size, pipeline_mp_size, num_micro_batches,\
+        ddp_impl, checkpoint_activations = benchmark_case
+
+    assert global_batch_size % (dp_size * num_micro_batches) == 0
+    micro_batch_size = global_batch_size // dp_size // num_micro_batches
 
     # Parallel configs
-    micro_batch_size = batch_size // dp_size
-
     # Initialize megatron
     sys.argv += ["--micro-batch-size", str(micro_batch_size)]
     sys.argv += ["--tensor-model-parallel-size", str(tensor_mp_size)]
-    sys.argv += ["--global-batch-size", str(batch_size)]
+    sys.argv += ["--pipeline-model-parallel-size", str(pipeline_mp_size)]
+    sys.argv += ["--global-batch-size", str(global_batch_size)]
     sys.argv += ["--num-layers", str(num_layers)]
     sys.argv += ["--hidden-size", str(hidden_size)]
     sys.argv += ["--num-attention-heads", str(num_heads)]
@@ -153,6 +155,7 @@ def benchmark_gpt_bert_one_case(benchmark_case):
     # Check initialization
     assert dp_size == mpu.get_data_parallel_world_size()
     assert tensor_mp_size == mpu.get_tensor_model_parallel_world_size()
+    assert pipeline_mp_size == mpu.get_pipeline_model_parallel_world_size()
 
     # Build model
     if model_type == "gpt":
@@ -174,15 +177,13 @@ def benchmark_gpt_bert_one_case(benchmark_case):
     # Warmup and reset timers
     run_func()
     timers = get_timers()
-    #names = ['forward-compute', 'backward-compute', 'backward-params-all-reduce',
-    #         'backward-embedding-all-reduce', 'optimizer']
     names = list(timers.timers.keys())
     for name in names:
         timers(name).reset()
 
     # Benchmark step time
-    repeat = 3
-    number = 3
+    repeat = 10
+    number = 1
     costs = benchmark_func(run_func, sync_func=None,
                            warmup=0, repeat=repeat, number=number)
     timers.log(names, normalizer=repeat * number)
@@ -190,14 +191,14 @@ def benchmark_gpt_bert_one_case(benchmark_case):
     # Print results
     if rank == 0:
         peak_mem = torch.cuda.max_memory_allocated(0)
-        tflops = compute_gpt_tflops(batch_size, seq_len, num_layers,
+        tflops = compute_gpt_tflops(global_batch_size, seq_len, num_layers,
                                     hidden_size, vocab_size,
                                     torch.distributed.get_world_size(),
                                     np.mean(costs))
         heads = ["Type", "Case", "Mesh Shape", "DDP Impl", "Checkpointing",
                  "Parameter Count", "Peak Mem", "Mean Time", "Std Time", "TFLOPS"]
-        values = [model_type, str(benchmark_case[1:-4]),
-                  str((dp_size, tensor_mp_size)),
+        values = [model_type, str(benchmark_case[1:-6]),
+                  str((dp_size, tensor_mp_size, pipeline_mp_size, num_micro_batches)),
                   "local" if ddp_impl else "torch",
                   str(checkpoint_activations),
                   f"{parameter_count/1e9:.3f}", f"{peak_mem/GB:5.3f}",


### PR DESCRIPTION
cc @zhuohan123 @zhisbug 
The 3d-parallelism in Megatron-lm is very easy to use. We can move our benchmark to megatron-lm's code base.


The readme on how to install the dependencies : https://github.com/parax-project/parax/blob/master/benchmark/megatron/README.md
Configurations of the benchmark suits:
https://github.com/parax-project/parax/blob/d447325d85bd4388df6a5569cde32d50e40df726/benchmark/megatron/benchmark_gpt_bert.py#L5-L36