### PR TITLE
fix donate invar in 3d pipeline parallelism

### DIFF
--- a/parax/pipeline_parallel/stage.py
+++ b/parax/pipeline_parallel/stage.py
@@ -481,7 +481,16 @@ def mark_missing_vars_in_pipeline_marks(stages: Sequence[JaxPipelineStage],
     return new_stages
 
 
-def rearange_vars(vars, selected, pipe_marker=None, is_input=True):
+def rearrange_vars(vars, selected: Sequence[Var], pipe_marker=None, is_input=True):
+    """
+    Rearrange vars to let those in selected be the first. If the pipe_marker is given,
+    rearrange invars and outvars in pipemarker also.
+    Args:
+        vars (Sequence[Var]): all vars to be rearranged.
+        selected (Sequence[Var]): vars selected to be prior.
+        pipe_marker (JaxprEqn): pipe marker corresponding to vars
+        is_input (bool): the var is input of pipe_marker, if False, it is output
+    """
     new_vars = list(selected)
     selected = set(selected)
     for var in vars:
@@ -531,8 +540,8 @@ def generate_sharded_xla_stages(name: str,
                 continue
             donation_mapping[stage.invars[idx]] = stage.outvars[idx]
         eqns += stage.eqns
-    invars = rearange_vars(invars, list(donation_mapping.keys()))
-    outvars = rearange_vars(outvars, list(donation_mapping.values()))
+    invars = rearrange_vars(invars, list(donation_mapping.keys()))
+    outvars = rearrange_vars(outvars, list(donation_mapping.values()))
     jaxpr = Jaxpr(
         constvars=list(consts_dir.keys()),
         invars=list(invars),

--- a/parax/pipeline_parallel/three_d_parallel.py
+++ b/parax/pipeline_parallel/three_d_parallel.py
@@ -17,7 +17,7 @@ from parax.pipeline_parallel.stage import (
     JaxPipelineStage, apply_grad_add_marker, apply_grad_get_mean,
     compute_to_acc_pipe, generate_sharded_xla_stages, get_var_mapping,
     mark_grad_mesh, mark_missing_vars_in_pipeline_marks, pipeline_dce,
-    rearange_vars, slice_apply_gradient,
+    rearrange_vars, slice_apply_gradient,
     slice_closed_jaxpr_by_full_pipeline_marks)
 from parax.util import get_micro_batch, slices_to_jaxpr
 
@@ -135,12 +135,12 @@ def split_donate_invars(global_invars, donation_mapping,
                 list(map(lambda v: gensym_fn(v.aval), appended_invars)),
                 pipe_start.params['name'], pipe_start.params['mark_type'])
 
-    # reschedule to keep donated invars and outvars have same index
+    # rearrange to keep donated invars and outvars have same index
     for stage_idx, stage in enumerate(stages):
         donate_mapping = donate_mappings[stage_idx]
-        new_invars, new_pipe_start = rearange_vars(
+        new_invars, new_pipe_start = rearrange_vars(
             stage.invars, list(donate_mapping.keys()), stage.eqns[0], True)
-        new_outvars, new_pipe_end = rearange_vars(
+        new_outvars, new_pipe_end = rearrange_vars(
             stage.outvars, list(donate_mapping.values()), stage.eqns[-1], False)
         stage.invars = new_invars
         stage.outvars = new_outvars


### PR DESCRIPTION
The original one does not set alias based on donate invars [in the final compilation](https://github.com/parax-project/parax/blob/e5bdfbcd08ccb9e46fb843ed050aa2458886691f/parax/pipeline_parallel/stage.py#L212). To do so, this PR:
1. adds `reschedule_vars` to keep donated invars always first ones and the corresponding outvar has the same index;
2. setup alias of each stage's `XlaComputation`
3. In the `compile_with_search` progress, donated invars are also added as much as possible.