### PR TITLE
fix physical mesh in compile with search

### DIFF
--- a/parax/device_mesh.py
+++ b/parax/device_mesh.py
@@ -393,14 +393,15 @@ class CompileWorker:
             avals,
             out_avals,
             donate_invars,
-            True,
+            None,
             logical_mesh_choices,
             global_config.mesh_shape_search_mode,
             global_config.memory_budget_per_device,
             search_task,
             record_file,
             multiple_stages=True,
-            grad_acc_num_micro_batches=None)
+            grad_acc_num_micro_batches=None,
+            bypass_device_assignment_check=True)
         assert len(
             protos) == 1, "compile worker compiles multiple stages in a time"
         return protos[0], strategy_config

--- a/parax/pipeline_parallel/stage.py
+++ b/parax/pipeline_parallel/stage.py
@@ -561,14 +561,15 @@ def generate_sharded_xla_stages(name: str,
         invars,
         outvars,
         dummy_donated_invars,
-        physical_mesh.is_distributed,
+        physical_mesh,
         logical_mesh_choices,
         logical_mesh_search_mode,
         memory_budget_per_device,
         search_task,
         record_file,
         multiple_stages=True,
-        grad_acc_num_micro_batches=None)
+        grad_acc_num_micro_batches=None,
+        bypass_device_assignment_check=physical_mesh.is_distributed)
     stages = [
         XlaShardedPipelineStage.from_auto_sharded_stage(
             auto_sharded_hlo_proto=proto,

--- a/parax/shard_parallel/auto_sharding.py
+++ b/parax/shard_parallel/auto_sharding.py
@@ -31,10 +31,11 @@ class HloProtoStatus(enum.IntEnum):
 
 
 def compile_with_search(backend, xla_computation, avals, out_avals,
-                        donated_invars, bypass_device_assignment_check, logical_mesh_choices,
+                        donated_invars, physical_mesh, logical_mesh_choices,
                         logical_mesh_search_mode, memory_budget_per_device,
                         search_task, record_file, multiple_stages,
-                        grad_acc_num_micro_batches):
+                        grad_acc_num_micro_batches,
+                        bypass_device_assignment_check):
     """Compile an XLA computation with mesh shape search and auto sharding solver.
 
     Args:
@@ -74,8 +75,7 @@ def compile_with_search(backend, xla_computation, avals, out_avals,
     compile_options = get_compile_options(
         num_replicas=1,
         num_partitions=total_devices,
-        device_assignment=np.arange(total_devices).reshape(
-            (1, -1)),
+        device_assignment=np.arange(total_devices).reshape((1, -1)),
         use_spmd_partitioning=True,
         parameter_is_tupled_arguments=False,
         build_random_seed=build_random_seed)

--- a/parax/shard_parallel/shard_callable.py
+++ b/parax/shard_parallel/shard_callable.py
@@ -171,14 +171,15 @@ def shard_parallel_internal(fun: lu.WrappedFun, in_tree, out_tree_thunk,
             avals,
             out_avals,
             donated_invars,
-            physical_mesh.is_distributed,
+            physical_mesh,
             logical_mesh_choices,
             logical_mesh_search_mode,
             memory_budget_per_device,
             search_task,
             record_file,
             multiple_stages=False,
-            grad_acc_num_micro_batches=None)
+            grad_acc_num_micro_batches=None,
+            bypass_device_assignment_check=physical_mesh.is_distributed)
     else:
         compiled = compile_with_given_strategy(backend, built, strategy_config,
                                                physical_mesh.total_devices,
@@ -236,14 +237,15 @@ def shard_parallel_internal_gradient_accumulation(
         avals,
         out_avals,
         donated_invars,
-        physical_mesh.is_distributed,
+        physical_mesh,
         logical_mesh_choices,
         logical_mesh_search_mode,
         memory_budget_per_device,
         search_task,
         record_file,
         multiple_stages=True,
-        grad_acc_num_micro_batches=num_micro_batches)
+        grad_acc_num_micro_batches=num_micro_batches,
+        bypass_device_assignment_check=physical_mesh.is_distributed)
     assert len(hlo_protos) == 2
 
     # Compile these two HLOs separately to get two XLA executables


### PR DESCRIPTION
The parameter `physical_mesh` of `compile_with_search` is removed in https://github.com/parax-project/parax/pull/115. However, though it can be replaced in some paths, with `logical_mesh_search_mode` set "measurement", it is required for profiling.