### PR TITLE
Donate activations

### DIFF
--- a/parax/pipeline_parallel/three_d_parallel.py
+++ b/parax/pipeline_parallel/three_d_parallel.py
@@ -14,10 +14,10 @@ from parax.pipeline_parallel.schedules import (GpipeSchedule,
                                                gen_dependency_with_stages)
 from parax.pipeline_parallel.computation import (
     create_donation_mapping, generate_computations_from_protos,
-    generate_sharded_xla_computations,
-    generate_sharded_xla_computations_compile_config, get_donatable_intermediate,
-    mark_missing_vars_in_pipeline_marks, pipeline_dce,
-    slice_closed_jaxpr_by_full_pipeline_marks, split_donate_invars)
+    generate_sharded_xla_computations_compile_config,
+    get_donatable_intermediate, mark_missing_vars_in_pipeline_marks,
+    pipeline_dce, slice_closed_jaxpr_by_full_pipeline_marks,
+    split_donate_invars)
 from parax.pipeline_parallel.apply_grad import (
     compute_grad_to_accumulate_grad, process_apply_gradient,
     split_compute_grad_and_apply_grad)
@@ -195,7 +195,7 @@ def three_d_parallel_callable(fun: lu.WrappedFun, in_tree, out_tree_thunk,
             mesh_idx]
         sharded_xla_stages = generate_computations_from_protos(
             jax_computations, acc_grad_outvars, computation_donate_invars,
-            computation_protos, strategy_config)
+            donatable_dict[mesh_idx], computation_protos, strategy_config)
         for i, xla_stage in zip(stage_id_dict[mesh_idx], sharded_xla_stages):
             xla_stages[i] = xla_stage
             xla_stage.get_compiled(physical_meshes[mesh_idx])


### PR DESCRIPTION
Donate activations as describted in https://github.com/parax-project/parax/issues/125
However, with condition that accumulate gradient and donate optimizer, the algorithm does not change much. In a two layer bert model, only one intermediate is additionally donated. This is because:
1. In apply gradient stage, currently outputs are updated weights, which share the same buffer of donated optimizer, so no need to add new donation;
2. In backward stage, likewise outputs are gradients and share the buffer of accumulated gradients in last round, no need to add new donation;
3. In forward stage, only the received activation from last stage can be donated(not main copy principle). 