### PR TITLE
using a better indexing

### DIFF
--- a/parax/util.py
+++ b/parax/util.py
@@ -560,6 +560,12 @@ def jax_tensor_set(src_buf, update, start_indices):
     return src_buf
 
 
+@partial(jax.jit, static_argnums=(1, 2))
+def jax_tensor_index(src_tensor, indices, size):
+    dst_tensor = jax.lax.dynamic_slice(src_tensor, indices, size)
+    return dst_tensor
+
+
 ########################################
 ##### OS / IO Utilities
 ########################################


### PR DESCRIPTION
This PR addresses #146. Some notes:

- Jax tensor indexing is very slow because operations like `tensor[tuple(offset)]` causes a lot of MemcpyH2D(4B) kernels (at least 3), this PR uses `dynamic_slice` instead.
- `dynammic_slice`: (1) reduces to one memcpyH2D(4B) + memcpy when slice shape and tensor shape match (2) reduces to a `dynamic_slice` kernel when it is really doing slicing (slice shape \subset tensor_shape). In both cases, it is better than `tensor[tuple(offset)]`
- Unlike `jax_buffer_set`, this jit is not for in-place writing. When jitted, this `memcpyH2D(4B)` disappears, so a slight performance improvement.



Some results:

Time (s) | Setting
-- | --
0.668 | fast path
0.71 | tensor[tuple(offset)]
0.668 | jax_buffer_index (jit version)
0.676 | jax_buffer_index

