### PR TITLE
fix grpc error

### DIFF
--- a/parax/device_mesh.py
+++ b/parax/device_mesh.py
@@ -56,7 +56,9 @@ class MeshHostWorker:
         self.host_id = host_id
         self.distributed_client = \
             xla_client._xla.get_distributed_runtime_client(server_address, host_id)
-        self.distributed_client.connect()
+        logger.debug("Trying to connect to xla runtime at {}...".format(server_address))
+        status = self.distributed_client.connect()
+        logger.debug("Success to connect to xla runtime at {}...".format(server_address))
         self.backend = xla_client.make_gpu_client(self.distributed_client,
                                                   node_id=host_id)
         # Monkey patch the backend
@@ -472,11 +474,13 @@ class PhysicalDeviceMesh:
 
     def _launch_xla_servers(self):
         # Launch distributed xla runtime
-        port = np.random.randint(10000, 11000)
+        port = np.random.randint(20000, 23000)
         self.server_address = f"{self.head_ip}:{port}"
         self.service_server = None
+        logger.debug("Trying to start XLA gRPC server on port: {}...".format(port))
         self.service_server = xla_client._xla.get_distributed_runtime_service(
             self.server_address, self.num_hosts)
+        logger.debug("Success to start XLA gRPC server on port: {}...".format(port))
         time.sleep(0.5)
 
         # Launch workers
@@ -783,6 +787,10 @@ class PhysicalDeviceMesh:
             for worker in self.workers:
                 ray.kill(worker)
             self.workers = None
+
+            # shutdown grpc server
+            self.service_server.shutdown()
+            self.service_server = None
         else:
             self.sync_workers()
 


### PR DESCRIPTION
1. ray actor is spawned from port 10001. Sometimes when a case went down (due to OOM or other reasons), ray can be slow on deallocating ports; so better to shift XLA ports to start from 20000
2. we  only shut down grpc clients (MeshHostWorker); we should also shut down grpc servers, which actually owns ports.