### PR TITLE
add bidirectional dict maintaining reverse mapping

### DIFF
--- a/parax/pipeline_parallel/decentralized_distributed_runtime.py
+++ b/parax/pipeline_parallel/decentralized_distributed_runtime.py
@@ -25,7 +25,7 @@ from parax.pipeline_parallel.cross_mesh_resharding import ReshardingTask
 from parax.pipeline_parallel.schedules import cached_property, PipelineSchedule
 from parax.pipeline_parallel.computation import XlaShardedPipelineComputation
 from parax.timer import timers
-from parax.util import OrderedSet, get_shard_shape
+from parax.util import DisjointDict, OrderedSet, get_shard_shape
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -135,12 +135,6 @@ def logging_instructions(instructions):
 
 def get_dict(d: Dict[Any, Dict], k) -> Dict:
     return d.setdefault(k, dict())
-
-
-def recursive_lookup(d, k):
-    if k in d:
-        return recursive_lookup(d, d[k])
-    return k
 
 
 class DecentralizedDistributedRuntime(BaseDistributedRuntime):
@@ -258,7 +252,7 @@ class DecentralizedDistributedRuntime(BaseDistributedRuntime):
         for mesh in self.physical_meshes:
             for worker in mesh.workers:
                 worker_tmp_instructions[worker] = []
-        donation_mapping = [dict() for _ in range(num_mesh)]
+        donation_mapping = [DisjointDict() for _ in range(num_mesh)]
         worker_to_idx = dict()
         for mesh_idx, mesh in enumerate(self.physical_meshes):
             for worker_idx, worker in enumerate(mesh.workers):
@@ -344,8 +338,7 @@ class DecentralizedDistributedRuntime(BaseDistributedRuntime):
                     for idx in range(len(stage.invars)):
                         if donated_invars[idx]:
                             donation_mapping[mesh_idx].update(
-                                zip(list(input_uuids[idx]),
-                                    list(output_uuids[idx])))
+                                list(input_uuids[idx]), list(output_uuids[idx]))
 
                     kwargs = {
                         "skip_grad_sync":
@@ -384,7 +377,7 @@ class DecentralizedDistributedRuntime(BaseDistributedRuntime):
                 accumulated_uuids = accumulated_uuids[worker_idx]
             # numpy for (arg, device)
             accumulated_uuids = [[
-                recursive_lookup(donation_mapping[mesh_idx], uuid)
+                donation_mapping[mesh_idx].recursive_lookup(uuid)
                 for uuid in list(uuids)
             ]
                                  for uuids in list(accumulated_uuids)]

--- a/parax/util.py
+++ b/parax/util.py
@@ -248,6 +248,39 @@ class OrderedSet:
         return f"{cls.__name__}[{item.__name__}]"
 
 
+class DisjointDict:
+
+    def __init__(self):
+        self.values = dict()
+        self.reversed_mapping = dict()
+
+    def update(self, keys, values):
+        for key, value in zip(keys, values):
+            value = self.recursive_lookup(value)
+            self.values[key] = value
+            self._reversed_recursive_update(key, value)
+
+    def _reversed_recursive_update(self, key, value):
+        if key in self.reversed_mapping:
+            reversed_mapping = self.reversed_mapping[key]
+            self.reversed_mapping.setdefault(value,
+                                             set()).update(reversed_mapping)
+            self.reversed_mapping.pop(key)
+            for k in reversed_mapping:
+                self.values[k] = value
+        self.reversed_mapping.setdefault(value, set()).add(key)
+
+    def recursive_lookup(self, key):
+        if key in self.values:
+            value = self.values[key]
+            assert value not in self.values
+            return value
+        return key
+
+    def keys(self):
+        return list(self.values.keys())
+
+
 def cached_property(fn, *args, **kwargs):
     """
     Decorator to make a function a "cached property".


### PR DESCRIPTION
previous `recursive_lookup` fails when number of microbatch is too large. The new version updates it aggressively, and keeps the `recursive_lookup` depth no more than 2.