### PR TITLE
Do not use cpp jit

### DIFF
--- a/alpa/util.py
+++ b/alpa/util.py
@@ -820,6 +820,11 @@ def cupy_to_jax_tensor(tensors):
     return from_dlpack(tensors.toDlpack())
 
 
+# Note: use Python jit instead of CPP jit,
+# because CPP jit has bugs on _DeviceArray.
+FLAGS.experimental_cpp_jit = False
+
+
 # Note(Hao): this function will be jit-ed into as many versions as the possible length of start_indices
 @partial(jax.jit, donate_argnums=0, static_argnums=2)
 def jax_tensor_set(src_buf, update, start_indices):


### PR DESCRIPTION
CPP jit still has bugs on `_DeviceArray` after rebasing jax. Revert the change in https://github.com/alpa-projects/alpa/pull/319#discussion_r795284332