### PR TITLE
 Reorganize passes and build options

### DIFF
--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -190,8 +190,14 @@ class MeshHostWorker:
     def run_executable(self, uuid: int, *args, **kwargs):
         self.executables[uuid].execute_on_worker(*args, **kwargs)
 
+    def get_exec_hlo_text(self, uuid: int):
+        return self.executables[uuid].get_hlo_text()
+
     def get_exec_total_allocation_size(self, uuid: int):
         return self.executables[uuid].get_total_allocation_size()
+
+    def get_exec_grad_sync_channel_ids(self, uuid: int):
+        return self.executables[uuid].grad_sync_channel_ids
 
     ##### Cross Mesh Resharding Related Functions #####
     @staticmethod

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -1281,31 +1281,19 @@ class VirtualPhysicalMesh:
         return self.get_logical_mesh((1, self.num_devices))
 
 
-def set_jax_env_on_driver(use_gpu_on_driver=False):
+def set_jax_env_on_driver(use_cpu_on_driver=True):
     """Set jax environment flags for the driver process, so the driver
     process can release GPU memory for the worker processes."""
 
     # Use cpu backend
-    if not use_gpu_on_driver:
-        jax.config.update('jax_platform_name', 'cpu')
-
-    # Use platform allocator in the driver process for auto-tuning
-    # the conv algorithms and gemm algorithms in cudnn and cublas.
-    old_allocator = os.environ.get("XLA_PYTHON_CLIENT_ALLOCATOR", None)
-
-    os.environ["XLA_PYTHON_CLIENT_ALLOCATOR"] = "platform"
-    backend = xb.get_backend("gpu")
-
-    if old_allocator:
-        os.environ["XLA_PYTHON_CLIENT_ALLOCATOR"] = old_allocator
-    else:
-        del os.environ["XLA_PYTHON_CLIENT_ALLOCATOR"]
+    if use_cpu_on_driver:
+        jax.config.update("jax_platform_name", "cpu")
 
 
 class DeviceCluster:
     """A ray cluster with GPU devices."""
 
-    def __init__(self, use_gpu_on_driver=False):
+    def __init__(self, use_cpu_on_driver=True):
         # pylint: disable=import-outside-toplevel
         from ray.worker import _global_node as ray_global_node
         try:
@@ -1313,7 +1301,7 @@ class DeviceCluster:
         except AttributeError:
             raise RuntimeError(
                 "Cannot access ray global node. Did you call ray.init?")
-        self.head_ip = self.head_info['node_ip_address']
+        self.head_ip = self.head_info["node_ip_address"]
 
         # Gather host ids
         self.host_info = []
@@ -1329,7 +1317,7 @@ class DeviceCluster:
             assert number.is_integer()
             self.num_devices.append(int(number))
 
-        set_jax_env_on_driver(use_gpu_on_driver)
+        set_jax_env_on_driver(use_cpu_on_driver)
 
     @property
     def num_cpus(self):

--- a/alpa/global_env.py
+++ b/alpa/global_env.py
@@ -224,7 +224,7 @@ def set_parallelize_options(
 
 is_worker = os.environ.get("ALPA_IS_WORKER", "False") == "True"
 
-os.environ["XLA_FLAGS"] = os.environ.get("XLA_FLAGS",
-                                         "") + " --xla_gpu_autotune_level=0"
+#os.environ["XLA_FLAGS"] = os.environ.get("XLA_FLAGS",
+#                                         "") + " --xla_gpu_autotune_level=0"
 
 #os.environ["XLA_FLAGS"] = os.environ.get("XLA_FLAGS", "") + " --xla_gpu_enable_async_all_reduce=true"

--- a/alpa/measure_record.py
+++ b/alpa/measure_record.py
@@ -40,17 +40,20 @@ class StrategyConfig:
 
     def __init__(self, build_random_seed: int, logical_mesh_shape: Tuple[int],
                  all_gather_threshold: int, all_reduce_threshold: int,
-                 auto_sharding_solution_vector: np.ndarray):
+                 auto_sharding_solution_vector: np.ndarray,
+                 auto_sharding_objective: int):
         self.build_random_seed = build_random_seed
         self.logical_mesh_shape = logical_mesh_shape
         self.all_gather_threshold = all_gather_threshold
         self.all_reduce_threshold = all_reduce_threshold
         self.auto_sharding_solution_vector = auto_sharding_solution_vector
+        self.auto_sharding_objective = auto_sharding_objective
 
     def to_jsonable(self):
         return (self.build_random_seed, tuple(self.logical_mesh_shape),
                 self.all_gather_threshold, self.all_reduce_threshold,
-                to_int_tuple(self.auto_sharding_solution_vector))
+                to_int_tuple(self.auto_sharding_solution_vector),
+                self.auto_sharding_objective)
 
     @staticmethod
     def from_jsonable(value):
@@ -58,7 +61,8 @@ class StrategyConfig:
          all_reduce_threshold, auto_sharding_solution_vector) = value
         return StrategyConfig(build_random_seed, logical_mesh_shape,
                               all_gather_threshold, all_reduce_threshold,
-                              np.array(auto_sharding_solution_vector))
+                              np.array(auto_sharding_solution_vector),
+                              self.auto_sharding_objective)
 
 
 class MeasureInput(namedtuple("MeasureInput", ["task", "config"])):

--- a/alpa/mesh_executable.py
+++ b/alpa/mesh_executable.py
@@ -472,6 +472,7 @@ class GradAccMeshDriverExecutable(MeshDriverExecutable):
         self.apply_grad_invar_indices = apply_grad_invar_indices
         self.num_micro_batches = num_micro_batches
         self.flop_count = flop_count
+        self.auto_sharding_objective = strategy_config.auto_sharding_objective
 
         # Read sharding specs
         logical_mesh_shape = strategy_config.logical_mesh_shape

--- a/alpa/mesh_executable.py
+++ b/alpa/mesh_executable.py
@@ -373,7 +373,7 @@ class NormalMeshWorkerExecutable(MeshWorkerExecutable):
         xla_computation = xla_client.XlaComputation(hlo_proto)
         num_devices = np.prod(strategy_config.logical_mesh_shape)
         assert num_devices == len(worker.backend.devices())
-        hlo_proto_status = HloProtoStatus.FULLY_OPTIMIZED
+        hlo_proto_status = HloProtoStatus.SPMD_PARTITIONED
 
         self.compiled = compile_with_given_strategy(
             worker.backend,
@@ -756,7 +756,7 @@ class GradAccMeshWorkerExecutable:
                  grad_sync_channel_ids: str):
         num_devices = np.prod(strategy_config.logical_mesh_shape)
         assert num_devices == len(worker.backend.devices())
-        hlo_proto_status = HloProtoStatus.FULLY_OPTIMIZED
+        hlo_proto_status = HloProtoStatus.SPMD_PARTITIONED
 
         self.accumulate_grad = compile_with_given_strategy(
             worker.backend,

--- a/alpa/monkey_patch.py
+++ b/alpa/monkey_patch.py
@@ -7,7 +7,6 @@ import jax
 from jax import core, lax, numpy as jnp
 from jax.interpreters.xla import (xops, jaxpr_subcomp, extend_name_stack,
                                   wrap_name)
-from jax.lib import xla_client as xc
 from jax._src.lib.xla_bridge import get_backend as default_get_backend
 import numpy as np
 

--- a/alpa/pipeline_parallel/base_runtime.py
+++ b/alpa/pipeline_parallel/base_runtime.py
@@ -159,12 +159,12 @@ class BaseDistributedRuntime(BaseRuntime):
         raise NotImplementedError()
 
     def _precompile_sharding_specs(self):
-        """Run get_compiled() for each stage to get sharding specs."""
+        """Run spmd partitioner pass for each stage to get sharding specs."""
         for stage_idx, stage in enumerate(self.stages):
             mesh_indices = list(self.schedule.stage_placement(stage_idx))
             assert len(mesh_indices) == 1
             mesh_idx = mesh_indices[0]
-            stage.get_compiled(self.physical_meshes[mesh_idx])
+            stage.get_spmd_partitioned()
 
     def _establish_nccl_groups(self):
         """

--- a/alpa/pipeline_parallel/computation.py
+++ b/alpa/pipeline_parallel/computation.py
@@ -6,14 +6,14 @@ from typing import Sequence, Any, Dict
 
 import jax
 from jax import jit
+from jax._src.lib import xla_bridge as xb, xla_client as xc, xla_extension as xe
 from jax._src.util import partial, safe_map
 from jax._src import dispatch
 from jax.core import (Atom, Var, JaxprEqn, Jaxpr, ClosedJaxpr, DropVar, Literal,
                       jaxpr_as_fun, new_jaxpr_eqn, gensym, named_call_p,
                       ShapedArray)
-from jax.interpreters import xla
+from jax.interpreters import xla, pxla
 from jax.interpreters.partial_eval import remat_call_p
-from jax.lib import xla_bridge as xb, xla_client as xc
 from jaxlib import xla_extension
 import numpy as np
 
@@ -23,11 +23,10 @@ from alpa.mesh_executable import PartialGradAccMeshDriverExecutable
 from alpa.pipeline_parallel.primitive_def import (mark_hook_jaxpreqn,
                                                   pipeline_p,
                                                   mark_pipeline_jaxpreqn)
-from alpa.shard_parallel.auto_sharding import (compile_with_search,
-                                               compile_with_given_strategy,
+from alpa.shard_parallel.auto_sharding import (run_auto_sharding_pass,
+                                               run_spmd_partitioner_pass,
                                                get_input_output_sharding_specs,
-                                               hlo_sharding_to_sharding_spec,
-                                               HloProtoStatus)
+                                               hlo_sharding_to_sharding_spec)
 from alpa.global_env import global_config
 from alpa.util import (OrderedSet, clone_jaxpr, get_compile_options,
                        jaxpr_to_hlo_computation, setup_computation_alias,
@@ -193,14 +192,14 @@ class XlaPipelineComputation(PipelineComputation):
 class XlaShardedPipelineComputation(PipelineComputation):
     """A pipeline computation defined by XLA HLO proto. The XLA HLO is annotated by sharding spec."""
 
-    hlo_proto: Any = None
-    donated_invars: Any = None
+    sharding_annotated_proto: bytes = None
+    donated_invars: Sequence[bool] = None
     strategy_config: StrategyConfig = None
-    input_sharding_specs: Any = None
-    output_sharding_specs: Any = None
+    input_sharding_specs: Sequence[pxla.ShardingSpec] = None
+    output_sharding_specs: Sequence[pxla.ShardingSpec] = None
     output_acc_grad_indices: Sequence[int] = None
     donatables: OrderedSet[Var] = None
-    compiled = None
+    spmd_partitioned_hlo_module: xe.HloModule = None
 
     @classmethod
     def dummy_computation(cls, name, logical_mesh_shape, gensym_func):
@@ -211,11 +210,11 @@ class XlaShardedPipelineComputation(PipelineComputation):
                                          logical_mesh_shape, 1, 1, None)
         compiled = compile_dummy_zero_constant(backend,
                                                np.prod(logical_mesh_shape))
-        hlo_proto = compiled.hlo_modules()[0].as_serialized_hlo_module_proto()
+        sharding_annotated_proto = compiled.hlo_modules()[0].as_serialized_hlo_module_proto()
         outvar = gensym_func(ShapedArray((), np.dtype(np.int32)))
         return cls(
             name=name,
-            hlo_proto=hlo_proto,
+            sharding_annotated_proto=sharding_annotated_proto,
             strategy_config=strategy_config,
             donated_invars=[],
             invars=[],
@@ -229,11 +228,11 @@ class XlaShardedPipelineComputation(PipelineComputation):
             cls,
             *,
             jax_pipeline_computation: JaxPipelineComputation,
-            auto_sharded_hlo_proto: xc.XlaComputation,
+            sharding_annotated_proto: xc.XlaComputation,
             strategy_config: StrategyConfig,
-            donated_invars=None,
-            acc_grad_outvars=(),
-            donatables=None):
+            donated_invars: Sequence[bool] = None,
+            acc_grad_outvars: Sequence[Var] = (),
+            donatables: OrderedSet[Var] = None):
         """Run auto-sharding optimizer on a Jax pipeline computation."""
         if donatables is None:
             donatables = OrderedSet()
@@ -248,7 +247,7 @@ class XlaShardedPipelineComputation(PipelineComputation):
         ]
 
         return cls(name=jax_pipeline_computation.name,
-                   hlo_proto=auto_sharded_hlo_proto,
+                   sharding_annotated_proto=sharding_annotated_proto,
                    strategy_config=strategy_config,
                    donated_invars=donated_invars,
                    invars=jax_pipeline_computation.invars,
@@ -303,66 +302,48 @@ class XlaShardedPipelineComputation(PipelineComputation):
         for invar in donated_invars:
             self.donated_invars[var_indices[invar]] = True
 
-    def get_compiled(self, mesh=None, is_distributed=None):
-        """Compile the XLA computation to get sharding specs."""
-        # TODO(yonghao): use more general cache functions
-        if self.compiled is not None:
-            return self.compiled
-
-        if (not isinstance(mesh, PhysicalDeviceMesh) and
-                is_distributed is None):
-            raise RuntimeError(
-                "Require a pre-allocated physical mesh to compile the runnable."
-            )
-
-        is_distributed = (mesh.is_distributed
-                          if mesh is not None else is_distributed)
+    def get_spmd_partitioned(self):
+        """Run spmd partitioner to get the input/output sharding specs after partitioning."""
+        if self.spmd_partitioned_hlo_module is not None:
+            return self.spmd_partitioned_hlo_module
 
         strategy_config = self.strategy_config
         logical_mesh_shape = strategy_config.logical_mesh_shape
-        xla_computation = xc.XlaComputation(self.hlo_proto)
+        xla_computation = xc.XlaComputation(self.sharding_annotated_proto)
         setup_computation_alias(xla_computation, self.donated_invars)
-        backend_name = 'gpu'
-        backend = xb.get_backend(backend_name)
+
         num_devices = np.prod(logical_mesh_shape)
         rewrite_for_grad_acc = len(self.output_acc_grad_indices) > 0
-        compiled = compile_with_given_strategy(
-            backend,
+        spmd_partitioned_hlo_module = run_spmd_partitioner_pass(
             xla_computation,
-            self.strategy_config,
             num_devices,
-            HloProtoStatus.SHARDING_ANNOTATED,
-            bypass_device_assignment_check=is_distributed,
             rewrite_for_grad_acc=rewrite_for_grad_acc,
             rewrite_grad_acc_indices=self.output_acc_grad_indices)
 
         avals = [var.aval for var in self.invars]
         out_avals = [var.aval for var in self.outvars]
         input_sharding_specs, output_sharding_specs = get_input_output_sharding_specs(
-            compiled.hlo_modules()[0], avals, out_avals, num_devices,
+            spmd_partitioned_hlo_module, avals, out_avals, num_devices,
             strategy_config.logical_mesh_shape)
         self.input_sharding_specs = input_sharding_specs
         self.output_sharding_specs = output_sharding_specs
-        self.compiled = compiled
-        return compiled
+        self.spmd_partitioned_hlo_module = spmd_partitioned_hlo_module
+        return spmd_partitioned_hlo_module
 
-    def get_runnable(self, mesh=None):
+    def get_runnable(self, mesh):
         """Return a callable of the pipeline computation."""
-        compiled = self.get_compiled(mesh)
-        # hlo_module = compiled.hlo_modules()[0]
+        hlo_module = self.get_spmd_partitioned()
 
-        # Return the final callable
         avals = [var.aval for var in self.invars]
         out_avals = [var.aval for var in self.outvars]
         mesh_executable = PartialGradAccMeshDriverExecutable(
-            mesh, compiled, self.strategy_config, avals, out_avals,
+            mesh, hlo_module, self.strategy_config, avals, out_avals,
             self.donated_invars, self.output_acc_grad_indices)
-
         return mesh_executable.get_driver_callable()
 
     def get_hlo_text(self):
         """Get the HLO text."""
-        xla_computation = xc.XlaComputation(self.hlo_proto)
+        xla_computation = xc.XlaComputation(self.sharding_annotated_proto)
         return xla_computation.as_hlo_text()
 
 
@@ -793,7 +774,7 @@ def generate_computations_from_protos(jax_computations, computation_names,
     proto_dict = dict(zip(computation_names, computation_protos))
     computations = [
         XlaShardedPipelineComputation.from_auto_sharded_computation(
-            auto_sharded_hlo_proto=proto_dict[computation.name],
+            sharding_annotated_proto=proto_dict[computation.name],
             jax_pipeline_computation=computation,
             strategy_config=strategy_config,
             donated_invars=donate_invars,
@@ -858,9 +839,8 @@ def generate_sharded_xla_computations_arguments(
 def generate_sharded_xla_computations(
         name: str, jax_computations: Sequence[JaxPipelineComputation],
         computation_donate_invars, donatable_lists, acc_grad_outvars,
-        num_micro_batches, logical_mesh_choices, autosharding_option,
-        memory_budget_per_device, logical_mesh_search_mode, search_task,
-        record_file):
+        num_micro_batches, logical_mesh, autosharding_option,
+        memory_budget_per_device):
     """
     Generate sharded XLA computations.
 
@@ -873,27 +853,19 @@ def generate_sharded_xla_computations(
     built = xc.XlaComputation(proto)
     in_avals, out_avals, donated_invars = jaxpr_args
 
-    backend_name = "gpu"
-    backend = xb.get_backend(backend_name)
-    _, computation_protos, strategy_config = compile_with_search(
-        backend,
+    _, computation_protos, strategy_config = run_auto_sharding_pass(
         built,
         in_avals,
         out_avals,
         donated_invars,
-        logical_mesh_choices,
+        logical_mesh,
         "stage_protos",
         num_micro_batches,
         autosharding_option,
-        bypass_device_assignment_check=True,
-        memory_budget_per_device=memory_budget_per_device,
-        logical_mesh_search_mode=logical_mesh_search_mode,
-        logical_mesh_search_physical_mesh=None,
-        search_task=search_task,
-        record_file=record_file)
+        memory_budget_per_device=memory_budget_per_device)
     computations = [
         XlaShardedPipelineComputation.from_auto_sharded_computation(
-            auto_sharded_hlo_proto=proto,
+            sharding_annotated_proto=proto,
             jax_pipeline_computation=computation,
             strategy_config=strategy_config,
             donated_invars=donate_invars,

--- a/alpa/pipeline_parallel/computation.py
+++ b/alpa/pipeline_parallel/computation.py
@@ -210,7 +210,8 @@ class XlaShardedPipelineComputation(PipelineComputation):
                                          logical_mesh_shape, 1, 1, None)
         compiled = compile_dummy_zero_constant(backend,
                                                np.prod(logical_mesh_shape))
-        sharding_annotated_proto = compiled.hlo_modules()[0].as_serialized_hlo_module_proto()
+        sharding_annotated_proto = compiled.hlo_modules(
+        )[0].as_serialized_hlo_module_proto()
         outvar = gensym_func(ShapedArray((), np.dtype(np.int32)))
         return cls(
             name=name,

--- a/alpa/pipeline_parallel/computation.py
+++ b/alpa/pipeline_parallel/computation.py
@@ -207,7 +207,7 @@ class XlaShardedPipelineComputation(PipelineComputation):
         backend_name = 'gpu'
         backend = xb.get_backend(backend_name)
         strategy_config = StrategyConfig(global_config.build_random_seed,
-                                         logical_mesh_shape, 1, 1, None)
+                                         logical_mesh_shape, 1, 1, None, 0)
         compiled = compile_dummy_zero_constant(backend,
                                                np.prod(logical_mesh_shape))
         sharding_annotated_proto = compiled.hlo_modules(

--- a/alpa/pipeline_parallel/decentralized_distributed_runtime.py
+++ b/alpa/pipeline_parallel/decentralized_distributed_runtime.py
@@ -185,10 +185,8 @@ class DecentralizedDistributedRuntime(BaseDistributedRuntime):
 
         self.uuid_counter = 0
         self.flop_count = flop_count
-        self.instruction_lists = {}
-        self.hlo_texts_after_spmd_partitioner = []
+        self.instruction_lists = {}  # Dict[worker -> List[PipelineInstruction]]
 
-        # states
         self.donate_invars = []
         self.delete_after_shard = []
         self.input_indices = []
@@ -199,13 +197,16 @@ class DecentralizedDistributedRuntime(BaseDistributedRuntime):
         self.mesh_output_indices = []
         self.output_spec_list = [[] for _ in range(self.num_mesh)]
 
-        # make this the states of this class
+        self.hlo_texts_after_spmd_partitioner = []
+        self.executable_uuids = []
+
+        # Compile pipeline instructions and send mesh executables to workers
         (executable_config_lists, input_local_uuid_list, grad_uuids,
          accumulated_uuid_lists) = self._compile()
 
-        self._worker_executable_uuid_mapping = {}
-        self._executable_uuid_worker_mapping = {}
-        # we create a PipelineMeshWorkerExecutable for each MeshHostWorker
+        # Create a PipelineMeshWorkerExecutable for each MeshHostWorker
+        self.worker_executable_uuid_mapping = {}
+        self.executable_uuid_worker_mapping = {}
         for mesh_idx, physical_mesh in enumerate(self.physical_meshes):
             mesh_grad_uuids = list(grad_uuids[mesh_idx])
             for worker_idx, worker in enumerate(physical_mesh.workers):
@@ -221,10 +222,10 @@ class DecentralizedDistributedRuntime(BaseDistributedRuntime):
                 uuid = next_mesh_executable_uuid()
                 worker.put_executable.remote(uuid, PipelineMeshWorkerExecutable,
                                              *args)
-                self._worker_executable_uuid_mapping[worker] = uuid
-                self._executable_uuid_worker_mapping[uuid] = worker
+                self.worker_executable_uuid_mapping[worker] = uuid
+                self.executable_uuid_worker_mapping[uuid] = worker
 
-        # for handling input/outputs
+        # For handling input/outputs
         self.outs_handler: Callable = None
         self._setup_outs_handler()
 
@@ -268,12 +269,11 @@ class DecentralizedDistributedRuntime(BaseDistributedRuntime):
         # compile args for tasks
         (executable_config_lists, executable_uuids,
          grad_uuids) = self._compile_task_configs(var_at)
-        # mesh_arg_indices
+        self.executable_uuids = executable_uuids
 
         input_local_uuid_list = self._compile_split_input_to_microbatches(
             not_batch_invars, var_at)
 
-        # Microbatch-related work
         worker_tmp_instructions = {}
         for mesh in self.physical_meshes:
             for worker in mesh.workers:
@@ -462,7 +462,7 @@ class DecentralizedDistributedRuntime(BaseDistributedRuntime):
         """
         Assign uuids for each task and prepare configs.
 
-        It resembles the __init__() method in DriverExecutables.
+        The configs save arguments for the __init__() method in DriverExecutable.
 
         Returns:
             executable_config_lists: configs of executables put on each mesh;
@@ -524,7 +524,6 @@ class DecentralizedDistributedRuntime(BaseDistributedRuntime):
             assert len(mesh_idx) == 1
             mesh_idx = list(mesh_idx)[0]
             hlo_module = stage.get_spmd_partitioned()
-            self.hlo_texts_after_spmd_partitioner.append(hlo_module.to_string())
             hlo_proto = hlo_module.as_serialized_hlo_module_proto()
             for worker in self.physical_meshes[mesh_idx].workers:
                 executable_config_lists[worker].append(
@@ -825,7 +824,7 @@ class DecentralizedDistributedRuntime(BaseDistributedRuntime):
         for mesh_idx, physical_mesh in enumerate(self.physical_meshes):
             for i, worker in enumerate(physical_mesh.workers):
                 worker.run_executable.remote(
-                    self._worker_executable_uuid_mapping[worker],
+                    self.worker_executable_uuid_mapping[worker],
                     input_uuids[mesh_idx][i], output_uuids[mesh_idx][i],
                     **kwargs)
 
@@ -987,6 +986,19 @@ class DecentralizedDistributedRuntime(BaseDistributedRuntime):
     def get_hlo_text(self, after_spmd_partitioner=True):
         """Return the HLO text for all stages."""
         if after_spmd_partitioner:
+            if self.hlo_texts_after_spmd_partitioner:
+                return self.hlo_texts_after_spmd_partitioner
+
+            hlo_texts = []
+            for stage_idx in range(len(self.stages)):
+                mesh_idx = self.schedule.stage_placement(stage_idx)
+                assert len(mesh_idx) == 1
+                mesh_idx = list(mesh_idx)[0]
+                physical_mesh = self.physical_meshes[mesh_idx]
+                hlo_text = physical_mesh.workers[0].get_exec_hlo_text.remote(
+                    self.executable_uuids[stage_idx])
+                hlo_texts.append(hlo_text)
+            self.hlo_texts_after_spmd_partitioner = ray.get(hlo_texts)
             return self.hlo_texts_after_spmd_partitioner
         else:
             ret = []
@@ -1044,7 +1056,7 @@ class DecentralizedDistributedRuntime(BaseDistributedRuntime):
                 worker: MeshHostWorker
                 all_worker_profiled.append(
                     worker.profile_executable_with_dummy_inputs.remote(
-                        self._worker_executable_uuid_mapping[worker]))
+                        self.worker_executable_uuid_mapping[worker]))
             if len(all_worker_profiled) == 1:
                 all_worker_profiled = all_worker_profiled[0]
             all_profiled_handles.append(all_worker_profiled)

--- a/alpa/pipeline_parallel/decentralized_distributed_runtime.py
+++ b/alpa/pipeline_parallel/decentralized_distributed_runtime.py
@@ -528,9 +528,9 @@ class DecentralizedDistributedRuntime(BaseDistributedRuntime):
             hlo_proto = hlo_module.as_serialized_hlo_module_proto()
             for worker in self.physical_meshes[mesh_idx].workers:
                 executable_config_lists[worker].append(
-                    PartialGradWorkerExecutableConfig(exec_uuid, hlo_proto,
-                                                      stage.strategy_config,
-                                                      stage.output_acc_grad_indices))
+                    PartialGradWorkerExecutableConfig(
+                        exec_uuid, hlo_proto, stage.strategy_config,
+                        stage.output_acc_grad_indices))
         return executable_config_lists, executable_uuids, grad_uuids
 
     def _compile_split_input_to_microbatches(self, not_batch_invars, var_at):

--- a/alpa/pipeline_parallel/pipeshard_parallel.py
+++ b/alpa/pipeline_parallel/pipeshard_parallel.py
@@ -241,8 +241,7 @@ def shard_each_stage(jax_all_stages, virtual_meshes, schedule, n_stages,
         # Setup dummy stages
         for i in dummy_stage_id_dict[mesh_idx]:
             xla_stages[i] = XlaShardedPipelineComputation.dummy_computation(
-                jax_all_stages[i].name, logical_mesh_choices[0].shape,
-                gensym_func)
+                jax_all_stages[i].name, logical_mesh.shape, gensym_func)
 
         stage_donate_invars = [
             donate_invars_dict[stage_idx]

--- a/alpa/pipeline_parallel/pipeshard_parallel.py
+++ b/alpa/pipeline_parallel/pipeshard_parallel.py
@@ -269,9 +269,7 @@ def shard_each_stage(jax_all_stages, virtual_meshes, schedule, n_stages,
             sharded_xla_stages, flops = generate_sharded_xla_computations(
                 str(mesh_idx), stage_dict[mesh_idx], stage_donate_invars,
                 donatable_dict[mesh_idx], acc_grad_outvars, num_micro_batches,
-                logical_mesh_choices, autosharding_option,
-                memory_budget_per_device, logical_mesh_search_mode, search_task,
-                record_file)
+                logical_mesh, autosharding_option, memory_budget_per_device)
             total_flops += flops
             for i, xla_stage in zip(stage_id_dict[mesh_idx],
                                     sharded_xla_stages):

--- a/alpa/pipeline_parallel/pipeshard_parallel.py
+++ b/alpa/pipeline_parallel/pipeshard_parallel.py
@@ -226,15 +226,13 @@ def shard_each_stage(jax_all_stages, virtual_meshes, schedule, n_stages,
     # Call auto-sharding pass on each stage
     xla_stages = [None] * n_stages
     compile_workers = CompileWorkerPool(num_meshes, 1)
-    compile_fn = lambda w, v: w.compile_proto_with_search.remote(*v)  # noqa
+    compile_fn = lambda w, v: w.run_auto_sharding_pass.remote(*v)  # noqa
     compile_intermediate = [None] * num_meshes
     total_flops = 0
     default_autosharding_option = global_config.default_autosharding_option
     for mesh_idx in range(num_meshes):
         virtual_mesh = virtual_meshes[mesh_idx]
-        logical_mesh_choices = [
-            virtual_mesh.get_logical_mesh(logical_mesh_shapes[mesh_idx])
-        ]
+        logical_mesh = virtual_mesh.get_logical_mesh(logical_mesh_shapes[mesh_idx])
         logical_mesh_search_mode = "cost_model"
         autosharding_option = default_autosharding_option.deepcopy_and_update(
             autosharding_option_dicts[mesh_idx])
@@ -254,19 +252,16 @@ def shard_each_stage(jax_all_stages, virtual_meshes, schedule, n_stages,
         if global_config.pipeline_distributed_compile:
             proto, jaxpr_args, flops = generate_sharded_xla_computations_arguments(
                 str(mesh_idx), stage_dict[mesh_idx], stage_donate_invars)
-            mesh_kwargs = {
-                "logical_mesh_choices": logical_mesh_choices,
+            other_kwargs = {
+                "logical_mesh": logical_mesh,
                 "return_mode": "stage_protos",
+                "as_option": autosharding_option,
                 "num_micro_batches": num_micro_batches,
-                "bypass_device_assignment_check": True,
                 "memory_budget_per_device": memory_budget_per_device,
-                "logical_mesh_search_mode": logical_mesh_search_mode,
-                "search_task": search_task,
-                "record_file": record_file,
             }
             compile_workers.submit(
                 compile_fn,
-                (mesh_idx, proto, jaxpr_args, autosharding_option, mesh_kwargs))
+                (mesh_idx, proto, jaxpr_args, other_kwargs))
             compile_intermediate[mesh_idx] = (stage_dict[mesh_idx],
                                               stage_donate_invars)
             total_flops += flops

--- a/alpa/pipeline_parallel/pipeshard_parallel.py
+++ b/alpa/pipeline_parallel/pipeshard_parallel.py
@@ -232,7 +232,8 @@ def shard_each_stage(jax_all_stages, virtual_meshes, schedule, n_stages,
     default_autosharding_option = global_config.default_autosharding_option
     for mesh_idx in range(num_meshes):
         virtual_mesh = virtual_meshes[mesh_idx]
-        logical_mesh = virtual_mesh.get_logical_mesh(logical_mesh_shapes[mesh_idx])
+        logical_mesh = virtual_mesh.get_logical_mesh(
+            logical_mesh_shapes[mesh_idx])
         logical_mesh_search_mode = "cost_model"
         autosharding_option = default_autosharding_option.deepcopy_and_update(
             autosharding_option_dicts[mesh_idx])
@@ -259,9 +260,8 @@ def shard_each_stage(jax_all_stages, virtual_meshes, schedule, n_stages,
                 "num_micro_batches": num_micro_batches,
                 "memory_budget_per_device": memory_budget_per_device,
             }
-            compile_workers.submit(
-                compile_fn,
-                (mesh_idx, proto, jaxpr_args, other_kwargs))
+            compile_workers.submit(compile_fn,
+                                   (mesh_idx, proto, jaxpr_args, other_kwargs))
             compile_intermediate[mesh_idx] = (stage_dict[mesh_idx],
                                               stage_donate_invars)
             total_flops += flops

--- a/alpa/pipeline_parallel/stage_profiling.py
+++ b/alpa/pipeline_parallel/stage_profiling.py
@@ -368,7 +368,7 @@ class HloCostModelProfileWorker:
         _, _, _, acc_grad_indices = profile_info
         xla_computation = xla_client.XlaComputation(compiled_output.model_proto)
 
-        hlo_proto_status = HloProtoStatus.FULLY_OPTIMIZED
+        hlo_proto_status = HloProtoStatus.SPMD_PARTITIONED
         try:
             compiled = compile_with_given_strategy(
                 self.backend,

--- a/alpa/pipeline_parallel/stage_profiling.py
+++ b/alpa/pipeline_parallel/stage_profiling.py
@@ -145,7 +145,8 @@ class CompileWorker:
         self.cnt += 1
 
         # Compile with search to get sharding annotations.
-        jaxpr_args = (config.input_avals, config.output_avals, config.donate_invars)
+        jaxpr_args = (config.input_avals, config.output_avals,
+                      config.donate_invars)
         other_kwargs = {
             "logical_mesh": logical_mesh,
             "return_mode": "stage_and_hook_protos",
@@ -191,7 +192,8 @@ class CompileWorker:
             logger.warning(f"Compilation error for stage {stage_id} : {e}")
             return stage_id, None
 
-        optimized_proto = compiled.hlo_modules()[0].as_serialized_hlo_module_proto()
+        optimized_proto = compiled.hlo_modules(
+        )[0].as_serialized_hlo_module_proto()
         return stage_id, CompileOutput(optimized_proto, strategy_config,
                                        input_sharding_protos,
                                        output_sharding_proto, hooked_proto,
@@ -200,7 +202,8 @@ class CompileWorker:
     def run_auto_sharding_pass(self, stage_id, proto, jaxpr_args, other_kwargs):
         """Run auto-sharding pass on a proto."""
         built = xla_client.XlaComputation(proto)
-        return stage_id, run_auto_sharding_pass(built, *jaxpr_args, **other_kwargs)
+        return stage_id, run_auto_sharding_pass(built, *jaxpr_args,
+                                                **other_kwargs)
 
 
 class CompileWorkerPool(BaseWorkerPoolWrapper):
@@ -351,11 +354,10 @@ class HloCostModelProfileWorker:
         """Use cost model to estimate cost on this profile worker."""
         _, _, _, acc_grad_indices = profile_info
         try:
-            compiled = run_backend_compilation(
-                self.backend,
-                compiled_output.model_proto,
-                compiled_output.strategy_config,
-                self.num_devices)
+            compiled = run_backend_compilation(self.backend,
+                                               compiled_output.model_proto,
+                                               compiled_output.strategy_config,
+                                               self.num_devices)
             # TODO:
             # 1. Bypass device assignment check
             # 2. do not run auto-tuning

--- a/alpa/pipeline_parallel/stage_profiling.py
+++ b/alpa/pipeline_parallel/stage_profiling.py
@@ -408,7 +408,7 @@ class HloCostModelProfileWorkerPool(BaseWorkerPoolWrapper):
         worker_cls = ray.remote(num_cpus=1,
                                 num_gpus=gpu_per_cpu)(HloCostModelProfileWorker)
         self.actors = [
-            worker_cls.options({
+            worker_cls.options(runtime_env={
                 "env_vars": env_vars
             }).remote(prof_result, mesh_num_devices, num_micro_batches)
             for _ in range(num_cpus)

--- a/alpa/shard_parallel/auto_sharding.py
+++ b/alpa/shard_parallel/auto_sharding.py
@@ -372,7 +372,9 @@ def run_spmd_partitioner_pass(
 def run_backend_compilation(backend: xe.Client,
                             xla_computation: Union[xe.XlaComputation,
                                                    xe.HloModule, bytes],
-                            strategy_config: StrategyConfig, num_devices: int):
+                            strategy_config: StrategyConfig,
+                            num_devices: int,
+                            bypass_device_assignment_check: bool = False):
     """Compile a spmd partitioned Hlo Module to an XLA executable.
 
     Args:
@@ -380,6 +382,7 @@ def run_backend_compilation(backend: xe.Client,
       xla_computation: The input HLO Module. The status should be SPMD_PARTITIONED.
       strategy_config: The auto-sharding strategy solution.
       num_devices: The total number of devices.
+      bypass_device_assignment_check: Whether to compile without exact devices.
     """
     compile_options = get_compile_options(
         num_replicas=1,
@@ -399,7 +402,7 @@ def run_backend_compilation(backend: xe.Client,
 
     with XlaPassContext({
             # Build options
-            "build_option::bypass_device_assignment_check": False,
+            "build_option::bypass_device_assignment_check": bypass_device_assignment_check,
             "build_option::run_pre_spmd_partitioner_passes": False,
             "build_option::run_auto_sharding": False,
             "build_option::run_spmd_partitioner": False,

--- a/alpa/shard_parallel/auto_sharding.py
+++ b/alpa/shard_parallel/auto_sharding.py
@@ -1,4 +1,23 @@
-"""Use the auto sharding pass in XLA."""
+"""Use the auto sharding pass in XLA.
+
+The compilation passes and status of an HloModule:
+
+UNOPTIMIZED
+  |
+  |  pre_spmd_partitioner passes
+  |
+  |  auto_sharding pass
+  V
+SHARDING_ANNOTATED
+  |
+  |  spmd partitioner pass
+  V
+SPMD_PARTITIONED
+  |
+  |  post_spmd_partitioner passes
+  V
+FULLY_OPTIMIZED
+"""
 import copy
 import enum
 import logging
@@ -9,10 +28,9 @@ from typing import Sequence, Optional, Union, Tuple
 import warnings
 
 import numpy as np
+from jax._src.lib import xla_bridge as xb, xla_client as xc, xla_extension as xe
 from jax.core import ShapedArray
 from jax.interpreters import xla, pxla
-from jaxlib import xla_extension
-from jaxlib.xla_client import OpSharding
 
 from alpa.global_env import global_config, AutoShardingOption
 from alpa.measure_record import (MeasureInput, MeasureResult, StrategyConfig,
@@ -24,31 +42,6 @@ logger.setLevel(logging.INFO)
 
 # A constant to represent infinity
 INFINITY_COST = 1e13
-
-
-class HloProtoStatus(enum.IntEnum):
-    """The status of a HLO protobuf.
-    The compilation passes and status of the HloModule:
-    
-    UNOPTIMIZED
-       |
-       |  pre spmd partitioner passes
-       |
-       |  auto_sharding pass
-       V
-    SHARDING_ANNOTATED
-       |
-       |  spmd partitioner pass
-       V
-    SPMD_PARTITIONED
-       |
-       |  post_spmd_partitioner_passes
-       V
-    XLA_EXECUTABLES
-    """
-    UNOPTIMIZED = 0  # An unoptimized HLO got from tracing the jaxpr.
-    SHARDING_ANNOTATED = 1  # A HLO with sharding annotation attached.
-    SPMD_PARTITIONED = 2 # A HLO that is partitioned by SPMD partitioner
 
 
 class LogicalDeviceMesh:
@@ -133,57 +126,43 @@ class LogicalDeviceMesh:
                                      other.mesh_alpha, other.mesh_beta))
 
 
-def compile_with_search(backend: xla_extension.Client,
-                        xla_computation: xla_extension.XlaComputation,
-                        avals: Sequence[ShapedArray],
-                        out_avals: Sequence[ShapedArray],
-                        donated_invars: Sequence[bool],
-                        logical_mesh_choices: Sequence[LogicalDeviceMesh],
-                        return_mode: str,
-                        num_micro_batches: int,
-                        as_option: AutoShardingOption,
-                        bypass_device_assignment_check: bool,
-                        memory_budget_per_device: Optional[float] = None,
-                        logical_mesh_search_mode: Optional[str] = None,
-                        logical_mesh_search_physical_mesh: Optional[
-                            "PhysicalDeviceMesh"] = None,
-                        search_task: Optional[SearchTask] = None,
-                        record_file: Optional[str] = None):
-    """Compile an XLA computation with mesh shape search and auto sharding solver.
+def run_auto_sharding_pass(xla_computation: xe.XlaComputation,
+                           avals: Sequence[ShapedArray],
+                           out_avals: Sequence[ShapedArray],
+                           donated_invars: Sequence[bool],
+                           logical_mesh: LogicalDeviceMesh,
+                           return_mode: str,
+                           num_micro_batches: int,
+                           as_option: AutoShardingOption,
+                           rewrite_for_grad_acc: bool = False,
+                           rewrite_grad_acc_indices: Optional[Sequence[int]] = None,
+                           memory_budget_per_device: Optional[float] = None):
+    """Run the auto-sharding pass to annotate sharding specs for an XLA Computation.
 
     Args:
-      backend: The XLA backend client.
-      xla_computation: The unoptimized xla computation
-        got by tracing the jax function.
+      xla_computation: The xla computation got by tracing the jax function,
+        whose status should be UNOPTIMIZED.
       avals: The abstract values of input arguments.
       out_avals: The abstract values of outputs.
       donated_invars: Whether the arguments are donated.
-      logical_mesh_choices: The candidates of logical mesh shape.
-        If there is only one choice, use the given one. If there are multiple choices,
-        we will try all of them and pick the best.
-      return_mode: The mode of return value. The choices are {"executable", "stage_protos", "stage_and_hook_protos"}.
-        If it is "executable", return the compiled xla executable.
-        If it is "stage_protos", return the HLO Module proto of multiple pipeline stages.
-        If it is "stage_and_hook_protos", return the HLO Module proto of multiple pipeline stages and the hooked hlo sharding.
+      logical_mesh: The logical device mesh.
+      return_mode: The mode of return value.
+        The choices are {"single", "stage_protos", "stage_and_hook_protos"}.
+        If it is "single", return a single HLO Module proto, whose status is SPMD_PARTITIONED.
+        If it is "stage_protos", return HLO Module protos of multiple pipeline stages,
+          whose statuses are SHARDING_ANNOTATED.
+        If it is "stage_and_hook_protos", return HLO Module protos of multiple pipeline stages
+          and the hooked hlo sharding. The statuses of the returned protos are SHARDING_ANNOTATED.
       num_micro_batches: The number of micro batches
         if gradient accumulation is used. If this is set, the cost of all-reduce
         for gradient synchronization is divided by this number.
       as_option: The options of the auto-sharding solver.
-      bypass_device_assignment_check: Whether to compile without exact devices.
+      rewrite_for_grad_acc: Whether to do rewriting for gradient accumulation.
+      rewrite_grad_acc_indices: The indices of tensors in output that are gradients.
       memory_budget_per_device: The memory budget per device in bytes.
-      logical_mesh_search_mode: Only used when doing logical mesh shape search.
-        The choices are {"measurement", "cost_model"}.
-        If it is "measurement", use real profiling to pick the best logical mesh shape.
-        If it is "cost_model", use cost estimation in HLO IR to pick the best one.
-        This is ignored if len(logical_mesh_choices) == 1.
-      logical_mesh_search_physical_mesh: Only used when doing logical mesh shape search.
-        The physical device mesh used for logical mesh search.
-      search_task: Only used when doing logical mesh shape search.
-        Used when dumping measurement records to the file.
-      record_file: Only used when doing logical mesh shape search.
-        If is not None, dump measurement records into this file.
     """
-    from alpa import testing
+    global last_s_val
+    global last_objective
 
     # Set compile options
     if memory_budget_per_device is None:
@@ -194,9 +173,8 @@ def compile_with_search(backend: xla_extension.Client,
     else:
         multiple_stages = False
 
-    run_post_spmd_partitioner_passes = not bypass_device_assignment_check and not multiple_stages
-
-    num_devices = logical_mesh_choices[0].num_devices
+    backend = xb.get_backend("gpu")
+    num_devices = logical_mesh.num_devices
     build_random_seed = global_config.build_random_seed
     compile_options = get_compile_options(
         num_replicas=1,
@@ -220,163 +198,124 @@ def compile_with_search(backend: xla_extension.Client,
         reduce_scatter_aggressive_partition = False
         all_gather_threshold = 1 << 60
 
-    def _invoke_compilation(logical_mesh):
-        global last_s_val
-        global last_objective
+    # Set configs for force_data_parallel
+    mesh_shape = logical_mesh.shape
+    if force_data_parallel:
+        # Forcibly generate data-parallel strategy
+        allow_all_gather = False
+        allow_all_to_all = False
 
-        mesh_shape = logical_mesh.shape
+        if mesh_shape[0] == 1:
+            force_batch_dim_to_mesh_dim = 1
+        elif mesh_shape[1] == 1:
+            force_batch_dim_to_mesh_dim = 0
+        else:
+            raise ValueError(
+                f"Cannot force data parallel for the mesh shape {mesh_shape}. "
+                "Please make sure the mesh shape only has a single non-one dimension."
+            )
+    else:
+        # Use default settings
+        allow_all_gather = as_option.allow_all_gather
+        allow_all_to_all = as_option.allow_all_to_all
 
-        # Set configs for force_data_parallel
-        if force_data_parallel:
-            # Forcibly generate data-parallel strategy
-            allow_all_gather = False
-            allow_all_to_all = False
-
-            if mesh_shape[0] == 1:
-                force_batch_dim_to_mesh_dim = 1
-            elif mesh_shape[1] == 1:
+        if as_option.force_batch_dim_to_mesh_dim is None:
+            # Automatically set force_batch_dim_to_mesh_dim
+            if logical_mesh.shape[0] > 1 and logical_mesh.shape[1] > 1:
+                # In 2d mesh, force the batch tensor dim to match the first mesh dim
                 force_batch_dim_to_mesh_dim = 0
             else:
-                raise ValueError(
-                    f"Cannot force data parallel for the mesh shape {mesh_shape}. "
-                    "Please make sure the mesh shape only has a single non-one dimension."
-                )
+                force_batch_dim_to_mesh_dim = -1
         else:
-            # Use default settings
-            allow_all_gather = as_option.allow_all_gather
-            allow_all_to_all = as_option.allow_all_to_all
+            force_batch_dim_to_mesh_dim = as_option.force_batch_dim_to_mesh_dim
 
-            if as_option.force_batch_dim_to_mesh_dim is None:
-                # Automatically set force_batch_dim_to_mesh_dim
-                if logical_mesh.shape[0] > 1 and logical_mesh.shape[1] > 1:
-                    # In 2d mesh, force the batch tensor dim to match the first mesh dim
-                    force_batch_dim_to_mesh_dim = 0
-                else:
-                    force_batch_dim_to_mesh_dim = -1
-            else:
-                force_batch_dim_to_mesh_dim = as_option.force_batch_dim_to_mesh_dim
+    # Set configs for reduce-scatter
+    if num_micro_batches is not None and num_micro_batches > 1:
+        reduce_scatter_grad_acc_friendly = True
+    else:
+        reduce_scatter_grad_acc_friendly = False
 
-        # Set configs for reduce-scatter
-        if num_micro_batches is not None and num_micro_batches > 1:
-            reduce_scatter_grad_acc_friendly = True
-        else:
-            reduce_scatter_grad_acc_friendly = False
+    # Set configs for gradient accumulation rewrite pass
+    if rewrite_for_grad_acc and rewrite_grad_acc_indices is None:
+        rewrite_grad_acc_indices = tuple(
+            range(
+                len(xla_computation.program_shape().result_shape().tuple_shapes(
+                ))))
 
-        # Temporarily disable this.
-        grad_acc_num_micro_batches = None
+    # Temporarily disable this.
+    grad_acc_num_micro_batches = None
 
-        with XlaPassContext({
-                # Build options
-                "build_option::bypass_device_assignment_check": bypass_device_assignment_check,
-                "build_option::run_pre_spmd_partitioner_passes": True,
-                "build_option::run_auto_sharding": True,
-                "build_option::run_spmd_partitioner": True,
-                "build_option::run_post_spmd_partitioner_passes": run_post_spmd_partitioner_passes,
+    with XlaPassContext({
+            # Build options
+            "build_option::bypass_device_assignment_check": True,
+            "build_option::run_pre_spmd_partitioner_passes": True,
+            "build_option::run_auto_sharding": True,
+            "build_option::run_spmd_partitioner": True,
+            "build_option::run_post_spmd_partitioner_passes": False,
 
-                # Auto-sharding solver options
-                "auto_sharding::memory_budget_per_device": memory_budget_per_device,
-                "auto_sharding::force_all_gather_cost": not allow_all_gather,
-                "auto_sharding::all_gather_cost": INFINITY_COST,
-                "auto_sharding::force_all_to_all_cost": not allow_all_to_all,
-                "auto_sharding::all_to_all_cost": INFINITY_COST,
-                "auto_sharding::allow_replicated_parameters":
-                    as_option.allow_replicated_parameters,
-                "auto_sharding::prefer_reduce_scatter": prefer_reduce_scatter,
-                "auto_sharding::reduce_scatter_grad_acc_friendly": reduce_scatter_grad_acc_friendly,
-                "auto_sharding::reduce_scatter_aggressive_partition": reduce_scatter_aggressive_partition,
-                "auto_sharding::batch_matmul_always_split_batch": True,
-                "auto_sharding::allow_recompute_heavy_op":
-                    as_option.allow_recompute_heavy_op,
-                "auto_sharding::allow_mixed_mesh_shape":
-                    as_option.allow_mixed_mesh_shape,
-                "auto_sharding::grad_acc_num_micro_batches":
-                    grad_acc_num_micro_batches or 1,
-                "auto_sharding::force_batch_dim_to_mesh_dim": force_batch_dim_to_mesh_dim,
-                "auto_sharding::force_simple_heuristic":
-                    as_option.force_simple_heuristic,
+            # Auto-sharding solver options
+            "auto_sharding::memory_budget_per_device": memory_budget_per_device,
+            "auto_sharding::force_all_gather_cost": not allow_all_gather,
+            "auto_sharding::all_gather_cost": INFINITY_COST,
+            "auto_sharding::force_all_to_all_cost": not allow_all_to_all,
+            "auto_sharding::all_to_all_cost": INFINITY_COST,
+            "auto_sharding::allow_replicated_parameters":
+                as_option.allow_replicated_parameters,
+            "auto_sharding::prefer_reduce_scatter": prefer_reduce_scatter,
+            "auto_sharding::reduce_scatter_grad_acc_friendly": reduce_scatter_grad_acc_friendly,
+            "auto_sharding::reduce_scatter_aggressive_partition": reduce_scatter_aggressive_partition,
+            "auto_sharding::batch_matmul_always_split_batch": True,
+            "auto_sharding::allow_recompute_heavy_op":
+                as_option.allow_recompute_heavy_op,
+            "auto_sharding::allow_mixed_mesh_shape":
+                as_option.allow_mixed_mesh_shape,
+            "auto_sharding::grad_acc_num_micro_batches":
+                grad_acc_num_micro_batches or 1,
+            "auto_sharding::force_batch_dim_to_mesh_dim": force_batch_dim_to_mesh_dim,
+            "auto_sharding::force_simple_heuristic":
+                as_option.force_simple_heuristic,
 
-                # Device mesh
-                "auto_sharding::device_mesh_ids": logical_mesh.flatten_ids,
-                "auto_sharding::device_mesh_shape": tuple(logical_mesh.shape),
-                "auto_sharding::device_mesh_alpha": tuple(
-                    float(x) for x in logical_mesh.mesh_alpha),
-                "auto_sharding::device_mesh_beta": tuple(
-                    float(x) for x in logical_mesh.mesh_beta),
-                "auto_sharding::device_mesh_prof_result": getattr(
-                    logical_mesh.physical_mesh, "prof_result", None),
+            # Device mesh
+            "auto_sharding::device_mesh_ids": logical_mesh.flatten_ids,
+            "auto_sharding::device_mesh_shape": tuple(logical_mesh.shape),
+            "auto_sharding::device_mesh_alpha": tuple(
+                float(x) for x in logical_mesh.mesh_alpha),
+            "auto_sharding::device_mesh_beta": tuple(
+                float(x) for x in logical_mesh.mesh_beta),
+            "auto_sharding::device_mesh_prof_result": getattr(
+                logical_mesh.physical_mesh, "prof_result", None),
 
-                # Communication combiner options
-                "combiner::all_gather_threshold": all_gather_threshold,
-                "combiner::all_reduce_threshold":
-                    as_option.all_reduce_threshold,
-                "combiner::use_continuous_buffer": True,
+            # Gradient accumulation rewrite
+            "auto_sharding::rewrite_for_grad_acc": rewrite_for_grad_acc,
+            "auto_sharding::rewrite_indices": rewrite_grad_acc_indices,
 
-                # Debug options
-                "auto_sharding::simplify_graph": True,
-                "auto_sharding::print_strategy": False,
-                "auto_sharding::force_strategy": False,
-                "auto_sharding::force_strategy_inst_indices": [],
-                "auto_sharding::force_strategy_stra_names": [],
-        }):
-            compiled = xla.backend_compile(backend, xla_computation,
-                                           compile_options)
-        return compiled, last_s_val, last_objective
+            # Communication combiner options
+            "combiner::all_gather_threshold": all_gather_threshold,
+            "combiner::all_reduce_threshold":
+                as_option.all_reduce_threshold,
+            "combiner::use_continuous_buffer": True,
 
-    if len(logical_mesh_choices) == 1:  # Compile with the given logical mesh
-        logical_mesh = logical_mesh_choices[0]
-        compiled, solution_vector, objective = _invoke_compilation(logical_mesh)
-        if multiple_stages:
-            hlo_stage_names, hlo_stages = get_auto_sharded_hlo_stages()
-            hooked_proto = get_hooked_sharding_protos()
-    else:  # Search for the best logical mesh
-        from alpa.mesh_executable import NormalMeshDriverExecutable
-        assert not multiple_stages
-        best_logical_mesh = best_compiled = best_solution_vector = best_objective = None
-        best_time_cost = float("inf")
-        for logical_mesh in logical_mesh_choices:
-            compiled, solution_vector, objective = _invoke_compilation(
-                logical_mesh)
-            strategy_config = StrategyConfig(build_random_seed,
-                                             logical_mesh.shape,
-                                             all_gather_threshold,
-                                             as_option.all_reduce_threshold,
-                                             solution_vector)
+            # Debug options
+            "auto_sharding::simplify_graph": True,
+            "auto_sharding::print_strategy": False,
+            "auto_sharding::force_strategy": False,
+            "auto_sharding::force_strategy_inst_indices": [],
+            "auto_sharding::force_strategy_stra_names": [],
+    }):
+        compiled = xla.backend_compile(backend, xla_computation,
+                                       compile_options)
 
-            if logical_mesh_search_mode == "measurement":
-                mesh_exe = NormalMeshDriverExecutable(
-                    logical_mesh_search_physical_mesh, compiled,
-                    strategy_config, avals, out_avals, donated_invars)
-                time_costs = tuple(mesh_exe.profile_with_dummy_inputs())
-            else:
-                assert logical_mesh_search_mode == "cost_model"
-                time_costs = (objective,)
+    if multiple_stages:
+        hlo_stage_names, hlo_stages = get_auto_sharded_hlo_stages()
+        hooked_proto = get_hooked_sharding_protos()
 
-            if np.mean(time_costs) < best_time_cost:
-                (best_logical_mesh, best_compiled, best_solution_vector,
-                 best_objective) = (logical_mesh, compiled, solution_vector,
-                                    objective)
-                best_time_cost = np.mean(time_costs)
-
-            # Save records to file
-            if record_file is not None:
-                assert search_task is not None
-                inp = MeasureInput(search_task, strategy_config)
-                res = MeasureResult(time_costs, objective, 0, int(time.time()))
-                save_to_file([inp], [res], record_file)
-
-        logical_mesh, compiled, solution_vector, objective = (
-            best_logical_mesh, best_compiled, best_solution_vector,
-            best_objective)
-
-    testing.last_compiled_executable = compiled
-    testing.last_compiled_auto_sharding_objective = objective
     strategy_config = StrategyConfig(build_random_seed, logical_mesh.shape,
                                      all_gather_threshold,
                                      as_option.all_reduce_threshold,
-                                     solution_vector)
+                                     last_s_val, last_objective)
 
-    if return_mode == "executable":
-        return compiled, strategy_config
+    if return_mode == "single":
+        return compiled.hlo_modules()[0], strategy_config
     elif return_mode == "stage_protos":
         return hlo_stage_names, hlo_stages, strategy_config
     elif return_mode == "stage_and_hook_protos":
@@ -385,67 +324,26 @@ def compile_with_search(backend: xla_extension.Client,
         raise ValueError("Invalid return mode:" + return_mode)
 
 
-def compile_with_given_strategy(
-        backend: xla_extension.Client,
-        xla_computation: xla_extension.XlaComputation,
-        strategy_config: StrategyConfig,
-        num_devices: int,
-        hlo_proto_status: HloProtoStatus,
-        bypass_device_assignment_check: bool,
-        rewrite_for_grad_acc: bool = False,
-        rewrite_grad_acc_indices: Optional[Sequence[int]] = None,
-        run_backend_codegen: Union[str, bool] = "auto"):
-    """Compile an XLA computation with a given auto sharding strategy.
+def run_spmd_partitioner_pass(xla_computation: xe.XlaComputation,
+                              num_devices: int,
+                              rewrite_for_grad_acc: bool = False,
+                              rewrite_grad_acc_indices: Optional[Sequence[int]] = None):
+    """Run SPMD partitioner pass on a sharding annotated HLO Module.
 
     Args:
-      backend: The XLA backend client.
-      xla_computation: The unoptimized xla computation
-        got by tracing the jax function.
-      strategy_config: The auto-sharding strategy solution.
+      xla_computation: The input HLO Module. The status should be SHARDING_ANNOTATED.
       num_devices: The total number of devices.
-      bypass_device_assignment_check: Set this to true if this compilation is invoked
-        on the driver node in the multi-host setting.
-      hlo_proto_status: The optimization status of the
-        input xla computation. see docs in the definition of `HloProtoStatus`.
       rewrite_for_grad_acc: Whether to do rewriting for gradient accumulation.
       rewrite_grad_acc_indices: The indices of tensors in output that are gradients.
-      run_backend_codegen: Whether to run the backend codegen to generate cuda binaries.
     """
+    backend = xb.get_backend("gpu")
     compile_options = get_compile_options(
         num_replicas=1,
         num_partitions=num_devices,
         device_assignment=np.arange(num_devices).reshape((1, -1)),
         use_spmd_partitioning=True,
         parameter_is_tupled_arguments=False,
-        build_random_seed=strategy_config.build_random_seed)
-    logical_mesh_shape = strategy_config.logical_mesh_shape
-
-    # Skip some compilation stages to
-    # 1. accelerate the compilation.
-    # 2. make sure the annotated sharding is not modified by other passes.
-    if hlo_proto_status == HloProtoStatus.UNOPTIMIZED:
-        run_pre_spmd_partitioner_passes = True
-        run_auto_sharding = True
-        run_spmd_partitioner = True
-        solution_vector = strategy_config.auto_sharding_solution_vector
-    elif hlo_proto_status == HloProtoStatus.SHARDING_ANNOTATED:
-        run_pre_spmd_partitioner_passes = False
-        run_auto_sharding = False
-        run_spmd_partitioner = True
-        solution_vector = []
-    elif hlo_proto_status == HloProtoStatus.SPMD_PARTITIONED:
-        run_pre_spmd_partitioner_passes = False
-        run_auto_sharding = False
-        run_spmd_partitioner = False
-        solution_vector = []
-    else:
-        raise ValueError(f"Invalid status: {hlo_proto_status}")
-
-    if run_backend_codegen == "auto":
-        run_post_spmd_partitioner_passes = not bypass_device_assignment_check
-    else:
-        assert isinstance(run_backend_codegen, bool)
-        run_post_spmd_partitioner_passes = run_backend_codegen
+        build_random_seed=global_config.build_random_seed)
 
     if rewrite_for_grad_acc and rewrite_grad_acc_indices is None:
         rewrite_grad_acc_indices = tuple(
@@ -455,21 +353,49 @@ def compile_with_given_strategy(
 
     with XlaPassContext({
             # Build options
-            "build_option::bypass_device_assignment_check": bypass_device_assignment_check,
-            "build_option::run_pre_spmd_partitioner_passes": run_pre_spmd_partitioner_passes,
-            "build_option::run_auto_sharding": run_auto_sharding,
-            "build_option::run_spmd_partitioner": run_spmd_partitioner,
-            "build_option::run_post_spmd_partitioner_passes": run_post_spmd_partitioner_passes,
+            "build_option::bypass_device_assignment_check": True,
+            "build_option::run_pre_spmd_partitioner_passes": False,
+            "build_option::run_auto_sharding": False,
+            "build_option::run_spmd_partitioner": True,
+            "build_option::run_post_spmd_partitioner_passes": False,
 
-            # Auto-sharding solver options
-            "auto_sharding::load_solution_vector": True,
-            "auto_sharding::solution_vector": to_int_tuple(solution_vector),
+            # Gradient accumulation rewrite
             "auto_sharding::rewrite_for_grad_acc": rewrite_for_grad_acc,
             "auto_sharding::rewrite_indices": rewrite_grad_acc_indices,
+    }):
+        compiled = backend.compile(xla_computation, compile_options)
 
-            # Device mesh
-            "auto_sharding::device_mesh_ids": tuple(range(num_devices)),
-            "auto_sharding::device_mesh_shape": tuple(logical_mesh_shape),
+    return compiled.hlo_modules()[0]
+
+
+def run_backend_compilation(
+        backend: xe.Client,
+        xla_computation: xe.XlaComputation,
+        strategy_config: StrategyConfig,
+        num_devices: int):
+    """Compile a spmd partitioned Hlo Module to an XLA executable.
+
+    Args:
+      backend: The XLA backend client.
+      xla_computation: The input HLO Module. The status should be SPMD_PARTITIONED.
+      strategy_config: The auto-sharding strategy solution.
+      num_devices: The total number of devices.
+    """
+    compile_options = get_compile_options(
+        num_replicas=1,
+        num_partitions=num_devices,
+        device_assignment=np.arange(num_devices).reshape((1, -1)),
+        use_spmd_partitioning=True,
+        parameter_is_tupled_arguments=False,
+        build_random_seed=strategy_config.build_random_seed)
+
+    with XlaPassContext({
+            # Build options
+            "build_option::bypass_device_assignment_check": False,
+            "build_option::run_pre_spmd_partitioner_passes": False,
+            "build_option::run_auto_sharding": False,
+            "build_option::run_spmd_partitioner": False,
+            "build_option::run_post_spmd_partitioner_passes": True,
 
             # Communication combiner options
             "combiner::all_gather_threshold":
@@ -477,12 +403,6 @@ def compile_with_given_strategy(
             "combiner::all_reduce_threshold":
                 strategy_config.all_reduce_threshold,
             "combiner::use_continuous_buffer": True,
-
-            # Other useless but required arguments
-            "auto_sharding::device_mesh_alpha":
-                (1.0,) * len(logical_mesh_shape),
-            "auto_sharding::device_mesh_beta": (1.0,) * len(logical_mesh_shape),
-            "auto_sharding::device_mesh_prof_result": None,
     }):
         compiled = backend.compile(xla_computation, compile_options)
 
@@ -490,7 +410,7 @@ def compile_with_given_strategy(
 
 
 def get_input_output_sharding_specs(
-    hlo_module: xla_extension.HloModule, avals: Sequence[ShapedArray],
+    hlo_module: xe.HloModule, avals: Sequence[ShapedArray],
     out_avals: Sequence[ShapedArray], num_devices: int,
     logical_mesh_shape: Sequence[int]
 ) -> Tuple[Sequence[pxla.ShardingSpec], Sequence[pxla.ShardingSpec]]:
@@ -538,7 +458,7 @@ def _hlo_sharding_to_sharding_spec_no_tuple(
 
     sharding = []
     mesh_mapping = []
-    if sharding_type == OpSharding.Type.OTHER:
+    if sharding_type == xc.OpSharding.Type.OTHER:
         tile_assignment = np.array(tile_assignment_devices).reshape(
             tile_assignment_dimensions)
 
@@ -590,7 +510,7 @@ def _hlo_sharding_to_sharding_spec_no_tuple(
             sharding = (pxla.Chunked(
                 (tile_assignment_dimensions[0] // col, col)),)
             mesh_mapping = (pxla.ShardedAxis(1), pxla.ShardedAxis(0))
-    elif sharding_type == OpSharding.Type.REPLICATED:
+    elif sharding_type == xc.OpSharding.Type.REPLICATED:
         sharding = (pxla.NoSharding(),) * len(aval.shape)
         mesh_mapping = (pxla.Replicated(np.prod(logical_mesh.shape)),)
     else:
@@ -600,7 +520,7 @@ def _hlo_sharding_to_sharding_spec_no_tuple(
 
 
 def hlo_sharding_to_sharding_spec(
-        hlo_sharding: xla_extension.HloSharding, aval: ShapedArray,
+        hlo_sharding: xe.HloSharding, aval: ShapedArray,
         logical_mesh_shape: Sequence[int]) -> pxla.ShardingSpec:
     """Convert hlo sharding to sharding spec."""
     logical_mesh = LogicalDeviceMesh(
@@ -608,7 +528,7 @@ def hlo_sharding_to_sharding_spec(
         np.arange(np.prod(logical_mesh_shape)).reshape(logical_mesh_shape))
     proto = hlo_sharding.proto_tuple()
     sharding_type, tuple_shardings = proto.type, proto.tuple_shardings
-    if sharding_type == OpSharding.Type.TUPLE:
+    if sharding_type == xc.OpSharding.Type.TUPLE:
         avals = aval
         return [
             _hlo_sharding_to_sharding_spec_no_tuple(shard, aval, logical_mesh)
@@ -906,8 +826,8 @@ def _call_solver_serialized_args(
         if verbose and r[idx][e_val[idx]] > 0:
             print(f"Edge cost {(i, j)} : {r[idx][e_val[idx]]}")
 
-    last_objective = objective
     last_s_val = s_val
+    last_objective = objective
 
     if objective > INFINITY_COST:
         warnings.warn("Detect unexpected behaviors in the auto-sharding pass.")
@@ -943,3 +863,13 @@ def get_auto_sharded_hlo_stages() -> Sequence[bytes]:
 
 def get_hooked_sharding_protos() -> bytes:
     return hooked_sharding_protos
+
+
+def compile_with_search():
+    pass
+
+def compile_with_given_strategy():
+    pass
+
+def HloProtoStatus():
+    pass

--- a/alpa/shard_parallel/auto_sharding.py
+++ b/alpa/shard_parallel/auto_sharding.py
@@ -370,7 +370,7 @@ def run_spmd_partitioner_pass(xla_computation: xe.XlaComputation,
 
 def run_backend_compilation(
         backend: xe.Client,
-        xla_computation: xe.XlaComputation,
+        xla_computation: Union[xe.XlaComputation, xe.HloModule, bytes],
         strategy_config: StrategyConfig,
         num_devices: int):
     """Compile a spmd partitioned Hlo Module to an XLA executable.
@@ -388,6 +388,13 @@ def run_backend_compilation(
         use_spmd_partitioning=True,
         parameter_is_tupled_arguments=False,
         build_random_seed=strategy_config.build_random_seed)
+
+    if isinstance(xla_computation, xe.HloModule):
+        xla_computation = xe.XlaComputation(xla_computation.as_serialized_hlo_module_proto())
+    elif isinstance(xla_computation, bytes):  # protobuf
+        xla_computation = xe.XlaComputation(xla_computation)
+    else:
+        assert isinstance(xla_computation, xe.XlaComputation)
 
     with XlaPassContext({
             # Build options

--- a/alpa/shard_parallel/auto_sharding.py
+++ b/alpa/shard_parallel/auto_sharding.py
@@ -870,13 +870,3 @@ def get_auto_sharded_hlo_stages() -> Sequence[bytes]:
 
 def get_hooked_sharding_protos() -> bytes:
     return hooked_sharding_protos
-
-
-def compile_with_search():
-    pass
-
-def compile_with_given_strategy():
-    pass
-
-def HloProtoStatus():
-    pass

--- a/alpa/shard_parallel/auto_sharding.py
+++ b/alpa/shard_parallel/auto_sharding.py
@@ -126,17 +126,18 @@ class LogicalDeviceMesh:
                                      other.mesh_alpha, other.mesh_beta))
 
 
-def run_auto_sharding_pass(xla_computation: xe.XlaComputation,
-                           avals: Sequence[ShapedArray],
-                           out_avals: Sequence[ShapedArray],
-                           donated_invars: Sequence[bool],
-                           logical_mesh: LogicalDeviceMesh,
-                           return_mode: str,
-                           num_micro_batches: int,
-                           as_option: AutoShardingOption,
-                           rewrite_for_grad_acc: bool = False,
-                           rewrite_grad_acc_indices: Optional[Sequence[int]] = None,
-                           memory_budget_per_device: Optional[float] = None):
+def run_auto_sharding_pass(
+        xla_computation: xe.XlaComputation,
+        avals: Sequence[ShapedArray],
+        out_avals: Sequence[ShapedArray],
+        donated_invars: Sequence[bool],
+        logical_mesh: LogicalDeviceMesh,
+        return_mode: str,
+        num_micro_batches: int,
+        as_option: AutoShardingOption,
+        rewrite_for_grad_acc: bool = False,
+        rewrite_grad_acc_indices: Optional[Sequence[int]] = None,
+        memory_budget_per_device: Optional[float] = None):
     """Run the auto-sharding pass to annotate sharding specs for an XLA Computation.
 
     Args:
@@ -291,8 +292,7 @@ def run_auto_sharding_pass(xla_computation: xe.XlaComputation,
 
             # Communication combiner options
             "combiner::all_gather_threshold": all_gather_threshold,
-            "combiner::all_reduce_threshold":
-                as_option.all_reduce_threshold,
+            "combiner::all_reduce_threshold": as_option.all_reduce_threshold,
             "combiner::use_continuous_buffer": True,
 
             # Debug options
@@ -311,8 +311,8 @@ def run_auto_sharding_pass(xla_computation: xe.XlaComputation,
 
     strategy_config = StrategyConfig(build_random_seed, logical_mesh.shape,
                                      all_gather_threshold,
-                                     as_option.all_reduce_threshold,
-                                     last_s_val, last_objective)
+                                     as_option.all_reduce_threshold, last_s_val,
+                                     last_objective)
 
     if return_mode == "single":
         return compiled.hlo_modules()[0], strategy_config
@@ -324,10 +324,11 @@ def run_auto_sharding_pass(xla_computation: xe.XlaComputation,
         raise ValueError("Invalid return mode:" + return_mode)
 
 
-def run_spmd_partitioner_pass(xla_computation: xe.XlaComputation,
-                              num_devices: int,
-                              rewrite_for_grad_acc: bool = False,
-                              rewrite_grad_acc_indices: Optional[Sequence[int]] = None):
+def run_spmd_partitioner_pass(
+        xla_computation: xe.XlaComputation,
+        num_devices: int,
+        rewrite_for_grad_acc: bool = False,
+        rewrite_grad_acc_indices: Optional[Sequence[int]] = None):
     """Run SPMD partitioner pass on a sharding annotated HLO Module.
 
     Args:
@@ -368,11 +369,10 @@ def run_spmd_partitioner_pass(xla_computation: xe.XlaComputation,
     return compiled.hlo_modules()[0]
 
 
-def run_backend_compilation(
-        backend: xe.Client,
-        xla_computation: Union[xe.XlaComputation, xe.HloModule, bytes],
-        strategy_config: StrategyConfig,
-        num_devices: int):
+def run_backend_compilation(backend: xe.Client,
+                            xla_computation: Union[xe.XlaComputation,
+                                                   xe.HloModule, bytes],
+                            strategy_config: StrategyConfig, num_devices: int):
     """Compile a spmd partitioned Hlo Module to an XLA executable.
 
     Args:
@@ -390,7 +390,8 @@ def run_backend_compilation(
         build_random_seed=strategy_config.build_random_seed)
 
     if isinstance(xla_computation, xe.HloModule):
-        xla_computation = xe.XlaComputation(xla_computation.as_serialized_hlo_module_proto())
+        xla_computation = xe.XlaComputation(
+            xla_computation.as_serialized_hlo_module_proto())
     elif isinstance(xla_computation, bytes):  # protobuf
         xla_computation = xe.XlaComputation(xla_computation)
     else:

--- a/alpa/shard_parallel/shard_callable.py
+++ b/alpa/shard_parallel/shard_callable.py
@@ -19,7 +19,7 @@ from alpa.global_env import global_config
 from alpa.measure_record import SearchTask, load_best_record, StrategyConfig
 from alpa.mesh_executable import NormalMeshDriverExecutable, GradAccMeshDriverExecutable
 from alpa.shard_parallel.auto_sharding import (run_auto_sharding_pass,
-        run_spmd_partitioner_pass)
+                                               run_spmd_partitioner_pass)
 from alpa.pipeline_parallel.apply_grad import APPLY_GRAD_MARKER_SUFFIX
 from alpa.util import jaxpr_to_hlo_computation, trace_jaxpr_with_micro_batch, setup_computation_alias, OrderedSet
 
@@ -267,10 +267,9 @@ def shard_parallel_internal_gradient_accumulation(
     setup_computation_alias(apply_grad, tmp_donate_invars)
 
     bypass_device_assignment_check = physical_mesh.is_distributed
-    accumulate_grad = run_spmd_partitioner_pass(
-        accumulate_grad,
-        physical_mesh.num_devices,
-        rewrite_for_grad_acc=True)
+    accumulate_grad = run_spmd_partitioner_pass(accumulate_grad,
+                                                physical_mesh.num_devices,
+                                                rewrite_for_grad_acc=True)
     apply_grad = run_spmd_partitioner_pass(apply_grad,
                                            physical_mesh.num_devices)
 

--- a/alpa/shard_parallel/shard_callable.py
+++ b/alpa/shard_parallel/shard_callable.py
@@ -7,7 +7,7 @@ from typing import Callable, Sequence, Optional
 import numpy as np
 
 from jax import linear_util as lu, disable_jit
-import jax._src.lib.xla_bridge as xb
+from jax._src.lib import xla_bridge as xb
 from jax.core import Jaxpr, ClosedJaxpr, Literal, new_jaxpr_eqn, gensym, ShapedArray
 from jax.interpreters import partial_eval as pe
 from jax.lax import add_p, div_p
@@ -18,7 +18,8 @@ from alpa.device_mesh import LogicalDeviceMesh, PhysicalDeviceMesh, DeviceCluste
 from alpa.global_env import global_config
 from alpa.measure_record import SearchTask, load_best_record, StrategyConfig
 from alpa.mesh_executable import NormalMeshDriverExecutable, GradAccMeshDriverExecutable
-from alpa.shard_parallel.auto_sharding import run_auto_sharding_pass
+from alpa.shard_parallel.auto_sharding import (run_auto_sharding_pass,
+        run_spmd_partitioner_pass)
 from alpa.pipeline_parallel.apply_grad import APPLY_GRAD_MARKER_SUFFIX
 from alpa.util import jaxpr_to_hlo_computation, trace_jaxpr_with_micro_batch, setup_computation_alias, OrderedSet
 
@@ -237,22 +238,16 @@ def shard_parallel_internal_gradient_accumulation(
         built.as_hlo_module())
     flop_count *= num_micro_batches
 
-    hlo_proto_names, hlo_protos, strategy_config = compile_with_search(
-        backend,
+    hlo_proto_names, hlo_protos, strategy_config = run_auto_sharding_pass(
         built,
         avals,
         out_avals,
         donated_invars,
-        logical_mesh_choices,
+        logical_mesh_choices[0],
         "stage_protos",
         num_micro_batches,
         global_config.default_autosharding_option,
-        bypass_device_assignment_check=physical_mesh.is_distributed,
-        memory_budget_per_device=memory_budget_per_device,
-        logical_mesh_search_mode=logical_mesh_search_mode,
-        logical_mesh_search_physical_mesh=physical_mesh,
-        search_task=search_task,
-        record_file=record_file)
+        memory_budget_per_device=memory_budget_per_device)
     assert len(hlo_protos) == 2
     assert hlo_proto_names[1].endswith(APPLY_GRAD_MARKER_SUFFIX)
 
@@ -272,19 +267,12 @@ def shard_parallel_internal_gradient_accumulation(
     setup_computation_alias(apply_grad, tmp_donate_invars)
 
     bypass_device_assignment_check = physical_mesh.is_distributed
-    accumulate_grad = compile_with_given_strategy(
-        backend,
+    accumulate_grad = run_spmd_partitioner_pass(
         accumulate_grad,
-        strategy_config,
         physical_mesh.num_devices,
-        HloProtoStatus.SHARDING_ANNOTATED,
-        bypass_device_assignment_check,
         rewrite_for_grad_acc=True)
-    apply_grad = compile_with_given_strategy(backend, apply_grad,
-                                             strategy_config,
-                                             physical_mesh.num_devices,
-                                             HloProtoStatus.SHARDING_ANNOTATED,
-                                             bypass_device_assignment_check)
+    apply_grad = run_spmd_partitioner_pass(apply_grad,
+                                           physical_mesh.num_devices)
 
     # Compile them to a single mesh executable
     mesh_executable = GradAccMeshDriverExecutable(physical_mesh,

--- a/alpa/testing.py
+++ b/alpa/testing.py
@@ -24,10 +24,6 @@ from alpa.pipeline_parallel.primitive_def import mark_pipeline
 from alpa.util import get_ray_namespace_str
 
 
-def get_auto_sharding_objective(func, *args):
-    executable = func.get_executable(*args)
-    return executable.strategy_config.auto_sharding_objective
-
 def assert_allclose(x, y, rtol=1e-4, atol=1e-4):
     """Assert the arrays in x and y are all close."""
     if isinstance(x, (dict, FrozenDictJax, FrozenDictFlax)):

--- a/alpa/testing.py
+++ b/alpa/testing.py
@@ -23,10 +23,10 @@ from alpa.pipeline_parallel.layer_construction import (
 from alpa.pipeline_parallel.primitive_def import mark_pipeline
 from alpa.util import get_ray_namespace_str
 
-# Store last compiled executables for unit tests.
-last_compiled_executable = None
-last_compiled_auto_sharding_objective = -1
 
+def get_auto_sharding_objective(func, *args):
+    executable = func.get_executable(*args)
+    return executable.strategy_config.auto_sharding_objective
 
 def assert_allclose(x, y, rtol=1e-4, atol=1e-4):
     """Assert the arrays in x and y are all close."""
@@ -374,3 +374,7 @@ class PipelineBasicTest(unittest.TestCase):
         hlo_text = executable.get_hlo_text()
         executable.shutdown()
         return hlo_text
+
+# Store last compiled executables for unit tests.
+last_compiled_executable = None
+last_compiled_auto_sharding_objective = -1

--- a/alpa/testing.py
+++ b/alpa/testing.py
@@ -370,7 +370,3 @@ class PipelineBasicTest(unittest.TestCase):
         hlo_text = executable.get_hlo_text()
         executable.shutdown()
         return hlo_text
-
-# Store last compiled executables for unit tests.
-last_compiled_executable = None
-last_compiled_auto_sharding_objective = -1

--- a/alpa/util.py
+++ b/alpa/util.py
@@ -19,6 +19,7 @@ import jax
 from jax._src import dispatch
 from jax._src.api import FLAGS, ShapeDtypeStruct
 from jax._src.dlpack import from_dlpack, to_dlpack
+from jax._src.lib import xla_bridge as xb, xla_client as xc, xla_extension as xe
 from jax.api_util import shaped_abstractify
 from jax.core import (Atom, ClosedJaxpr, DropVar, Jaxpr, JaxprEqn, Literal,
                       ShapedArray, Var)
@@ -26,7 +27,6 @@ from jax.experimental.maps import FrozenDict
 from jax.interpreters import xla, pxla
 from jax.interpreters import partial_eval as pe
 from jax.interpreters.xla import _DeviceArray
-from jax.lib import xla_bridge as xb, xla_client as xc, xla_extension as xe
 import jax.numpy as jnp
 from jax.tree_util import tree_map, tree_flatten, PyTreeDef
 import numpy as np

--- a/benchmark/alpa/benchmark_2d_one_case_gpt_bert.py
+++ b/benchmark/alpa/benchmark_2d_one_case_gpt_bert.py
@@ -6,7 +6,7 @@ import numpy as np
 import optax
 
 import alpa
-from alpa import parallelize, global_config, set_parallelize_options, testing
+from alpa import parallelize, global_config, set_parallelize_options
 from alpa.model.bert_model import BertConfig, FlaxBertForMaskedLMModule, TrainState
 from alpa.model.gpt_model import FlaxGPTForLMModule
 from alpa.util import map_to_shape, count_communication_primitives, print_used_time, GB
@@ -152,7 +152,7 @@ def benchmark_gpt_bert_internal(physical_mesh, model_type, benchmark_case, niter
 
     # Check sharding strategy
     alloc_mem = executable.get_total_allocation_size()
-    ilp_objective = testing.last_compiled_auto_sharding_objective or 0.0
+    ilp_objective = executable.auto_sharding_objective or 0.0
     hlo_text = executable.get_hlo_text()
     with open("tmp/last_2d.hlo", "w") as fout:
         fout.write(hlo_text)

--- a/benchmark/alpa/benchmark_2d_one_case_moe.py
+++ b/benchmark/alpa/benchmark_2d_one_case_moe.py
@@ -5,7 +5,7 @@ import numpy as np
 import ray
 
 import alpa
-from alpa import global_config, set_parallelize_options, testing
+from alpa import global_config, set_parallelize_options
 from alpa.model.moe import FlaxMoEForLMModule, MoEConfig, TrainState
 from alpa.model.model_util import optax_adafactor
 from alpa.util import count_communication_primitives, print_used_time, compute_param_number, GB
@@ -115,7 +115,7 @@ def benchmark_moe_internal(physical_mesh, benchmark_case, niter):
 
     # Check sharding strategy
     alloc_mem = executable.get_total_allocation_size()
-    ilp_objective = testing.last_compiled_auto_sharding_objective or 0.0
+    ilp_objective = executable.auto_sharding_objective or 0.0
     hlo_text = executable.get_hlo_text()
     with open("tmp/last_2d.hlo", "w") as fout:
         fout.write(hlo_text)

--- a/benchmark/alpa/benchmark_2d_one_case_wresnet.py
+++ b/benchmark/alpa/benchmark_2d_one_case_wresnet.py
@@ -7,7 +7,7 @@ import numpy as np
 import optax
 
 import alpa
-from alpa import parallelize, global_config, set_parallelize_options, testing
+from alpa import parallelize, global_config, set_parallelize_options
 from alpa.model.wide_resnet import get_wide_resnet, TrainState
 from alpa.util import (map_to_shape, count_communication_primitives,
                         print_used_time, compute_param_number, GB)
@@ -232,7 +232,7 @@ def benchmark_wresnet_internal(physical_mesh, benchmark_case, niter):
 
     # Check sharding strategy
     alloc_mem = executable.get_total_allocation_size()
-    ilp_objective = testing.last_compiled_auto_sharding_objective or 0.0
+    ilp_objective = executable.auto_sharding_objective or 0.0
     hlo_text = executable.get_hlo_text()
     with open("tmp/last_wresnet_2d.hlo", "w") as fout:
         fout.write(hlo_text)

--- a/tests/test_auto_sharding_basic.py
+++ b/tests/test_auto_sharding_basic.py
@@ -96,7 +96,9 @@ class AutoShardingBasicTest(unittest.TestCase):
         func(optimizer, x, y, {"dropout": rngkey})
 
         # Check sharding strategy (data-parallel)
-        hlo_ir = func.get_executable(optimizer, x, y, {"dropout": rngkey}).get_hlo_text()
+        hlo_ir = func.get_executable(optimizer, x, y, {
+            "dropout": rngkey
+        }).get_hlo_text()
         assert "u64[1024]{0} iota()" in hlo_ir  # 1024 = 32 * 32 * 16 / 4 / 4
 
         assert hlo_ir.count("channel_id") == 1

--- a/tests/test_auto_sharding_basic.py
+++ b/tests/test_auto_sharding_basic.py
@@ -32,10 +32,6 @@ class AutoShardingBasicTest(unittest.TestCase):
         a = jnp.ones((128, 128))
         b = add_one(a)
 
-        # Check sharding strategy
-        hlo_module = testing.last_compiled_executable.hlo_modules()[0]
-        hlo_ir = hlo_module.to_string()
-
         # Assert b is sharded
         assert (b.sharding_spec == pxla.ShardingSpec(
             sharding=(NoSharding(), Chunked([4])),
@@ -100,8 +96,7 @@ class AutoShardingBasicTest(unittest.TestCase):
         func(optimizer, x, y, {"dropout": rngkey})
 
         # Check sharding strategy (data-parallel)
-        hlo_module = testing.last_compiled_executable.hlo_modules()[0]
-        hlo_ir = hlo_module.to_string()
+        hlo_ir = func.get_executable(optimizer, x, y, {"dropout": rngkey}).get_hlo_text()
         assert "u64[1024]{0} iota()" in hlo_ir  # 1024 = 32 * 32 * 16 / 4 / 4
 
         assert hlo_ir.count("channel_id") == 1
@@ -132,9 +127,10 @@ class AutoShardingBasicTest(unittest.TestCase):
             #b = a.reshape((9, 16))
             return b
 
-        split(jnp.ones((144)))
+        a = jnp.ones(144)
+        split(a)
 
-        assert_close(testing.last_compiled_auto_sharding_objective, 0)
+        assert_close(testing.get_auto_sharding_objective(split, a), 0)
 
 
 def suite():

--- a/tests/test_auto_sharding_basic.py
+++ b/tests/test_auto_sharding_basic.py
@@ -130,7 +130,8 @@ class AutoShardingBasicTest(unittest.TestCase):
         a = jnp.ones(144)
         split(a)
 
-        assert_close(testing.get_auto_sharding_objective(split, a), 0)
+        executable = split.get_executable(a)
+        assert_close(executable.auto_sharding_objective, 0)
 
 
 def suite():

--- a/tests/test_auto_sharding_bert.py
+++ b/tests/test_auto_sharding_bert.py
@@ -90,7 +90,8 @@ class AutoShardingAttentionTest(unittest.TestCase):
                 "rng": rngkey
             }, deterministic, model.apply)
 
-        return optimizer, executable.get_hlo_text(), executable.auto_sharding_objective
+        return optimizer, executable.get_hlo_text(
+        ), executable.auto_sharding_objective
 
     def run_bert_mlm(self, batch_size, seq_len, num_layers, hidden_size,
                      num_heads, vocab_size, deterministic, device_mesh):
@@ -161,7 +162,8 @@ class AutoShardingAttentionTest(unittest.TestCase):
                 "rng": rngkey
             })
 
-        return optimizer, executable.get_hlo_text(), executable.auto_sharding_objective
+        return optimizer, executable.get_hlo_text(
+        ), executable.auto_sharding_objective
 
     def test_bert_layer_data_parallel(self):
         batch_size = 64

--- a/tests/test_auto_sharding_bert.py
+++ b/tests/test_auto_sharding_bert.py
@@ -7,7 +7,7 @@ import jax.numpy as jnp
 import numpy as np
 from flax import optim, linen as nn
 
-from alpa import parallelize, set_parallelize_options, testing, PhysicalDeviceMesh, global_config
+from alpa import parallelize, set_parallelize_options, PhysicalDeviceMesh, global_config
 from alpa.model.bert_model import (BertConfig, FlaxBertLayerCollection,
                                    FlaxBertForMaskedLMModule)
 from alpa.util import count_communication_primitives
@@ -82,10 +82,15 @@ class AutoShardingAttentionTest(unittest.TestCase):
             }, deterministic, model.apply)
 
         # Get optimized HLO IR
-        hlo_module = testing.last_compiled_executable.hlo_modules()[0]
-        hlo_ir = hlo_module.to_string()
+        executable = train_step.get_executable(
+            optimizer, {
+                "hidden_states": hidden_states,
+                "attention_mask": attention_mask,
+                "label": label,
+                "rng": rngkey
+            }, deterministic, model.apply)
 
-        return optimizer, hlo_ir, testing.last_compiled_auto_sharding_objective
+        return optimizer, executable.get_hlo_text(), executable.auto_sharding_objective
 
     def run_bert_mlm(self, batch_size, seq_len, num_layers, hidden_size,
                      num_heads, vocab_size, deterministic, device_mesh):
@@ -146,10 +151,17 @@ class AutoShardingAttentionTest(unittest.TestCase):
             })
 
         # Get optimized HLO IR
-        hlo_module = testing.last_compiled_executable.hlo_modules()[0]
-        hlo_ir = hlo_module.to_string()
+        executable = train_step.get_executable(
+            optimizer, {
+                "input_ids": input_ids,
+                "attention_mask": attention_mask,
+                "token_type_ids": token_type_ids,
+                "position_ids": position_ids,
+                "labels": labels,
+                "rng": rngkey
+            })
 
-        return optimizer, hlo_ir, testing.last_compiled_auto_sharding_objective
+        return optimizer, executable.get_hlo_text(), executable.auto_sharding_objective
 
     def test_bert_layer_data_parallel(self):
         batch_size = 64
@@ -365,11 +377,11 @@ class AutoShardingAttentionTest(unittest.TestCase):
         optimize = func(optimizer, x, y)
 
         # Check communication cost
-        hlo_module = testing.last_compiled_executable.hlo_modules()[0]
-        hlo_ir = hlo_module.to_string()
+        executable = func.get_executable(optimizer, x, y)
+        hlo_ir = executable.get_hlo_text()
+        objective = executable.auto_sharding_objective
 
         params = jax.tree_util.tree_leaves(optimizer.target)
-        objective = testing.last_compiled_auto_sharding_objective
         expected = (
             logical_mesh.all_reduce_cost(
                 vocab_size * hidden_size * 4 / mesh_shape[1], 0) +

--- a/tests/test_auto_sharding_bert.py
+++ b/tests/test_auto_sharding_bert.py
@@ -90,8 +90,8 @@ class AutoShardingAttentionTest(unittest.TestCase):
                 "rng": rngkey
             }, deterministic, model.apply)
 
-        return optimizer, executable.get_hlo_text(
-        ), executable.auto_sharding_objective
+        return (optimizer, executable.get_hlo_text(),
+                executable.auto_sharding_objective)
 
     def run_bert_mlm(self, batch_size, seq_len, num_layers, hidden_size,
                      num_heads, vocab_size, deterministic, device_mesh):
@@ -162,8 +162,8 @@ class AutoShardingAttentionTest(unittest.TestCase):
                 "rng": rngkey
             })
 
-        return optimizer, executable.get_hlo_text(
-        ), executable.auto_sharding_objective
+        return (optimizer, executable.get_hlo_text(),
+                executable.auto_sharding_objective)
 
     def test_bert_layer_data_parallel(self):
         batch_size = 64

--- a/tests/test_auto_sharding_conv.py
+++ b/tests/test_auto_sharding_conv.py
@@ -180,8 +180,8 @@ class AutoShardingConvTest(unittest.TestCase):
 
         # Get optimized HLO IR
         executable = train_step.get_executable(state, {"x": x, "y": y})
-        return state, executable.get_hlo_text(
-        ), executable.auto_sharding_objective
+        return (state, executable.get_hlo_text(),
+                executable.auto_sharding_objective)
 
     def test_n_layer_conv_data_parallel(self):
         batch_size = 16

--- a/tests/test_auto_sharding_conv.py
+++ b/tests/test_auto_sharding_conv.py
@@ -180,7 +180,8 @@ class AutoShardingConvTest(unittest.TestCase):
 
         # Get optimized HLO IR
         executable = train_step.get_executable(state, {"x": x, "y": y})
-        return state, executable.get_hlo_text(), executable.auto_sharding_objective
+        return state, executable.get_hlo_text(
+        ), executable.auto_sharding_objective
 
     def test_n_layer_conv_data_parallel(self):
         batch_size = 16

--- a/tests/test_auto_sharding_conv.py
+++ b/tests/test_auto_sharding_conv.py
@@ -10,7 +10,7 @@ import jax.numpy as jnp
 import numpy as np
 import optax
 
-from alpa import parallelize, set_parallelize_options, testing, PhysicalDeviceMesh, global_config
+from alpa import parallelize, set_parallelize_options, PhysicalDeviceMesh, global_config
 from alpa.util import map_to_shape, count_communication_primitives
 
 from test_auto_sharding_mlp import assert_close, assert_all_replicated, is_sharded
@@ -179,9 +179,8 @@ class AutoShardingConvTest(unittest.TestCase):
         state = train_step(state, {"x": x, "y": y})
 
         # Get optimized HLO IR
-        hlo_module = testing.last_compiled_executable.hlo_modules()[0]
-        hlo_ir = hlo_module.to_string()
-        return state, hlo_ir, testing.last_compiled_auto_sharding_objective
+        executable = train_step.get_executable(state, {"x": x, "y": y})
+        return state, executable.get_hlo_text(), executable.auto_sharding_objective
 
     def test_n_layer_conv_data_parallel(self):
         batch_size = 16

--- a/tests/test_auto_sharding_gradient_accumulation.py
+++ b/tests/test_auto_sharding_gradient_accumulation.py
@@ -11,7 +11,7 @@ import jax
 import jax.numpy as jnp
 import ray
 
-from alpa import (parallelize, set_parallelize_options, grad, testing,
+from alpa import (parallelize, set_parallelize_options, grad,
                   global_config, PhysicalDeviceMesh, DeviceCluster)
 from alpa.util import count_communication_primitives
 from alpa.testing import assert_allclose
@@ -33,7 +33,7 @@ class GradAccumulationTest(unittest.TestCase):
 
     def run_gradient_accumulation(self, use_ray, use_2d_mesh):
         if use_ray:
-            device_cluster = DeviceCluster()
+            device_cluster = DeviceCluster(use_cpu_on_driver=False)
             physical_mesh = device_cluster.get_physical_mesh()
             logical_mesh = physical_mesh.get_default_logical_mesh()
         else:
@@ -142,12 +142,12 @@ class GradAccumulationTest(unittest.TestCase):
 
 def suite():
     suite = unittest.TestSuite()
-    suite.addTest(
-        GradAccumulationTest("test_gradient_accumulation_single_host"))
+    #suite.addTest(
+    #    GradAccumulationTest("test_gradient_accumulation_single_host"))
     suite.addTest(GradAccumulationTest("test_gradient_accumulation_multi_host"))
-    suite.addTest(GradAccumulationTest("test_gradient_accumulation_2d_mesh"))
-    suite.addTest(
-        GradAccumulationTest("test_gradient_accumulation_reduce_scatter"))
+    #suite.addTest(GradAccumulationTest("test_gradient_accumulation_2d_mesh"))
+    #suite.addTest(
+    #    GradAccumulationTest("test_gradient_accumulation_reduce_scatter"))
     return suite
 
 

--- a/tests/test_auto_sharding_gradient_accumulation.py
+++ b/tests/test_auto_sharding_gradient_accumulation.py
@@ -11,8 +11,8 @@ import jax
 import jax.numpy as jnp
 import ray
 
-from alpa import (parallelize, set_parallelize_options, grad,
-                  global_config, PhysicalDeviceMesh, DeviceCluster)
+from alpa import (parallelize, set_parallelize_options, grad, global_config,
+                  PhysicalDeviceMesh, DeviceCluster)
 from alpa.util import count_communication_primitives
 from alpa.testing import assert_allclose
 

--- a/tests/test_auto_sharding_gradient_accumulation.py
+++ b/tests/test_auto_sharding_gradient_accumulation.py
@@ -142,12 +142,12 @@ class GradAccumulationTest(unittest.TestCase):
 
 def suite():
     suite = unittest.TestSuite()
-    #suite.addTest(
-    #    GradAccumulationTest("test_gradient_accumulation_single_host"))
+    suite.addTest(
+        GradAccumulationTest("test_gradient_accumulation_single_host"))
     suite.addTest(GradAccumulationTest("test_gradient_accumulation_multi_host"))
-    #suite.addTest(GradAccumulationTest("test_gradient_accumulation_2d_mesh"))
-    #suite.addTest(
-    #    GradAccumulationTest("test_gradient_accumulation_reduce_scatter"))
+    suite.addTest(GradAccumulationTest("test_gradient_accumulation_2d_mesh"))
+    suite.addTest(
+        GradAccumulationTest("test_gradient_accumulation_reduce_scatter"))
     return suite
 
 

--- a/tests/test_auto_sharding_mlp.py
+++ b/tests/test_auto_sharding_mlp.py
@@ -12,7 +12,7 @@ from flax.training.train_state import TrainState
 from jax.interpreters.pxla import Chunked, NoSharding, Replicated, ShardedAxis
 import optax
 
-from alpa import parallelize, set_parallelize_options, testing, PhysicalDeviceMesh
+from alpa import parallelize, set_parallelize_options, PhysicalDeviceMesh
 from alpa.global_env import global_config
 from alpa.util import map_to_shape, count_communication_primitives
 
@@ -231,9 +231,8 @@ class AutoShardingMLPTest(unittest.TestCase):
         state = train_step(state, {"x": x, "y": y})
 
         # Get optimized HLO IR
-        hlo_module = testing.last_compiled_executable.hlo_modules()[0]
-        hlo_ir = hlo_module.to_string()
-        return state, hlo_ir, testing.last_compiled_auto_sharding_objective
+        executable = train_step.get_executable(state, {"x": x, "y": y})
+        return state, executable.get_hlo_text(), executable.auto_sharding_objective
 
     def test_n_layer_mlp_data_parallel(self):
         num_layers = 6

--- a/tests/test_auto_sharding_mlp.py
+++ b/tests/test_auto_sharding_mlp.py
@@ -232,7 +232,8 @@ class AutoShardingMLPTest(unittest.TestCase):
 
         # Get optimized HLO IR
         executable = train_step.get_executable(state, {"x": x, "y": y})
-        return state, executable.get_hlo_text(), executable.auto_sharding_objective
+        return state, executable.get_hlo_text(
+        ), executable.auto_sharding_objective
 
     def test_n_layer_mlp_data_parallel(self):
         num_layers = 6

--- a/tests/test_auto_sharding_mlp.py
+++ b/tests/test_auto_sharding_mlp.py
@@ -232,8 +232,8 @@ class AutoShardingMLPTest(unittest.TestCase):
 
         # Get optimized HLO IR
         executable = train_step.get_executable(state, {"x": x, "y": y})
-        return state, executable.get_hlo_text(
-        ), executable.auto_sharding_objective
+        return (state, executable.get_hlo_text(),
+                executable.auto_sharding_objective)
 
     def test_n_layer_mlp_data_parallel(self):
         num_layers = 6

--- a/tests/test_auto_sharding_moe.py
+++ b/tests/test_auto_sharding_moe.py
@@ -93,8 +93,8 @@ class AutoShardingMoETest(unittest.TestCase):
                 "labels": labels,
                 "rng": rngkey
             }, deterministic, model.apply)
-        return optimizer, executable.get_hlo_text(
-        ), executable.auto_sharding_objective
+        return (optimizer, executable.get_hlo_text(),
+                executable.auto_sharding_objective)
 
     def run_moe_lm(self, batch_size, seq_len, num_layers, hidden_size,
                    num_heads, vocab_size, S, E, deterministic, device_mesh):
@@ -181,8 +181,8 @@ class AutoShardingMoETest(unittest.TestCase):
                 "position_ids": position_ids,
                 "labels": labels,
             }, deterministic, rngkey)
-        return state, executable.get_hlo_text(
-        ), executable.auto_sharding_objective
+        return (state, executable.get_hlo_text(),
+                executable.auto_sharding_objective)
 
     def test_moe_layer(self):
         batch_size = 64

--- a/tests/test_auto_sharding_moe.py
+++ b/tests/test_auto_sharding_moe.py
@@ -10,7 +10,7 @@ from jax.interpreters.pxla import Chunked, NoSharding, Replicated, ShardedAxis
 import numpy as np
 import optax
 
-from alpa import parallelize, set_parallelize_options, testing, PhysicalDeviceMesh, global_config
+from alpa import parallelize, set_parallelize_options, PhysicalDeviceMesh, global_config
 from alpa.util import map_to_shape, count_communication_primitives
 from alpa.model.moe import FlaxMoELayer, FlaxMoEForLMModule, MoEConfig, TrainState
 from alpa.model.model_util import optax_adafactor
@@ -86,9 +86,14 @@ class AutoShardingMoETest(unittest.TestCase):
             }, deterministic, model.apply)
 
         # Get optimized HLO IR
-        hlo_module = testing.last_compiled_executable.hlo_modules()[0]
-        hlo_ir = hlo_module.to_string()
-        return optimizer, hlo_ir, testing.last_compiled_auto_sharding_objective
+        executable = train_step.get_executable(
+            optimizer, {
+                "hidden_states": hidden_states,
+                "attention_mask": attention_mask,
+                "labels": labels,
+                "rng": rngkey
+            }, deterministic, model.apply)
+        return optimizer, executable.get_hlo_text(), executable.auto_sharding_objective
 
     def run_moe_lm(self, batch_size, seq_len, num_layers, hidden_size,
                    num_heads, vocab_size, S, E, deterministic, device_mesh):
@@ -167,9 +172,15 @@ class AutoShardingMoETest(unittest.TestCase):
             }, deterministic, rngkey)
 
         # Get optimized HLO IR
-        hlo_module = testing.last_compiled_executable.hlo_modules()[0]
-        hlo_ir = hlo_module.to_string()
-        return state, hlo_ir, testing.last_compiled_auto_sharding_objective
+        executable = train_step.get_executable(
+            state, {
+                "input_ids": input_ids,
+                "attention_mask": attention_mask,
+                "token_type_ids": token_type_ids,
+                "position_ids": position_ids,
+                "labels": labels,
+            }, deterministic, rngkey)
+        return state, executable.get_hlo_text(). executable.auto_sharding_objective
 
     def test_moe_layer(self):
         batch_size = 64

--- a/tests/test_auto_sharding_moe.py
+++ b/tests/test_auto_sharding_moe.py
@@ -93,7 +93,8 @@ class AutoShardingMoETest(unittest.TestCase):
                 "labels": labels,
                 "rng": rngkey
             }, deterministic, model.apply)
-        return optimizer, executable.get_hlo_text(), executable.auto_sharding_objective
+        return optimizer, executable.get_hlo_text(
+        ), executable.auto_sharding_objective
 
     def run_moe_lm(self, batch_size, seq_len, num_layers, hidden_size,
                    num_heads, vocab_size, S, E, deterministic, device_mesh):
@@ -180,7 +181,8 @@ class AutoShardingMoETest(unittest.TestCase):
                 "position_ids": position_ids,
                 "labels": labels,
             }, deterministic, rngkey)
-        return state, executable.get_hlo_text(). executable.auto_sharding_objective
+        return state, executable.get_hlo_text(
+        ), executable.auto_sharding_objective
 
     def test_moe_layer(self):
         batch_size = 64

--- a/tests/test_device_mesh.py
+++ b/tests/test_device_mesh.py
@@ -26,7 +26,7 @@ class DeviceMeshTest(unittest.TestCase):
 
     def test_add_one(self):
         # Launch a multi-host device mesh
-        device_cluster = DeviceCluster(use_gpu_on_driver=True)
+        device_cluster = DeviceCluster(use_cpu_on_driver=False)
         physical_mesh = device_cluster.get_physical_mesh()
         num_devices = len(
             physical_mesh.host_ids) * physical_mesh.num_devices_per_host
@@ -53,7 +53,7 @@ class DeviceMeshTest(unittest.TestCase):
 
     def test_mlp(self):
         # Launch a multi-host device mesh
-        device_cluster = DeviceCluster(use_gpu_on_driver=True)
+        device_cluster = DeviceCluster(use_cpu_on_driver=False)
         physical_mesh = device_cluster.get_physical_mesh()
         set_parallelize_options(devices=physical_mesh)
 
@@ -104,7 +104,7 @@ class DeviceMeshTest(unittest.TestCase):
         physical_mesh.shutdown()
 
     def test_distributed_array(self):
-        device_cluster = DeviceCluster(use_gpu_on_driver=True)
+        device_cluster = DeviceCluster(use_cpu_on_driver=False)
         physical_mesh = device_cluster.get_physical_mesh()
         logical_mesh = physical_mesh.get_default_logical_mesh()
 
@@ -128,7 +128,7 @@ class DeviceMeshTest(unittest.TestCase):
         assert isinstance(a, pxla.ShardedDeviceArray)
 
         # Multi host
-        device_cluster = DeviceCluster(use_gpu_on_driver=True)
+        device_cluster = DeviceCluster(use_cpu_on_driver=False)
         physical_mesh = device_cluster.get_physical_mesh()
         set_parallelize_options(devices=physical_mesh)
 

--- a/tests/test_pipeline_stage_construct_util.py
+++ b/tests/test_pipeline_stage_construct_util.py
@@ -93,7 +93,7 @@ class StageConstructUtilTest(unittest.TestCase):
                             donated_invars,
                             num_microbatch=2):
         gensym_func = gensym([closed_jaxpr.jaxpr])
-        compute_grad_jaxpr, apply_grad_jaxpr, barrier = (
+        closed_jaxpr, compute_grad_jaxpr, apply_grad_jaxpr, barrier = (
             split_compute_grad_and_apply_grad(closed_jaxpr, gensym_func))
         have_apply_grad = barrier is not None
         assert have_apply_grad


### PR DESCRIPTION
Currently, we run auto-sharding, spmd partitioner, and HLO optimization pipeline on the driver; run Cuda codegen on workers.
However, there is a CUDNN/CUBLAS auto-tuning pass in the HLO optimization pipeline, which requires GPU memory. Because all GPU memory is occupied by the workers, this pass cannot be executed on the driver. Currently, this pass is disabled to resolve the memory conflicts. However, this pass is critical for cudnn's performance. In this PR, we move the HLO optimization pipeline to workers and resolve the memory conflict, so we can enable this pass again.

This PR reorganizes passes and refactored the auto sharding pass APIs in `alpa/shard_parallel/auto_sharding.py`
The status of an HLO module is described below. 
https://github.com/alpa-projects/alpa/blob/bbdcc0d6432e5e75303a92d71a16f2374f776bab/alpa/shard_parallel/auto_sharding.py#L3-L20
Only spmd related passes are executed on the driver while all other passes (i.e. "post_spmd_partitioner passes") are executed on workers.

After this PR,
1. All compilation on the driver does not need GPU memory.
2. All compilation on the driver is platform agnostic. This makes it easier to support other platforms (e.g., TPU). As a todo item, we can create some new XLA APIs to do the compilation on the driver instead of hacking gpu_compiler.cc and using the GPU backend APIs.