### PR TITLE
[Documentation] install flax==0.4.0

### DIFF
--- a/docs/install/from_source.rst
+++ b/docs/install/from_source.rst
@@ -27,7 +27,7 @@ To install alpa from source, we need to build these forks.
 
   .. code:: bash
 
-    pip3 install cmake tqdm numpy scipy numba pybind11 ray[default] flax
+    pip3 install cmake tqdm numpy scipy numba pybind11 ray[default] flax==0.4.0
     pip3 install cupy-cuda111   # use your own CUDA version
 
     # In case NCCL is not automatically installed during cupy installation, please install it manually


### PR DESCRIPTION
The installation guide `pip3 install flax` will install flax 0.4.1 in default, which is not compatible with current jax-alpa (jax==0.2.26). The resulting error may occur when import alpa, which is quite obscure.