### PR TITLE
[RUNTIME] Save/Load DistributedArray on each Host node distributedly

### DIFF
--- a/alpa/collective/collective_group/gloo_collective_group.py
+++ b/alpa/collective/collective_group/gloo_collective_group.py
@@ -454,7 +454,8 @@ def _check_cpu_tensors(tensors):
                            " Got {} != 1.".format(len(tensors)))
     d = gloo_util.get_tensor_device(tensors[0])
     if d != "cpu":
-        raise RuntimeError("Gloo only accept cpu tensor." " Got {}.".format(d))
+        raise RuntimeError("Gloo only accept cpu tensor."
+                           " Got {}.".format(d))
 
 
 def _flatten_for_scatter_gather(tensor_list, copy=False):

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -7,6 +7,7 @@ from itertools import chain
 import logging
 from operator import attrgetter
 import os
+import re
 import time
 from typing import Any, List, Union, Sequence, Tuple, Optional
 
@@ -28,6 +29,7 @@ from jax.lib import xla_client
 import jax.numpy as jnp
 import numpy as np
 import ray
+import tensorstore as ts
 
 from alpa import mesh_profiling
 import alpa.collective as col
@@ -96,6 +98,72 @@ class MeshHostWorker:
                     jax_tensor_to_cupy(device_put(
                         jnp.ones((1,), dtype=jnp.int8), d),
                                        take_ownership=True))
+
+    ##### TensorStore Related Functions #####
+    def get_tensorstore_spec(self, ckpt_path: str):
+        spec = {
+            'driver': 'zarr',
+            'kvstore': {},
+            'metadata_key': f".zarray{self.host_id}"
+        }
+        if ckpt_path.startswith('gs://'):
+            m = re.fullmatch('^gs://([^/]*)/(.*)$', ckpt_path, re.DOTALL)
+            if m is None:
+                raise ValueError(
+                    'The ckpt_path should contain the bucket name and the '
+                    f'file path inside the bucket. Got: {ckpt_path}')
+            gcs_bucket = m.group(1)
+            path_without_bucket = m.group(2)
+            spec['kvstore'] = {
+                'driver': 'gcs',
+                'bucket': gcs_bucket,
+                'path': path_without_bucket
+            }
+        else:
+            spec['kvstore'] = {'driver': 'file', 'path': ckpt_path}
+        return spec
+
+    def load_buffers_from_ts_store(self, ckpt_dir: str, uuids: Sequence[int],
+                     shard_indices: Sequence[Index], device_ids: Sequence[int]):
+        ts_spec = self.get_tensorstore_spec(ckpt_dir)
+        t = ts.open(ts.Spec(ts_spec), open=True).result()
+
+        for index, uuid, device_id in zip(shard_indices, uuids, device_ids):
+            data = t[index].read().result()
+            self.put_buffer(uuid, device_id, data)
+
+    def save_buffers_to_ts_store(self, ckpt_dir: str, uuids: Sequence[int],
+                     shard_indices: Sequence[Index],
+                     global_shape: Sequence[int]):
+        for uuid in uuids:
+            assert uuid in self.buffers
+
+        ts_spec = self.get_tensorstore_spec(ckpt_dir)
+        dtype = self.buffers[uuids[0]].dtype
+        if dtype == jnp.bfloat16:
+            # Tensorstore uses 'bfloat16', not '<V2'.
+            dtype = 'bfloat16'
+        else:
+            dtype = np.dtype(dtype).str
+        metadata = {
+            'compressor': {
+                'id': 'gzip'
+            },
+            'shape': global_shape,
+            'chunks': self.buffers[uuids[0]].shape,
+            'dtype': dtype,
+        }
+        ts_spec['metadata'] = metadata
+        t = ts.open(ts.Spec(ts_spec),
+                    create=True,
+                    open=True,
+                    context=ts.Context({'file_io_concurrency': {
+                        'limit': 128
+                    }})).result()
+
+        for index, uuid in zip(shard_indices, uuids):
+            t[index].write(self.buffers[uuid]).result()
+
 
     ##### Buffer Related Functions #####
     def put_buffer(self, uuid: int, device_id: int, data: np.ndarray):
@@ -1122,6 +1190,51 @@ class DistributedArray:
 
     def flush(self):
         self._npy_value = None
+
+    ##### distributed save/load #####
+    def save(self, path: str):
+        """Save one replica of the array to `path` distributedly."""
+        one_replica_buffers = [
+            self.remote_buffers[i] for i in self.one_replica_buffer_indices
+        ]
+        one_replica_indices = [
+            self.indices[i] for i in self.one_replica_buffer_indices
+        ]
+        buf_refs_per_host = {k: [] for k in self.device_mesh.host_ids}
+        indices_per_host = {k: [] for k in self.device_mesh.host_ids}
+        for buf_ref, indice in zip(one_replica_buffers, one_replica_indices):
+            buf_refs_per_host[buf_ref.host_id].append(buf_ref.uuid)
+            indices_per_host[buf_ref.host_id].append(indice)
+        obj_refs = []
+        for host_id, uuids in buf_refs_per_host.items():
+            obj_refs.append(
+                self.device_mesh.workers[host_id].save_buffers_to_ts_store.remote(
+                    path, uuids, indices_per_host[host_id], self.shape))
+        return ray.get(obj_refs)
+
+    @classmethod
+    def load(cls, path: str, aval: ShapedArray, device_mesh: PhysicalDeviceMesh, sharding_spec: ShardingSpec):
+        """Load the data from `path` distributedly with `aval` and return a new DistributedArray"""
+        from alpa.mesh_executable import create_remote_buffer_refs
+        buf_refs, buf_uuids = create_remote_buffer_refs(device_mesh, 1)
+        indices = pxla.spec_to_indices(aval.shape, sharding_spec)
+
+        buf_refs_per_host = {k: [] for k in device_mesh.host_ids}
+        indices_per_host = {k: [] for k in device_mesh.host_ids}
+        device_ids_per_host = {k: [] for k in device_mesh.host_ids}
+        for buf_ref, indice in zip(buf_refs, indices):
+            buf_refs_per_host[buf_ref.host_id].append(buf_ref.uuid)
+            indices_per_host[buf_ref.host_id].append(indice)
+            device_ids_per_host[buf_ref.host_id].append(buf_ref.device_id)
+        obj_refs = []
+        for host_id, uuids in buf_refs_per_host.items():
+            obj_refs.append(
+                    device_mesh.workers[host_id].load_buffers_from_ts_store.remote(
+                    path, uuids, indices_per_host[host_id],
+                    device_ids_per_host[host_id]))
+        ray.get(obj_refs)
+        return DistributedArray(device_mesh, aval, sharding_spec, buf_refs, indice)
+
 
     @property
     def one_replica_buffer_indices(self):

--- a/alpa/global_env.py
+++ b/alpa/global_env.py
@@ -65,7 +65,9 @@ class GlobalConfig:
         self.xla_client_mem_fraction = 0.90
         self.xla_gpu_autotune_level = 4
         self.delete_remote_buffers_threshold = 500
-        self.use_aws_efa = os.environ.get("ALPA_USE_AWS_EFA", "").lower() in ["true", "1"]  # use AWS EFA network interface
+        self.use_aws_efa = os.environ.get("ALPA_USE_AWS_EFA", "").lower() in [
+            "true", "1"
+        ]  # use AWS EFA network interface
 
         ########## Options of shard_parallel ##########
         self.shard_parallel_search_logical_mesh_shape = False

--- a/alpa/monkey_patch.py
+++ b/alpa/monkey_patch.py
@@ -72,8 +72,8 @@ def _zeros(c, xla_shape):
         zero = pyval_to_ir_constant(c, np.array(0, dtype=dtype))
         return xops.Broadcast(zero, shape)
     else:
-         # It is a token
-         return xops.CreateToken(c)
+        # It is a token
+        return xops.CreateToken(c)
 
 
 def _remat_using_while(ctx, in_nodes, name, call_jaxpr):

--- a/docs/install/from_source.rst
+++ b/docs/install/from_source.rst
@@ -28,7 +28,7 @@ To install alpa from source, we need to build these forks.
 
       .. code:: bash
     
-        pip3 install cmake tqdm pybind11 numba numpy scipy pulp ray flax==0.4.1
+        pip3 install cmake tqdm pybind11 numba numpy scipy pulp ray flax==0.4.1 tensorstore
         pip3 install cupy-cuda114  # use your own CUDA version. Here cuda-cuda114 means cuda 11.4.
 
   - NCCL:

--- a/tests/test_auto_sharding_basic.py
+++ b/tests/test_auto_sharding_basic.py
@@ -174,6 +174,7 @@ class AutoShardingBasicTest(unittest.TestCase):
         assert_close(executable.auto_sharding_objective, 0)
 
     def test_argmax(self):
+
         @parallelize
         def split(a):
             b = jnp.argmax(a, axis=0)
@@ -188,6 +189,7 @@ class AutoShardingBasicTest(unittest.TestCase):
         assert "(param: f32[144,36])" in hlo_ir
 
     def test_sort(self):
+
         @parallelize
         def split(a):
             b = jnp.argsort(a)

--- a/tests/test_dist_save_load.py
+++ b/tests/test_dist_save_load.py
@@ -1,0 +1,86 @@
+"""Test distributed mulit-host device mesh."""
+
+import subprocess
+import tempfile
+import unittest
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import ray
+
+from alpa import DeviceCluster, DistributedArray
+from alpa.testing import assert_allclose
+
+class DistSaveLoadTest(unittest.TestCase):
+
+    def setUp(self):
+        ray.init(address="auto", ignore_reinit_error=True)
+
+    def tearDown(self):
+        ray.shutdown()
+
+    def test_distributed_array_save_load(self):
+        # Launch a device mesh contains four devices
+        device_cluster = DeviceCluster()
+        if device_cluster.num_devices < 4:
+            self.skipTest("This unit test requires a cluster with at least 4 devices! ")
+        host_num = min(len(device_cluster.host_info), 4)
+        device_per_host = 4 // host_num
+        physical_mesh = device_cluster.get_physical_mesh(list(range(host_num)), device_per_host)
+        logical_mesh = physical_mesh.get_logical_mesh([2, 2])
+
+        global_input_shape = (4, 2)
+        num = np.prod(np.array(global_input_shape))
+
+        # Build DistributedArray to be saved
+        # [[0,1],          [[0],  [[1],
+        #  [2,3],  shard    [2]]   [3]]
+        #  [4,5],  ====>   [[4],  [[5],
+        #  [6,7]]           [6]]   [7]]
+        global_input_data1 = jnp.arange(num).reshape(global_input_shape)
+        input_sharding_spec = logical_mesh.make_tile_spec(
+            global_input_data1, [0, 1], [0, 1])
+        input_indices = input_sharding_spec.indices(
+            global_input_data1.shape).flatten()
+        (dist_input_data1,) = physical_mesh.shard_args_to_arrays(
+            (jax.ShapedArray(global_input_data1.shape, jnp.int32),),
+            (input_indices,), (input_sharding_spec,), (global_input_data1,))
+
+        # Check the DistributedArray's remote buffers
+        remote_buffers1 = dist_input_data1.device_mesh.get_remote_buffers(dist_input_data1.remote_buffers, batching=True)
+        desired_buffers1 = [[[0], [2]], [[1], [3]], [[4], [6]], [[5], [7]]]
+        assert_allclose(np.array(desired_buffers1), np.array(remote_buffers1))
+
+        # Save the DistributedArray (one replica only)
+        tmpdir = tempfile.TemporaryDirectory()
+        subprocess.run(["rm", "-rf", tmpdir.name])
+        dist_input_data1.save(tmpdir.name)
+
+        # Load previously saved DistributedArray with a different shardingSpec
+        # [[0,1],          [[0,1],  [[0,1],
+        #  [2,3],  shard    [2,3]]   [2,3]]
+        #  [4,5],  ====>   [[4,5],  [[4,5],
+        #  [6,7]]           [6,7]]   [6,7]]
+        load_sharding_spec = logical_mesh.make_tile_spec(
+            global_input_data1, [0, 1], [0])
+        dist_load_data1 = DistributedArray.load(tmpdir.name, jax.ShapedArray(global_input_data1.shape, jnp.int32), physical_mesh, load_sharding_spec)
+
+        # Check the DistributedArray's remote buffers
+        remote_buffers2 = dist_load_data1.device_mesh.get_remote_buffers(dist_load_data1.remote_buffers, batching=True)
+        desired_buffers2 = [[[0, 1], [2, 3]], [[0, 1], [2, 3]], [[4, 5], [6, 7]],[[4, 5], [6, 7]]] 
+        assert_allclose(np.array(desired_buffers2), np.array(remote_buffers2))
+
+        # Cleanup
+        physical_mesh.shutdown()
+
+
+def suite():
+    suite = unittest.TestSuite()
+    suite.addTest(DistSaveLoadTest("test_distributed_array_save_load"))
+    return suite
+
+
+if __name__ == "__main__":
+    runner = unittest.TextTestRunner()
+    runner.run(suite())

--- a/tests/test_dist_save_load.py
+++ b/tests/test_dist_save_load.py
@@ -12,6 +12,7 @@ import ray
 from alpa import DeviceCluster, DistributedArray
 from alpa.testing import assert_allclose
 
+
 class DistSaveLoadTest(unittest.TestCase):
 
     def setUp(self):
@@ -24,10 +25,12 @@ class DistSaveLoadTest(unittest.TestCase):
         # Launch a device mesh contains four devices
         device_cluster = DeviceCluster()
         if device_cluster.num_devices < 4:
-            self.skipTest("This unit test requires a cluster with at least 4 devices! ")
+            self.skipTest(
+                "This unit test requires a cluster with at least 4 devices! ")
         host_num = min(len(device_cluster.host_info), 4)
         device_per_host = 4 // host_num
-        physical_mesh = device_cluster.get_physical_mesh(list(range(host_num)), device_per_host)
+        physical_mesh = device_cluster.get_physical_mesh(
+            list(range(host_num)), device_per_host)
         logical_mesh = physical_mesh.get_logical_mesh([2, 2])
 
         global_input_shape = (4, 2)
@@ -48,7 +51,8 @@ class DistSaveLoadTest(unittest.TestCase):
             (input_indices,), (input_sharding_spec,), (global_input_data1,))
 
         # Check the DistributedArray's remote buffers
-        remote_buffers1 = dist_input_data1.device_mesh.get_remote_buffers(dist_input_data1.remote_buffers, batching=True)
+        remote_buffers1 = dist_input_data1.device_mesh.get_remote_buffers(
+            dist_input_data1.remote_buffers, batching=True)
         desired_buffers1 = [[[0], [2]], [[1], [3]], [[4], [6]], [[5], [7]]]
         assert_allclose(np.array(desired_buffers1), np.array(remote_buffers1))
 
@@ -64,11 +68,16 @@ class DistSaveLoadTest(unittest.TestCase):
         #  [6,7]]           [6,7]]   [6,7]]
         load_sharding_spec = logical_mesh.make_tile_spec(
             global_input_data1, [0, 1], [0])
-        dist_load_data1 = DistributedArray.load(tmpdir.name, jax.ShapedArray(global_input_data1.shape, jnp.int32), physical_mesh, load_sharding_spec)
+        dist_load_data1 = DistributedArray.load(
+            tmpdir.name, jax.ShapedArray(global_input_data1.shape, jnp.int32),
+            physical_mesh, load_sharding_spec)
 
         # Check the DistributedArray's remote buffers
-        remote_buffers2 = dist_load_data1.device_mesh.get_remote_buffers(dist_load_data1.remote_buffers, batching=True)
-        desired_buffers2 = [[[0, 1], [2, 3]], [[0, 1], [2, 3]], [[4, 5], [6, 7]],[[4, 5], [6, 7]]] 
+        remote_buffers2 = dist_load_data1.device_mesh.get_remote_buffers(
+            dist_load_data1.remote_buffers, batching=True)
+        desired_buffers2 = [[[0, 1], [2, 3]], [[0, 1], [2, 3]], [[4, 5], [6,
+                                                                          7]],
+                            [[4, 5], [6, 7]]]
         assert_allclose(np.array(desired_buffers2), np.array(remote_buffers2))
 
         # Cleanup


### PR DESCRIPTION
I added two methods for class DistributedArray: 
- save(path)  will save only one replica of the data that the DistributedArray's remote_buffers point to. This function can be called in the driver and it will dispatch the saving process to the MeshHostWorker, which uses TensorStore package to save the DeviceArray into EFS.
- load(path) will dispatch the loading process to the MeshHostWorker, which uses TensorStore package to load the data stored in EFS into the buffers.
The saved and loaded DistributedArray can have different ShardingSpec, so I think this can be the starting point for the model's distributed save/load.

You can also check the test_dist_save_load.py unit test. 