### PR TITLE
[PROFILING] Fix mesh profiling

### DIFF
--- a/alpa/global_env.py
+++ b/alpa/global_env.py
@@ -65,7 +65,9 @@ class GlobalConfig:
         self.xla_client_mem_fraction = 0.90
         self.xla_gpu_autotune_level = 4
         self.delete_remote_buffers_threshold = 500
-        self.use_aws_efa = os.environ.get("ALPA_USE_AWS_EFA", "").lower() in ["true", "1"]  # use AWS EFA network interface
+        self.use_aws_efa = os.environ.get("ALPA_USE_AWS_EFA", "").lower() in [
+            "true", "1"
+        ]  # use AWS EFA network interface
 
         ########## Options of shard_parallel ##########
         self.shard_parallel_search_logical_mesh_shape = False

--- a/alpa/mesh_profiling.py
+++ b/alpa/mesh_profiling.py
@@ -680,9 +680,9 @@ def enumerate_all_collective_spec(num_hosts, num_devices_per_host,
 
         for replica_group in replica_groups:
             for dtype in ["f32", "f16"]:
-
-                if replica_group != (tuple(range(8)),) or dtype != "f32":
-                    continue
+                # Debug filter
+                #if replica_group != (tuple(range(8)),) or dtype != "f32":
+                #    continue
 
                 if (max(replica_group[0]) - min(replica_group[0]) <
                         num_devices_per_host):

--- a/alpa/mesh_profiling.py
+++ b/alpa/mesh_profiling.py
@@ -248,8 +248,8 @@ def _op_reduce_scatter(operand, dtype, reduce_op, replica_groups, channel_id):
     return ret
 
 
-def _compile_profiling_executable_while_loop(
-        backend, shapes, op_func, num_devices):
+def _compile_profiling_executable_while_loop(backend, shapes, op_func,
+                                             num_devices):
     """
     Compile an xla executable for benchmarking operators.
     It is a while loop that calls the operator for multiple times.
@@ -311,7 +311,7 @@ def _compile_profiling_executable_while_loop(
 
 def _compile_profiling_executable_once(backend, shapes, op_func, num_devices):
     """
-    Compile a xla executable for benchmarking operators.
+    Compile an xla executable for benchmarking operators.
     It runs the op only once.
     """
     in_tuple_shape = xc.Shape.tuple_shape(
@@ -363,8 +363,11 @@ def rank_0_print(host_id, msg):
     if host_id == 0:
         print(msg, flush=True)
 
+
+# A set containing all replica group patterns with nccl communicator created.
 global communicator_set
-communicator_set = set() 
+communicator_set = set()
+
 
 def profile_one_hlo_op(backend, local_devices, host_id, num_devices,
                        num_devices_per_node, op_info):
@@ -538,7 +541,8 @@ def profile_one_hlo_op(backend, local_devices, host_id, num_devices,
         for j, (shape, dtype) in enumerate(all_shapes):
             if j == 0:
                 device_inputs.append([
-                    backend.buffer_from_pyval(np.int32(warmup), local_devices[k])
+                    backend.buffer_from_pyval(np.int32(warmup),
+                                              local_devices[k])
                     for k in range(len(local_devices))
                 ])
             else:

--- a/alpa/mesh_profiling.py
+++ b/alpa/mesh_profiling.py
@@ -608,8 +608,9 @@ def profile_hlo_ops(op_infos, backend, local_devices, host_id, num_devices,
             if i % barrier_every == 0:
                 # Run barrier to reduce hanging/deadlock issues
                 run_with_timeout(profile_one_hlo_op,
-                    (backend, local_devices, host_id, num_devices, ('barrier',)),
-                    timeout=single_timeout)
+                                 (backend, local_devices, host_id, num_devices,
+                                  ('barrier',)),
+                                 timeout=single_timeout)
 
             if host_id == 0 and (i + 1) % save_every == 0:
                 old_cache_len = len(cache_dict)
@@ -652,6 +653,7 @@ def profile_dot(device_cluster, cache_filename):
         )
 
     physical_mesh.shutdown()
+    time.sleep(2)
     return dot_cost_dict
 
 
@@ -707,8 +709,8 @@ def enumerate_all_collective_spec(num_hosts, num_devices_per_host,
                     all_specs.add((tuple(replica_group), dtype, 1 << i))
 
     all_specs = list(all_specs)
-    all_specs.sort(key=lambda k:
-                   (k[0][0][0] - k[0][0][-1], to_np_dtype(k[1]).itemsize, -k[2]))
+    all_specs.sort(key=lambda k: (k[0][0][0] - k[0][0][-1], to_np_dtype(k[1]).
+                                  itemsize, -k[2]))
     return list(all_specs)
 
 

--- a/alpa/mesh_profiling.py
+++ b/alpa/mesh_profiling.py
@@ -651,6 +651,7 @@ def profile_dot(device_cluster, cache_filename):
             f"Matmul: {(n, m, k, dtype)}, TFLOPS: {flop_count / results[i]/ 1e12:.2f}"
         )
 
+    physical_mesh.shutdown()
     return dot_cost_dict
 
 

--- a/alpa/mesh_profiling.py
+++ b/alpa/mesh_profiling.py
@@ -578,7 +578,7 @@ def profile_hlo_ops(op_infos, backend, local_devices, host_id, num_devices,
                     cache_filename, single_timeout):
     """Profile a list of HLO operators on a worker."""
     results = []
-    save_every = 20
+    save_every = 15
 
     if os.path.exists(cache_filename):
         rank_0_print(host_id,
@@ -681,7 +681,7 @@ def enumerate_all_collective_spec(num_hosts, num_devices_per_host,
         for replica_group in replica_groups:
             for dtype in ["f32", "f16"]:
                 # Debug filter
-                #if replica_group != (tuple(range(8)),) or dtype != "f32":
+                #if replica_group != (tuple(range(32)),) or dtype != "f32":
                 #    continue
 
                 if (max(replica_group[0]) - min(replica_group[0]) <
@@ -700,7 +700,7 @@ def enumerate_all_collective_spec(num_hosts, num_devices_per_host,
 
     all_specs = list(all_specs)
     all_specs.sort(key=lambda k:
-                   (k[0][0][0] - k[0][0][-1], to_np_dtype(k[1]).itemsize, k[2]))
+                   (k[0][0][0] - k[0][0][-1], to_np_dtype(k[1]).itemsize, -k[2]))
     return list(all_specs)
 
 
@@ -775,7 +775,7 @@ def profile_all(device_cluster, cluster_key, max_comm_size_intra_node,
                     batch_result = physical_mesh.profile_hlo_ops(
                         op_infos[s:s + batch_size],
                         cache_filename,
-                        single_timeout=bound(fail_ct * 100, 100, 500),
+                        single_timeout=bound(fail_ct * 100, 100, 400),
                         batch_timeout=batch_size * 100)
                 except ray.exceptions.RayError:
                     batch_result = None

--- a/alpa/mesh_profiling.py
+++ b/alpa/mesh_profiling.py
@@ -248,9 +248,10 @@ def _op_reduce_scatter(operand, dtype, reduce_op, replica_groups, channel_id):
     return ret
 
 
-def _compile_profiling_executable(backend, shapes, op_func, num_devices):
+def _compile_profiling_executable_while_loop(
+        backend, shapes, op_func, num_devices):
     """
-    Compile a xla executable for benchmarking operators.
+    Compile an xla executable for benchmarking operators.
     It is a while loop that calls the operator for multiple times.
     """
 
@@ -308,6 +309,41 @@ def _compile_profiling_executable(backend, shapes, op_func, num_devices):
     return shapes, backend.compile(loop_computation, compile_options)
 
 
+def _compile_profiling_executable_once(backend, shapes, op_func, num_devices):
+    """
+    Compile a xla executable for benchmarking operators.
+    It runs the op only once.
+    """
+    in_tuple_shape = xc.Shape.tuple_shape(
+        [xc.Shape.array_shape(dtype, shape) for shape, dtype in shapes])
+
+    sharding = xc.OpSharding()
+    sharding.type = sharding.type.REPLICATED
+    sharding.tile_assignment_dimensions.extend([1])
+    sharding.tile_assignment_devices.extend([0])
+
+    body = xc.XlaBuilder("body")
+    operands = [
+        _op_parameter(body, i, shape, dtype)
+        for i, (shape, dtype) in enumerate(shapes)
+    ]
+    body.set_sharding(sharding)
+    op_func(operands)
+    body.clear_sharding()
+    ops.Tuple(body, operands)
+    for i in range(len(shapes)):
+        body.setup_alias((i,), i, ())
+    body_computation = body.Build()
+
+    compile_options = xb.get_compile_options(
+        num_replicas=1,
+        num_partitions=num_devices,
+        device_assignment=np.arange(num_devices).reshape((1, -1)),
+        use_spmd_partitioning=True,
+    )
+    return shapes, backend.compile(body_computation, compile_options)
+
+
 def bound(value, minimum, maximum):
     return max(min(value, maximum), minimum)
 
@@ -327,22 +363,17 @@ def rank_0_print(host_id, msg):
     if host_id == 0:
         print(msg, flush=True)
 
+global communicator_set
+communicator_set = set() 
 
 def profile_one_hlo_op(backend, local_devices, host_id, num_devices,
                        num_devices_per_node, op_info):
     """Profile one HLO operator."""
-
-    # p3.16
-    #dot_fp16_work = 50e12
-    #dot_fp32_work = 10e12
-    #comm_single_node_work = 1 << 33
-    #comm_multi_node_work = 1 << 31
-
-    # p4.24
     dot_fp16_work = 100e12
     dot_fp32_work = 50e12
     comm_single_node_work = 1 << 34
     comm_multi_node_work = 1 << 32
+    replica_groups = None
 
     if op_info[0] == "dot":
         n, m, k, dtype_str = op_info[1]
@@ -450,8 +481,6 @@ def profile_one_hlo_op(backend, local_devices, host_id, num_devices,
             out = _op_all_reduce(operands[0], dtype, "add", replica_groups,
                                  channel_id)
             operands[-1] = out
-
-        work = number = 0
     elif op_info[0] == "barrier":
         replica_groups = (tuple(i for i in range(num_devices)),)
         dtype = to_np_dtype("f32")
@@ -462,64 +491,82 @@ def profile_one_hlo_op(backend, local_devices, host_id, num_devices,
             out = _op_all_reduce(operands[0], dtype, "add", replica_groups,
                                  channel_id)
             operands[-1] = out
-
-        work = number = 0
     else:
         raise NotImplementedError(f"Invalid op: {op_info[0]}")
 
-    if number == 0:
-        warmup = 1
-    else:
-        warmup = max(number // 10, 2)
-
     if op_info[0] in ["create-communicator", "barrier"]:
         rank_0_print(host_id, f"{op_info[0]}")
-    else:
-        rank_0_print(
-            host_id, f"Profiling {op_info}, work: {work}, number: {number}, "
-            f"time: {time.time():.0f}.")
 
-    # Compile
-    shapes, compiled = _compile_profiling_executable(backend, shapes, op_func,
-                                                     num_devices)
+        # Compile
+        all_shapes, compiled = _compile_profiling_executable_once(
+            backend, shapes, op_func, num_devices)
 
-    # Warm up
-    device_inputs = []
-    for j, (shape, dtype) in enumerate(shapes):
-        if j == 0:
+        # Run
+        device_inputs = []
+        for shape, dtype in all_shapes:
             device_inputs.append([
-                backend.buffer_from_pyval(np.int32(warmup), local_devices[k])
-                for k in range(len(local_devices))
-            ])
-        else:
-            device_inputs.append([
-                backend.buffer_from_pyval(np.empty(shape, dtype),
+                backend.buffer_from_pyval(np.ones(shape, dtype),
                                           local_devices[k])
                 for k in range(len(local_devices))
             ])
 
-    [d.synchronize_all_activity() for d in local_devices]
-    device_inputs = compiled.execute_sharded_on_local_devices(device_inputs)
-    [d.synchronize_all_activity() for d in local_devices]
+        [d.synchronize_all_activity() for d in local_devices]
+        device_inputs = compiled.execute_sharded_on_local_devices(device_inputs)
+        [d.synchronize_all_activity() for d in local_devices]
+        return 0
+    else:
+        # Create the nccl communicator
+        # This step is a workaround for some nccl/xla deadlock
+        if replica_groups and replica_groups not in communicator_set:
+            tmp_op_info = ("create-communicator", (op_info[1][0],))
+            profile_one_hlo_op(backend, local_devices, host_id, num_devices,
+                               num_devices_per_node, tmp_op_info)
+            communicator_set.add(replica_groups)
 
-    if number == 0:
-        return -1.0
+        warmup = max(number // 10, 2)
 
-    # Run profiling
-    device_inputs[0] = [
-        backend.buffer_from_pyval(np.int32(number), local_devices[k])
-        for k in range(len(local_devices))
-    ]
+        rank_0_print(
+            host_id, f"Profiling {op_info}, work: {work}, number: {number}, "
+            f"timestamp: {time.time():.0f}.")
 
-    [d.synchronize_all_activity() for d in local_devices]
-    tic = time.time()
-    compiled.execute_sharded_on_local_devices(device_inputs)
-    [d.synchronize_all_activity() for d in local_devices]
-    toc = time.time()
+        # Compile
+        all_shapes, compiled = _compile_profiling_executable_while_loop(
+            backend, shapes, op_func, num_devices)
 
-    # Return
-    mean_time = (toc - tic) / number
-    return mean_time
+        # Warm up
+        device_inputs = []
+        for j, (shape, dtype) in enumerate(all_shapes):
+            if j == 0:
+                device_inputs.append([
+                    backend.buffer_from_pyval(np.int32(warmup), local_devices[k])
+                    for k in range(len(local_devices))
+                ])
+            else:
+                device_inputs.append([
+                    backend.buffer_from_pyval(np.ones(shape, dtype),
+                                              local_devices[k])
+                    for k in range(len(local_devices))
+                ])
+
+        [d.synchronize_all_activity() for d in local_devices]
+        device_inputs = compiled.execute_sharded_on_local_devices(device_inputs)
+        [d.synchronize_all_activity() for d in local_devices]
+
+        # Run profiling
+        device_inputs[0] = [
+            backend.buffer_from_pyval(np.int32(number), local_devices[k])
+            for k in range(len(local_devices))
+        ]
+
+        [d.synchronize_all_activity() for d in local_devices]
+        tic = time.time()
+        compiled.execute_sharded_on_local_devices(device_inputs)
+        [d.synchronize_all_activity() for d in local_devices]
+        toc = time.time()
+
+        # Return
+        mean_time = (toc - tic) / number
+        return mean_time
 
 
 def run_with_timeout(func, args=(), kwargs={}, timeout=None):
@@ -545,8 +592,7 @@ def profile_hlo_ops(op_infos, backend, local_devices, host_id, num_devices,
     """Profile a list of HLO operators on a worker."""
     results = []
     num_devices_per_node = 8
-    save_every = 15
-    barrier_timeout = 30
+    save_every = 20
 
     if os.path.exists(cache_filename):
         rank_0_print(host_id,
@@ -555,19 +601,7 @@ def profile_hlo_ops(op_infos, backend, local_devices, host_id, num_devices,
     else:
         cache_dict = {}
 
-    def barrier():
-        profile_one_hlo_op(backend, local_devices, host_id, num_devices,
-                           num_devices_per_node, ("barrier",))
-
     old_cache_len = len(cache_dict)
-    all_cache_hit = True
-    save_new = False
-    if op_infos[0][0] in [
-            "all-gather", "all-reduce", "all-to-all", "reduce-scatter"
-    ]:
-        run_barrier = True
-    else:
-        run_barrier = False
 
     try:
         for i, op_info in enumerate(op_infos):
@@ -576,20 +610,7 @@ def profile_hlo_ops(op_infos, backend, local_devices, host_id, num_devices,
                 results.append(cache_dict[op_info])
                 continue
 
-            if all_cache_hit == True and run_barrier:
-                # First time, create the nccl communicator
-                run_with_timeout(barrier, timeout=barrier_timeout)
-                tmp_op_info = ("create-communicator", (op_info[1][0],))
-                mean_time = run_with_timeout(
-                    profile_one_hlo_op,
-                    (backend, local_devices, host_id, num_devices,
-                     num_devices_per_node, tmp_op_info),
-                    timeout=barrier_timeout)
-
             # Profile one op
-            all_cache_hit = False
-            if run_barrier:
-                run_with_timeout(barrier, timeout=barrier_timeout)
             mean_time = run_with_timeout(
                 profile_one_hlo_op,
                 (backend, local_devices, host_id, num_devices,
@@ -602,20 +623,18 @@ def profile_hlo_ops(op_infos, backend, local_devices, host_id, num_devices,
                 old_cache_len = len(cache_dict)
                 rank_0_print(host_id, "Save cache...")
                 pickle.dump(cache_dict, open(cache_filename, "wb"))
-                save_new = True
     except TimeoutError:
         print(f"Worker {host_id} timeout error", flush=True)
-        return None, False, save_new
+        return None
     except RuntimeError:
         print(f"Worker {host_id} runtime error", flush=True)
-        return None, False, save_new
+        return None
 
     if host_id == 0 and len(cache_dict) > old_cache_len:
         rank_0_print(host_id, "Save cache...")
         pickle.dump(cache_dict, open(cache_filename, "wb"))
-        save_new = True
 
-    return np.array(results), all_cache_hit, save_new
+    return np.array(results)
 
 
 def profile_dot(device_cluster, cache_filename):
@@ -629,7 +648,7 @@ def profile_dot(device_cluster, cache_filename):
         for i in range(0, 64):
             n = 128 * i
             op_infos.append(("dot", (n, n, n, dtype)))
-    results, _, _ = physical_mesh.profile_hlo_ops(op_infos, cache_filename)
+    results = physical_mesh.profile_hlo_ops(op_infos, cache_filename)
 
     dot_cost_dict = defaultdict(list)
     for i in range(len(op_infos)):
@@ -758,40 +777,35 @@ def profile_all(device_cluster, cluster_key, comm_size_range, max_fail_retry,
             print(f"Batch size: {batch_size}, key: {batch_key}")
 
             # Profile a batch
-            if batch_key not in failed_batch_keys:
+            if batch_key in failed_batch_keys:
+                # This batch is skipped due to too many errors
+                batch_result = [np.inf] * batch_size
+            else:
                 try:
-                    batch_result, all_cache_hit, save_new = physical_mesh.profile_hlo_ops(
+                    batch_result = physical_mesh.profile_hlo_ops(
                         op_infos[s:s + batch_size],
                         cache_filename,
                         single_timeout=bound(fail_ct * 50, 50, 500),
                         batch_timeout=batch_size * 20)
                 except ray.exceptions.RayError:
                     batch_result = None
-                    all_cache_hit = save_new = False
-            else:
-                batch_result = [np.inf] * batch_size
-                all_cache_hit = True
-                save_new = False
 
             if batch_result is not None:
                 results.extend(batch_result)
                 s += batch_size
-
-            if save_new or all_cache_hit:
                 fail_ct = 0
             else:
                 fail_ct += 1
 
-            if fail_ct > max_fail_retry:  # Skip this batch if there are too many errors
-                print(f"Failed key: {batch_key}")
-                failed_batch_keys.add(batch_key)
-                pickle.dump(failed_batch_keys,
-                            open(failed_batch_keys_filename, "wb"))
+                if fail_ct > max_fail_retry:
+                    # Skip this batch if there are too many errors
+                    print(f"Failed key: {batch_key}")
+                    failed_batch_keys.add(batch_key)
+                    pickle.dump(failed_batch_keys,
+                                open(failed_batch_keys_filename, "wb"))
 
-            # Reboot physical mesh
-            if not all_cache_hit:
                 print(f"Reboot physical mesh. fail_ct: {fail_ct}")
-                physical_mesh.shutdown(forced=fail_ct > 0)
+                physical_mesh.shutdown(forced=True)
                 physical_mesh = None
                 time.sleep(10)
                 physical_mesh = tmp_mesh.get_physical_mesh()

--- a/alpa/monkey_patch.py
+++ b/alpa/monkey_patch.py
@@ -72,8 +72,8 @@ def _zeros(c, xla_shape):
         zero = pyval_to_ir_constant(c, np.array(0, dtype=dtype))
         return xops.Broadcast(zero, shape)
     else:
-         # It is a token
-         return xops.CreateToken(c)
+        # It is a token
+        return xops.CreateToken(c)
 
 
 def _remat_using_while(ctx, in_nodes, name, call_jaxpr):

--- a/benchmark/alpa/README.md
+++ b/benchmark/alpa/README.md
@@ -43,5 +43,10 @@ Type: gpt  Model Config: (32, 1024, 2560, 32, 32)  Parallel Config: (2, 2, 2)  P
 
 2. Run profiling to generate the database for the HLO instruction cost model.
 ```
-python3 gen_prof_database.py
+# for AWS p3.16:
+python3 gen_prof_database.py --max-comm-size-intra-node 32 --max-comm-size-inter-node 29
+
+# for AWS p4.24:
+python3 gen_prof_database.py --efa --max-comm-size-intra-node 33 --max-comm-size-inter-node 30 --max-fail-retry 8
 ```
+

--- a/benchmark/alpa/gen_prof_database.py
+++ b/benchmark/alpa/gen_prof_database.py
@@ -5,7 +5,7 @@ AWS p3.16:
 python3 gen_prof_database.py --max-comm-size-intra-node 32 --max-comm-size-inter-node 29
 
 AWS p4.24:
-python3 gen_prof_database.py --efa --max-comm-size-intra-node 33 --max-comm-size-intra-node 31
+python3 gen_prof_database.py --efa --max-comm-size-intra-node 33 --max-comm-size-inter-node 30 --max-fail-retry 8
 """
 
 import ray

--- a/benchmark/alpa/gen_prof_database.py
+++ b/benchmark/alpa/gen_prof_database.py
@@ -2,10 +2,10 @@
 
 Usage:
 AWS p3.16:
-python3 gen_prof_database.py --comm-size-max 30
+python3 gen_prof_database.py --max-comm-size-intra-node 32 --max-comm-size-inter-node 29
 
 AWS p4.24:
-python3 gen_prof_database.py --efa --comm-size-max 32
+python3 gen_prof_database.py --efa --max-comm-size-intra-node 33 --max-comm-size-intra-node 31
 """
 
 import ray
@@ -21,8 +21,11 @@ if __name__ == "__main__":
     parser.add_argument("--efa", action="store_true")
     parser.add_argument("--filename", type=str, default="prof_database.pkl",
         help="The filename of the output database")
-    parser.add_argument("--comm-size-max", type=int, required=True,
-        help="Run profiling for communication up to 2^x bytes, where x "
+    parser.add_argument("--max-comm-size-intra-node", type=int, required=True,
+        help="Run profiling for communication up to 2^x bytes within a node, where x "
+             "is this argument")
+    parser.add_argument("--max-comm-size-inter-node", type=int, required=True,
+        help="Run profiling for communication up to 2^x bytes cross nodes, where x "
              "is this argument")
     parser.add_argument("--cache-filename", type=str,
         default="/home/ubuntu/efs/alpa/benchmark/alpa/tmp/hlo_op_cost_dict.pkl",
@@ -50,7 +53,8 @@ if __name__ == "__main__":
 
     prof_database = cluster.profile_all(
         args.cluster_key,
-        comm_size_range=(0, args.comm_size_max + 1),
+        args.max_comm_size_intra_node,
+        args.max_comm_size_inter_node,
         max_fail_retry=args.max_fail_retry,
         cache_filename=args.cache_filename)
     prof_database.save(args.filename)

--- a/tests/test_auto_sharding_basic.py
+++ b/tests/test_auto_sharding_basic.py
@@ -174,6 +174,7 @@ class AutoShardingBasicTest(unittest.TestCase):
         assert_close(executable.auto_sharding_objective, 0)
 
     def test_argmax(self):
+
         @parallelize
         def split(a):
             b = jnp.argmax(a, axis=0)
@@ -188,6 +189,7 @@ class AutoShardingBasicTest(unittest.TestCase):
         assert "(param: f32[144,36])" in hlo_ir
 
     def test_sort(self):
+
         @parallelize
         def split(a):
             b = jnp.argsort(a)

--- a/tests/test_hlo_cost_model.py
+++ b/tests/test_hlo_cost_model.py
@@ -74,7 +74,8 @@ class HloCostModelTest(unittest.TestCase):
     def test_cluster_profling(self):
         cluster = DeviceCluster()
         prof_database = cluster.profile_all("p3.16",
-                                            comm_size_range=(19, 20),
+                                            2,
+                                            2,
                                             max_fail_retry=5,
                                             cache_filename="tmp_cache.pkl")
         prof_database.save("tmp_prof_database.pkl")


### PR DESCRIPTION
Improve the nccl communicator initialization, which greatly reduces the number of failures and retries during generating the profiling database.
The key is that we should not create the NCCL communicator in an HLO with while loop.