### PR TITLE
[RUNTIME] Distributed Save and Load for Model

### DIFF
--- a/alpa/__init__.py
+++ b/alpa/__init__.py
@@ -3,7 +3,7 @@ from alpa.data_loader import DataLoader, MeshDriverDataLoader
 from alpa.device_mesh import (DeviceCluster, PhysicalDeviceMesh,
                               LocalPhysicalDeviceMesh,
                               DistributedPhysicalDeviceMesh, DistributedArray,
-                              ReplicatedDistributedArray, fetch)
+                              fetch)
 from alpa.global_env import global_config, set_parallelize_options
 from alpa.mesh_profiling import ProfilingResultDatabase
 from alpa.pipeline_parallel.primitive_def import (mark_pipeline,

--- a/alpa/__init__.py
+++ b/alpa/__init__.py
@@ -2,8 +2,8 @@ from alpa.api import clear_callable_cache, grad, parallelize, value_and_grad
 from alpa.data_loader import DataLoader, MeshDriverDataLoader
 from alpa.device_mesh import (DeviceCluster, PhysicalDeviceMesh,
                               LocalPhysicalDeviceMesh,
-                              DistributedPhysicalDeviceMesh, DistributedArray, ReplicatedDistributedArray,
-                              fetch)
+                              DistributedPhysicalDeviceMesh, DistributedArray,
+                              ReplicatedDistributedArray, fetch)
 from alpa.global_env import global_config, set_parallelize_options
 from alpa.mesh_profiling import ProfilingResultDatabase
 from alpa.pipeline_parallel.primitive_def import (mark_pipeline,

--- a/alpa/__init__.py
+++ b/alpa/__init__.py
@@ -2,7 +2,7 @@ from alpa.api import clear_callable_cache, grad, parallelize, value_and_grad
 from alpa.data_loader import DataLoader, MeshDriverDataLoader
 from alpa.device_mesh import (DeviceCluster, PhysicalDeviceMesh,
                               LocalPhysicalDeviceMesh,
-                              DistributedPhysicalDeviceMesh, DistributedArray,
+                              DistributedPhysicalDeviceMesh, DistributedArray, ReplicatedDistributedArray,
                               fetch)
 from alpa.global_env import global_config, set_parallelize_options
 from alpa.mesh_profiling import ProfilingResultDatabase
@@ -11,6 +11,7 @@ from alpa.pipeline_parallel.primitive_def import (mark_pipeline,
 from alpa.pipeline_parallel.layer_construction import (
     manual_remat, automatic_remat, automatic_layer_construction,
     manual_layer_construction)
+from alpa.serialization import save_checkpoint, restore_checkpoint
 from alpa.shard_parallel.auto_sharding import LogicalDeviceMesh
 from alpa.util import XlaPassContext
 from alpa.timer import timers

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -102,7 +102,7 @@ class MeshHostWorker:
                 self.signal_tensors.append(
                     jax_tensor_to_cupy(device_put(
                         jnp.ones((1,), dtype=jnp.int8), d),
-                                       take_ownership=True))
+                        take_ownership=True))
 
     ##### Buffer Related Functions #####
     def put_buffer(self, uuid: int, device_id: int, data: np.ndarray):
@@ -1275,8 +1275,7 @@ class DistributedPhysicalDeviceMesh(PhysicalDeviceMesh):
     def get_max_memory_allocated(self):
         self.sync_workers()
         return max(
-            ray.get([w.get_max_memory_allocated.remote() for w in self.workers
-                    ]))
+            ray.get([w.get_max_memory_allocated.remote() for w in self.workers]))
 
     def get_available_memory(self):
         return min(

--- a/alpa/pipeline_parallel/decentralized_distributed_runtime.py
+++ b/alpa/pipeline_parallel/decentralized_distributed_runtime.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 import enum
 import logging
 from typing import Any, Dict, Sequence, List, Callable, Optional, Union, Tuple
-from jax import tree_flatten
 from jax._src.tree_util import tree_unflatten
 
 from jax.core import Var
@@ -926,7 +925,7 @@ class DecentralizedDistributedRuntime(BaseDistributedRuntime):
         split_to_ori = {}
         ori_to_split = {}
         load_info_map = {}
-        
+
         # build the mapping between original (flatten) index and split (and flatten) index
         split_idx = 0
         for i, is_batch in enumerate(self.is_batch):
@@ -958,7 +957,6 @@ class DecentralizedDistributedRuntime(BaseDistributedRuntime):
             else:
                 load_info_arr[i] = load_info_map[ori_to_split[i]]
         return tree_unflatten(self.in_tree, load_info_arr)
-        
 
     def run(self, *args, **kwargs):
         """The run function that maps to train_step()."""

--- a/alpa/pipeline_parallel/decentralized_distributed_runtime.py
+++ b/alpa/pipeline_parallel/decentralized_distributed_runtime.py
@@ -86,13 +86,12 @@ class PipelineInstruction:
                    info=info)
 
     @classmethod
-    def Recv(
-            cls,  # noqa
-            task_uuid,
-            output_uuids,
-            set_empty_buffer,
-            allgather_uuid=None,
-            info=""):  # noqa
+    def Recv(cls, # noqa
+             task_uuid,
+             output_uuids,
+             set_empty_buffer,
+             allgather_uuid=None,
+             info=""):  # noqa
         return cls(opcode=PipelineInstType.RECV,
                    task_uuid=task_uuid,
                    input_uuids=None,
@@ -192,7 +191,7 @@ class DecentralizedDistributedRuntime(BaseDistributedRuntime):
                  num_batch: int,
                  flop_count: int,
                  concat_vars_mapping: Dict[Var, Var],
-                 in_tree = None):
+                 in_tree=None):
         super().__init__(pipeline_stages=pipeline_stages,
                          global_invars=global_invars,
                          grad_dummy_invars=grad_dummy_invars,

--- a/alpa/pipeline_parallel/decentralized_distributed_runtime.py
+++ b/alpa/pipeline_parallel/decentralized_distributed_runtime.py
@@ -3,7 +3,9 @@ from collections import namedtuple, defaultdict
 from dataclasses import dataclass
 import enum
 import logging
-from typing import Any, Dict, Sequence, List, Callable, Optional, Union
+from typing import Any, Dict, Sequence, List, Callable, Optional, Union, Tuple
+from jax import tree_flatten
+from jax._src.tree_util import tree_unflatten
 
 from jax.core import Var
 from jax.interpreters import pxla

--- a/alpa/pipeline_parallel/decentralized_distributed_runtime.py
+++ b/alpa/pipeline_parallel/decentralized_distributed_runtime.py
@@ -3,12 +3,12 @@ from collections import namedtuple, defaultdict
 from dataclasses import dataclass
 import enum
 import logging
-from typing import Any, Dict, Sequence, List, Callable, Optional, Union, Tuple
-from jax._src.tree_util import tree_unflatten
+from typing import Any, Dict, Sequence, List, Callable, Optional, Union
 
 from jax.core import Var
 from jax.interpreters import pxla
 from jax.lib import xla_bridge as xb
+from jax.tree_util import tree_unflatten
 import numpy as np
 import ray.exceptions
 

--- a/alpa/pipeline_parallel/pipeshard_parallel.py
+++ b/alpa/pipeline_parallel/pipeshard_parallel.py
@@ -184,6 +184,7 @@ def pipeshard_parallel_callable(fun: lu.WrappedFun, in_tree, out_tree_thunk,
 
     # Wrap all things into a distributed runtime
     grad_in_to_out = {k: repr(v) for k, v in grad_in_to_out.items()}
+<<<<<<< HEAD
     global_outvars, concat_vars_mapping = _rewrite_global_outvars_post_concate(
         global_outvars, reduction_vector, microbatch_bound,
         post_microbatch_bound, gensym_func)
@@ -199,6 +200,19 @@ def pipeshard_parallel_callable(fun: lu.WrappedFun, in_tree, out_tree_thunk,
         num_batch=num_microbatch,
         flop_count=total_flops,
         concat_vars_mapping=concat_vars_mapping)
+=======
+    jp = DecentralizedDistributedRuntime(pipeline_stages=xla_stages,
+                                         global_invars=global_invars,
+                                         grad_dummy_invars=grad_in_to_out,
+                                         global_outvars=global_outvars,
+                                         physical_meshes=physical_meshes,
+                                         dependency=dependency,
+                                         schedule=schedule,
+                                         is_batch=batch_invars,
+                                         num_batch=num_micro_batches,
+                                         flop_count=total_flops,
+                                         in_tree=in_tree)
+>>>>>>> d53d3d1 (reorganize API for model save load)
 
     def ret_func(*args):
         return jp.run(*args)

--- a/alpa/pipeline_parallel/pipeshard_parallel.py
+++ b/alpa/pipeline_parallel/pipeshard_parallel.py
@@ -184,7 +184,6 @@ def pipeshard_parallel_callable(fun: lu.WrappedFun, in_tree, out_tree_thunk,
 
     # Wrap all things into a distributed runtime
     grad_in_to_out = {k: repr(v) for k, v in grad_in_to_out.items()}
-<<<<<<< HEAD
     global_outvars, concat_vars_mapping = _rewrite_global_outvars_post_concate(
         global_outvars, reduction_vector, microbatch_bound,
         post_microbatch_bound, gensym_func)
@@ -199,20 +198,8 @@ def pipeshard_parallel_callable(fun: lu.WrappedFun, in_tree, out_tree_thunk,
         is_batch=batch_invars,
         num_batch=num_microbatch,
         flop_count=total_flops,
-        concat_vars_mapping=concat_vars_mapping)
-=======
-    jp = DecentralizedDistributedRuntime(pipeline_stages=xla_stages,
-                                         global_invars=global_invars,
-                                         grad_dummy_invars=grad_in_to_out,
-                                         global_outvars=global_outvars,
-                                         physical_meshes=physical_meshes,
-                                         dependency=dependency,
-                                         schedule=schedule,
-                                         is_batch=batch_invars,
-                                         num_batch=num_micro_batches,
-                                         flop_count=total_flops,
-                                         in_tree=in_tree)
->>>>>>> d53d3d1 (reorganize API for model save load)
+        concat_vars_mapping=concat_vars_mapping,
+        in_tree=in_tree)
 
     def ret_func(*args):
         return jp.run(*args)

--- a/alpa/serialization.py
+++ b/alpa/serialization.py
@@ -15,7 +15,6 @@ from jax.core import ShapedArray
 from jax._src.tree_util import tree_flatten, tree_leaves, tree_unflatten
 import msgpack
 import numpy as np
-from tensorflow.io import gfile
 
 from alpa.device_mesh import DistributedArray, ReplicatedDistributedArray, PhysicalDeviceMesh
 
@@ -94,7 +93,7 @@ def save_checkpoint(ckpt_dir: Union[str, os.PathLike], target: PyTree,
     state_dict = to_state_dict(target)
     os.makedirs(ckpt_dir, exist_ok=True)
     ckpt_path = os.path.join(ckpt_dir, f"checkpoint_{step}")
-    with gfile.GFile(ckpt_path, 'wb') as fp:
+    with open(ckpt_path, 'wb') as fp:
         fp.write(
             msgpack.packb(state_dict,
                           default=_msgpack_ext_pack_wrapper(ckpt_dir),
@@ -145,7 +144,7 @@ def restore_checkpoint(ckpt_dir: Union[str, os.PathLike], step: int, target: PyT
             load_info: shardingSpec and deviceMesh allocation info for loading.
     """
     ckpt_path = os.path.join(ckpt_dir, f"checkpoint_{step}")
-    with gfile.GFile(ckpt_path, 'rb') as fp:
+    with open(ckpt_path, 'rb') as fp:
         ckpt_contents = fp.read()
     state_dict_content = msgpack.unpackb(ckpt_contents,
                                          ext_hook=_msgpack_ext_unpack,

--- a/alpa/serialization.py
+++ b/alpa/serialization.py
@@ -1,0 +1,89 @@
+"""Serialization utilities for Alpa.
+Adapted from https://flax.readthedocs.io/en/latest/_modules/flax/serialization.html, 
+add support for DistributedArray serialization in Alpa.
+"""
+
+import enum
+import os
+from typing import Callable, Optional, Sequence, Union, Any
+import uuid
+
+from flax.serialization import to_state_dict
+import jax
+import msgpack
+import numpy as np
+from tensorflow.io import gfile
+
+from alpa import DistributedArray, ReplicatedDistributedArray
+
+PyTree = Any
+
+class _MsgpackExtType(enum.IntEnum):
+    """Messagepack custom type ids."""
+    ndarray = 1
+    native_complex = 2
+    npscalar = 3
+    distarray = 4
+    replicated_distarray = 5
+
+
+def _msgpack_ext_pack_wrapper(ckpt_dir):
+    def _msgpack_ext_pack(x):
+        """Messagepack encoders for custom types."""
+        # if isinstance(x, (np.ndarray, jax.xla.DeviceArray)):
+        #     return msgpack.ExtType(_MsgpackExtType.ndarray, _ndarray_to_bytes(x))
+        # if np.issctype(type(x)):
+        #     # pack scalar as ndarray
+        #     return msgpack.ExtType(_MsgpackExtType.npscalar,
+        #                            _ndarray_to_bytes(np.asarray(x)))
+        # elif isinstance(x, complex):
+        #     return msgpack.ExtType(_MsgpackExtType.native_complex,
+        #                            msgpack.packb((x.real, x.imag)))
+        if isinstance(x, DistributedArray):
+            save_dir = os.path.join(ckpt_dir, uuid.uuid4().hex)
+            x.save(save_dir)
+            return msgpack.ExtType(_MsgpackExtType.distarray, msgpack.packb(save_dir))
+        elif isinstance(x, ReplicatedDistributedArray):
+            save_dir = os.path.join(ckpt_dir, uuid.uuid4().hex)
+            x.replica.save(save_dir)
+            return msgpack.ExtType(_MsgpackExtType.replicated_distarray, msgpack.packb(save_dir))
+        return x
+    return _msgpack_ext_pack
+
+def _msgpack_ext_unpack(code, data):
+    """Messagepack decoders for custom types."""
+    # if code == _MsgpackExtType.ndarray:
+    #     return _ndarray_from_bytes(data)
+    # elif code == _MsgpackExtType.native_complex:
+    #     complex_tuple = msgpack.unpackb(data)
+    #     return complex(complex_tuple[0], complex_tuple[1])
+    # elif code == _MsgpackExtType.npscalar:
+    #     ar = _ndarray_from_bytes(data)
+    #     return ar[()]  # unpack ndarray to scalar
+    if code == _MsgpackExtType.distarray:
+        return msgpack.unpackb(data)
+    elif code == _MsgpackExtType.replicated_distarray:
+        return msgpack.unpackb(data)
+    return msgpack.ExtType(code, data)
+
+
+def save_checkpoint(ckpt_dir: Union[str, os.PathLike], 
+                    target: PyTree,
+                    step: int):
+    """The same as flax.training.checkpoints.save_checkpoint. Save a checkpoint of the model, but support DistributedArrays in alpa."""
+    # TODO: copy all the safe-saving stuff from https://flax.readthedocs.io/en/latest/_modules/flax/training/checkpoints.html#save_checkpoint
+    state_dict = to_state_dict(target)
+    os.makedirs(ckpt_dir, exist_ok=True)
+    ckpt_tmp_path = os.path.join(ckpt_dir, f"checkpoint_{step}")
+    with gfile.GFile(ckpt_tmp_path, 'wb') as fp:
+        fp.write(msgpack.packb(state_dict, default=_msgpack_ext_pack_wrapper(ckpt_dir), strict_types=True))
+
+def restore_checkpoint(ckpt_dir: Union[str, os.PathLike], 
+                       step: int):
+    """The same as flax.training.checkpoints.load_checkpoint. Restore last/best checkpoint from checkpoints in path, but support DistributedArrays in alpa."""
+    # TODO: copy all the safe-loading stuff from https://flax.readthedocs.io/en/latest/_modules/flax/training/checkpoints.html#restore_checkpoint
+    ckpt_path = os.path.join(ckpt_dir, f"checkpoint_{step}")
+    with gfile.GFile(ckpt_path, 'rb') as fp:
+        ckpt_contents = fp.read()
+    state_dict = msgpack.unpackb(ckpt_contents, ext_hook=_msgpack_ext_unpack, raw=False)
+    return state_dict

--- a/alpa/serialization.py
+++ b/alpa/serialization.py
@@ -21,6 +21,7 @@ from alpa.device_mesh import DistributedArray, ReplicatedDistributedArray, Physi
 
 PyTree = Any
 
+
 class _MsgpackExtType(enum.IntEnum):
     """Messagepack custom type ids."""
     ndarray = 1
@@ -28,6 +29,7 @@ class _MsgpackExtType(enum.IntEnum):
     npscalar = 3
     distarray = 4
     replicated_distarray = 5
+
 
 def _msgpack_ext_pack_wrapper(ckpt_dir):
 
@@ -98,19 +100,21 @@ def save_checkpoint(ckpt_dir: Union[str, os.PathLike], target: PyTree,
                           default=_msgpack_ext_pack_wrapper(ckpt_dir),
                           strict_types=True))
 
+
 class LoadInfo:
     """
     A wrapper for the loading information.
     """
-    def __init__(self, avals: Sequence[ShapedArray], 
-                       meshes: Sequence[PhysicalDeviceMesh], 
-                       specs: Sequence[ShardingSpec]):
+    def __init__(self, 
+                 avals: Sequence[ShapedArray], 
+                 meshes: Sequence[PhysicalDeviceMesh], 
+                 specs: Sequence[ShardingSpec]):
         assert len(avals) == len(meshes)
         assert len(meshes) == len(specs)
         self.avals = avals
         self.meshes = meshes
         self.specs = specs
-    
+
     def add_replica(self, aval, mesh, spec):
         self.avals.append(aval)
         self.meshes.append(mesh)
@@ -126,9 +130,9 @@ class LoadInfo:
         return len(self.avals) > 1
 
 
-def restore_checkpoint(ckpt_dir: Union[str,os.PathLike], step: int, target: PyTree, load_info: PyTree):
+def restore_checkpoint(ckpt_dir: Union[str, os.PathLike], step: int, target: PyTree, load_info: PyTree):
     """Restore the specified checkpoint from `path`. 
-    
+
         Similar to flax.training.checkpoints.load_checkpoint, 
         but support DistributedArrays and ReplicatedDistributedArray in alpa.
         # TODO: copy all the safe-loading stuff from 

--- a/alpa/serialization.py
+++ b/alpa/serialization.py
@@ -8,7 +8,7 @@ import os
 from typing import Callable, Optional, Sequence, Union, Any
 import uuid
 
-from flax.serialization import to_state_dict
+from flax.serialization import to_state_dict, from_state_dict
 import jax
 import msgpack
 import numpy as np
@@ -79,6 +79,7 @@ def save_checkpoint(ckpt_dir: Union[str, os.PathLike],
         fp.write(msgpack.packb(state_dict, default=_msgpack_ext_pack_wrapper(ckpt_dir), strict_types=True))
 
 def restore_checkpoint(ckpt_dir: Union[str, os.PathLike], 
+                       target: PyTree,
                        step: int):
     """The same as flax.training.checkpoints.load_checkpoint. Restore last/best checkpoint from checkpoints in path, but support DistributedArrays in alpa."""
     # TODO: copy all the safe-loading stuff from https://flax.readthedocs.io/en/latest/_modules/flax/training/checkpoints.html#restore_checkpoint
@@ -86,4 +87,4 @@ def restore_checkpoint(ckpt_dir: Union[str, os.PathLike],
     with gfile.GFile(ckpt_path, 'rb') as fp:
         ckpt_contents = fp.read()
     state_dict = msgpack.unpackb(ckpt_contents, ext_hook=_msgpack_ext_unpack, raw=False)
-    return state_dict
+    return from_state_dict(target, state_dict)

--- a/tests/test_dist_save_load.py
+++ b/tests/test_dist_save_load.py
@@ -38,8 +38,17 @@ class DistSaveLoadTest(unittest.TestCase):
         assert_allclose(x, y)
 
     def test_distributed_array_save_load(self):
-        # Launch a device mesh contains four devices
         device_cluster = DeviceCluster()
+        if len(device_cluster.host_info) > 1:
+            # Get EFS mount point for the multi-host test
+            save_prefix = self._get_efs_mount_point()
+            if save_prefix is None:
+                self.skipTest("The multi-host test requires a mounted EFS! ")
+        else:
+            # Use tmp dir for the single-host test
+            save_prefix = "/tmp/"
+
+        # Launch a device mesh contains four devices
         if device_cluster.num_devices < 4:
             self.skipTest(
                 "This unit test requires a cluster with at least 4 devices! ")
@@ -72,7 +81,7 @@ class DistSaveLoadTest(unittest.TestCase):
         self.check_dist_array_eq(desired_buffers1, dist_input_data1)
 
         # Save the DistributedArray (one replica only)
-        tmpdir = tempfile.TemporaryDirectory()
+        tmpdir = tempfile.TemporaryDirectory(prefix=save_prefix)
         subprocess.run(["rm", "-rf", tmpdir.name])
         dist_input_data1.save(tmpdir.name)
 
@@ -116,6 +125,7 @@ class DistSaveLoadTest(unittest.TestCase):
             if save_prefix is None:
                 self.skipTest("The multi-host test requires a mounted EFS! ")
         else:
+            # Use tmp dir for the single-host test
             save_prefix = "/tmp/"
 
         # Init model and optimizer
@@ -177,6 +187,7 @@ class DistSaveLoadTest(unittest.TestCase):
             if save_prefix is None:
                 self.skipTest("The multi-host test requires a mounted EFS! ")
         else:
+            # Use tmp dir for the single-host test
             save_prefix = "/tmp/"
 
         # Config

--- a/tests/test_dist_save_load.py
+++ b/tests/test_dist_save_load.py
@@ -10,12 +10,15 @@ import jax
 import jax.numpy as jnp
 from jax.tree_util import tree_flatten, tree_unflatten, PyTreeDef
 import numpy as np
+import optax
 import ray
 
-from alpa import DeviceCluster, DistributedArray, parallelize, set_parallelize_options, save_checkpoint, restore_checkpoint
+from alpa import DeviceCluster, DistributedArray, parallelize, set_parallelize_options, save_checkpoint, restore_checkpoint, manual_layer_construction
 from alpa.global_env import set_parallelize_options, global_config
+from alpa.model.bert_model import BertConfig
+from alpa.model.model_util import TrainState
 from alpa.pipeline_parallel.primitive_def import mark_pipeline
-from alpa.testing import (MLPModel, create_train_state, get_mlp_train_step,
+from alpa.testing import (MLPModel, BertLayerModel, create_train_state, get_bert_layer_train_step, get_mlp_train_step,
                           assert_allclose)
 
 
@@ -64,8 +67,8 @@ class DistSaveLoadTest(unittest.TestCase):
             (input_indices,), (input_sharding_spec,), (global_input_data1,))
 
         # Check the DistributedArray's remote buffers
-        desired_buffers1 = [[[0], [2]], [[1], [3]], [[4], [6]], [[5], [7]]]
-        self.check_dist_array_eq(np.array(desired_buffers1), dist_input_data1)
+        desired_buffers1 = np.array([[[0], [2]], [[1], [3]], [[4], [6]], [[5], [7]]])
+        self.check_dist_array_eq(desired_buffers1, dist_input_data1)
 
         # Save the DistributedArray (one replica only)
         tmpdir = tempfile.TemporaryDirectory()
@@ -84,10 +87,10 @@ class DistSaveLoadTest(unittest.TestCase):
             physical_mesh, load_sharding_spec)
 
         # Check the DistributedArray's remote buffers
-        desired_buffers2 = [[[0, 1], [2, 3]], [[0, 1], [2, 3]], [[4, 5], [6,
+        desired_buffers2 = np.array([[[0, 1], [2, 3]], [[0, 1], [2, 3]], [[4, 5], [6,
                                                                           7]],
-                            [[4, 5], [6, 7]]]
-        self.check_dist_array_eq(np.array(desired_buffers2), dist_load_data1)
+                            [[4, 5], [6, 7]]])
+        self.check_dist_array_eq(desired_buffers2, dist_load_data1)
 
         # Cleanup
         physical_mesh.shutdown()
@@ -105,6 +108,8 @@ class DistSaveLoadTest(unittest.TestCase):
         model = MLPModel(hidden_dim=hidden_dim,
                          output_dim=output_dim,
                          manual_pipeline_layer=True)
+        
+        # Init batch args
         rngkey = jax.random.PRNGKey(0)
         x = jax.random.normal(rngkey, (batch_size, input_dim))
         y = jax.random.normal(rngkey, (batch_size, output_dim))
@@ -135,15 +140,89 @@ class DistSaveLoadTest(unittest.TestCase):
         # Run after load
         serial_state = serial_train_step(serial_state, batch)[0]
         load_state = parallel_train_step(load_state, batch)[0]
+        
+        # Check results
         assert_allclose(serial_state.params, load_state.params, 1e-3, 1e-3)
 
         # Cleanup
         executable.shutdown()
+    
+    def test_distributed_bert_save_load(self):
+        # Set pipeline parallel option
+        virtual_mesh = DeviceCluster().get_virtual_physical_mesh()
+        set_parallelize_options(devices=virtual_mesh,
+                                strategy="pipeshard_parallel")
+
+        # Config
+        batch_size = 16
+        seq_len = 8
+        hidden_size = 128
+        num_heads = 8
+        n_layers = 4
+        dtype = jnp.float32
+
+        # Init batch args
+        rngkey = jax.random.PRNGKey(0)
+        x = jax.random.normal(rngkey, (batch_size, seq_len, hidden_size),
+                              dtype=dtype)
+        y = jax.random.normal(rngkey, (batch_size, seq_len, hidden_size),
+                              dtype=dtype)
+        attention_mask = jnp.ones((batch_size, seq_len), dtype=dtype)
+        batch = {"x": x, "y": y, "attention_mask": attention_mask}
+
+        # Init model and optimizer
+        model = BertLayerModel(config=BertConfig(hidden_size=hidden_size,
+                                                 intermediate_size=hidden_size *
+                                                 4,
+                                                 num_attention_heads=num_heads,
+                                                 num_hidden_layers=n_layers))
+        rngkey = jax.random.PRNGKey(0)
+        params = model.init(rngkey, x, attention_mask)
+        tx = optax.sgd(learning_rate=1e-2)
+        state = TrainState.create(apply_fn=model.apply,
+                                  params=params,
+                                  tx=tx,
+                                  dynamic_scale=None)
+
+        # Compile
+        global_config.num_micro_batches = 2
+        serial_train_step = get_bert_layer_train_step(False, None, None, n_layers, False)
+        parallel_train_step = get_bert_layer_train_step(True, True, False, n_layers, False)
+        executable = parallel_train_step.get_executable(state, batch)
+
+        # Run before save
+        serial_state = state
+        parallel_state = state
+        serial_state = serial_train_step(serial_state, batch)[0]
+        parallel_state = parallel_train_step(parallel_state, batch)[0]
+        assert_allclose(serial_state.params, parallel_state.params, 1e-3, 1e-3)
+
+        with tempfile.TemporaryDirectory(prefix="/home/ubuntu/efs/") as ckpt_dir:
+            # Save checkpoint 
+            save_checkpoint(ckpt_dir, parallel_state, 1)
+
+            # Restore checkpoint
+            load_path_dict = restore_checkpoint(ckpt_dir, state, 1)
+            load_state = executable.load_state_dict(load_path_dict)
+
+        # Run after load
+        serial_state = serial_train_step(serial_state, batch)[0]
+        load_state = parallel_train_step(load_state, batch)[0]
+
+        # Check results
+        assert_allclose(serial_state.params, load_state.params, 1e-3, 1e-3)
+        
+        # Cleanup
+        executable.shutdown()
+
+
+
 
 def suite():
     suite = unittest.TestSuite()
     suite.addTest(DistSaveLoadTest("test_distributed_array_save_load"))
     suite.addTest(DistSaveLoadTest("test_distributed_mlp_save_load"))
+    suite.addTest(DistSaveLoadTest("test_distributed_bert_save_load"))
     return suite
 
 

--- a/tests/test_dist_save_load.py
+++ b/tests/test_dist_save_load.py
@@ -4,16 +4,15 @@ from re import X
 import subprocess
 import tempfile
 import unittest
+from alpa.device_mesh import ReplicatedDistributedArray
 
-from flax import linen as nn
-from flax import optim
-from flax.serialization import to_state_dict
 import jax
 import jax.numpy as jnp
+from jax.tree_util import tree_flatten, tree_unflatten, PyTreeDef
 import numpy as np
 import ray
 
-from alpa import DeviceCluster, DistributedArray, parallelize, set_parallelize_options, save_checkpoint
+from alpa import DeviceCluster, DistributedArray, parallelize, set_parallelize_options, save_checkpoint, restore_checkpoint
 from alpa.global_env import set_parallelize_options, global_config
 from alpa.pipeline_parallel.primitive_def import mark_pipeline
 from alpa.testing import (MLPModel, create_train_state, get_mlp_train_step,
@@ -27,6 +26,13 @@ class DistSaveLoadTest(unittest.TestCase):
 
     def tearDown(self):
         ray.shutdown()
+    
+    def check_dist_array_eq(self, x, y):
+        if isinstance(x, DistributedArray):
+            x = np.array(x.device_mesh.get_remote_buffers(x.remote_buffers, batching=True))
+        if isinstance(y, DistributedArray):
+            y = np.array(y.device_mesh.get_remote_buffers(y.remote_buffers, batching=True))
+        assert_allclose(x, y)
 
     def test_distributed_array_save_load(self):
         # Launch a device mesh contains four devices
@@ -58,10 +64,8 @@ class DistSaveLoadTest(unittest.TestCase):
             (input_indices,), (input_sharding_spec,), (global_input_data1,))
 
         # Check the DistributedArray's remote buffers
-        remote_buffers1 = dist_input_data1.device_mesh.get_remote_buffers(
-            dist_input_data1.remote_buffers, batching=True)
         desired_buffers1 = [[[0], [2]], [[1], [3]], [[4], [6]], [[5], [7]]]
-        assert_allclose(np.array(desired_buffers1), np.array(remote_buffers1))
+        self.check_dist_array_eq(np.array(desired_buffers1), dist_input_data1)
 
         # Save the DistributedArray (one replica only)
         tmpdir = tempfile.TemporaryDirectory()
@@ -80,88 +84,18 @@ class DistSaveLoadTest(unittest.TestCase):
             physical_mesh, load_sharding_spec)
 
         # Check the DistributedArray's remote buffers
-        remote_buffers2 = dist_load_data1.device_mesh.get_remote_buffers(
-            dist_load_data1.remote_buffers, batching=True)
         desired_buffers2 = [[[0, 1], [2, 3]], [[0, 1], [2, 3]], [[4, 5], [6,
                                                                           7]],
                             [[4, 5], [6, 7]]]
-        assert_allclose(np.array(desired_buffers2), np.array(remote_buffers2))
+        self.check_dist_array_eq(np.array(desired_buffers2), dist_load_data1)
 
         # Cleanup
         physical_mesh.shutdown()
     
-    # def test_distributed_mlp_save_load(self):
-    #     # Launch a multi-host device mesh
-    #     virtual_mesh = DeviceCluster().get_virtual_physical_mesh()
-    #     set_parallelize_options(devices=virtual_mesh,
-    #                             strategy="pipeshard_parallel",
-    #                             pipeline_stage_mode="uniform_stage")
-
-    #     batch_size = 16
-    #     input_dim = hidden_dim = output_dim = 32
-
-    #     class Model(nn.Module):
-
-    #         @nn.compact
-    #         def __call__(self, x):
-    #             x = nn.Dense(features=hidden_dim)(x)
-    #             x = nn.relu(x)
-    #             x = nn.Dense(features=output_dim)(x)
-    #             return x
-
-    #     def train_step(optimizer, batch, apply_fn):
-
-    #         def loss_func(params):
-    #             out = apply_fn(params, batch["x"])
-    #             return jnp.mean((out - batch["y"])**2)
-
-    #         grad = jax.grad(loss_func)(optimizer.target)
-    #         new_optimizer = optimizer.apply_gradient(grad)
-    #         return new_optimizer
-
-    #     # One batch of data and label
-    #     batch = {
-    #         "x": np.random.randn(batch_size, input_dim),
-    #         "y": np.random.randn(batch_size, output_dim),
-    #     }
-
-    #     # Init model and optimizer
-    #     model = Model()
-    #     rngkey = jax.random.PRNGKey(0)
-    #     state = create_train_state(rngkey, model, [batch["x"]])
-
-    #     # Compile
-    #     global_config.num_micro_batches = 2
-    #     serial_train_step = get_mlp_train_step(False, None, None, False)
-    #     parallel_train_step = get_mlp_train_step(True, True, False, False)
-
-    #     serial_state = state
-    #     parallel_state = state
-    #     serial_state = serial_train_step(serial_state, batch)[0]
-    #     parallel_state = parallel_train_step(parallel_state, batch)[0]
-    #     assert_allclose(serial_state.params, parallel_state.params, 1e-3, 1e-3)
-
-    #     # Checkpoint (TODO: remove hard-coded path)
-    #     # ckpt_dir1 = "/home/ubuntu/efs/ckpt1"
-    #     # subprocess.run(["rm", "-rf", ckpt_dir1])
-    #     # save_checkpoint(ckpt_dir1, parallel_state, 1)
-
-    #     # Restore checkpoint
-    #     # train_step_parallel_restore = parallelize(train_step)
-    #     # executable = train_step_parallel_restore.get_executable(optimizer, batch, model.apply)
-    #     # optimizer_parallel_load = restore_checkpoint(ckpt_dir1, 1)
-
-    #     # Check results
-    #     # assert_allclose(optimizer_serial.target, optimizer_parallel_load.target)
-
-    #     # Cleanup
-    #     # executable.shutdown()
-
     def test_distributed_mlp_save_load(self):
         virtual_mesh = DeviceCluster().get_virtual_physical_mesh()
         set_parallelize_options(devices=virtual_mesh,
-                                strategy="pipeshard_parallel",
-                                pipeline_stage_mode="uniform_stage")
+                                strategy="pipeshard_parallel")
 
         # Init model and optimizer
         batch_size = 64
@@ -186,7 +120,10 @@ class DistSaveLoadTest(unittest.TestCase):
         parallel_state = state
         serial_state = serial_train_step(serial_state, batch)[0]
         parallel_state = parallel_train_step(parallel_state, batch)[0]
-        assert_allclose(serial_state.params, parallel_state.params, 1e-3, 1e-3)
+        # state_flat1, flat_tree1 = tree_flatten(parallel_state)
+        # parallel_state = parallel_train_step(parallel_state, batch)[0]
+        # state_flat2, flat_tree2 = tree_flatten(parallel_state)
+        # assert_allclose(serial_state.params, parallel_state.params, 1e-3, 1e-3)
 
         # Checkpoint (TODO: remove hard-coded path)
         ckpt_dir1 = "/home/ubuntu/efs/ckpt1"
@@ -194,9 +131,20 @@ class DistSaveLoadTest(unittest.TestCase):
         save_checkpoint(ckpt_dir1, parallel_state, 1)
 
         # Restore checkpoint
-        # train_step_parallel_restore = parallelize(train_step)
-        # executable = train_step_parallel_restore.get_executable(optimizer, batch, model.apply)
-        # optimizer_parallel_load = restore_checkpoint(ckpt_dir1, 1)
+        flat_save_state, save_tree = tree_flatten(parallel_state)
+        flat_load_path, load_tree = tree_flatten(restore_checkpoint(ckpt_dir1, state, 1))
+        flat_load_state = []
+        for x, path in zip(flat_save_state, flat_load_path):
+            if isinstance(x, ReplicatedDistributedArray):
+                x = x.replica
+            y = DistributedArray.load(path, x.aval, x.device_mesh, x.sharding_spec)
+            flat_load_state.append(y)
+            self.check_dist_array_eq(x, y)
+        load_state = tree_unflatten(load_tree, flat_load_state)
+
+        # state_flat_load = executable.load_args(state_flat)
+        # parallel_state_load = tree_unflatten(state_tree, state_flat_load)
+        # print(parallel_state_load)
 
         # Check results
         # assert_allclose(optimizer_serial.target, optimizer_parallel_load.target)

--- a/tests/test_dist_save_load.py
+++ b/tests/test_dist_save_load.py
@@ -1,16 +1,23 @@
-"""Test save and load of distributed arrays."""
+"""Test distributed save and load."""
 
+from re import X
 import subprocess
 import tempfile
 import unittest
 
+from flax import linen as nn
+from flax import optim
+from flax.serialization import to_state_dict
 import jax
 import jax.numpy as jnp
 import numpy as np
 import ray
 
-from alpa import DeviceCluster, DistributedArray
-from alpa.testing import assert_allclose
+from alpa import DeviceCluster, DistributedArray, parallelize, set_parallelize_options, save_checkpoint
+from alpa.global_env import set_parallelize_options, global_config
+from alpa.pipeline_parallel.primitive_def import mark_pipeline
+from alpa.testing import (MLPModel, create_train_state, get_mlp_train_step,
+                          assert_allclose)
 
 
 class DistSaveLoadTest(unittest.TestCase):
@@ -82,11 +89,125 @@ class DistSaveLoadTest(unittest.TestCase):
 
         # Cleanup
         physical_mesh.shutdown()
+    
+    # def test_distributed_mlp_save_load(self):
+    #     # Launch a multi-host device mesh
+    #     virtual_mesh = DeviceCluster().get_virtual_physical_mesh()
+    #     set_parallelize_options(devices=virtual_mesh,
+    #                             strategy="pipeshard_parallel",
+    #                             pipeline_stage_mode="uniform_stage")
 
+    #     batch_size = 16
+    #     input_dim = hidden_dim = output_dim = 32
+
+    #     class Model(nn.Module):
+
+    #         @nn.compact
+    #         def __call__(self, x):
+    #             x = nn.Dense(features=hidden_dim)(x)
+    #             x = nn.relu(x)
+    #             x = nn.Dense(features=output_dim)(x)
+    #             return x
+
+    #     def train_step(optimizer, batch, apply_fn):
+
+    #         def loss_func(params):
+    #             out = apply_fn(params, batch["x"])
+    #             return jnp.mean((out - batch["y"])**2)
+
+    #         grad = jax.grad(loss_func)(optimizer.target)
+    #         new_optimizer = optimizer.apply_gradient(grad)
+    #         return new_optimizer
+
+    #     # One batch of data and label
+    #     batch = {
+    #         "x": np.random.randn(batch_size, input_dim),
+    #         "y": np.random.randn(batch_size, output_dim),
+    #     }
+
+    #     # Init model and optimizer
+    #     model = Model()
+    #     rngkey = jax.random.PRNGKey(0)
+    #     state = create_train_state(rngkey, model, [batch["x"]])
+
+    #     # Compile
+    #     global_config.num_micro_batches = 2
+    #     serial_train_step = get_mlp_train_step(False, None, None, False)
+    #     parallel_train_step = get_mlp_train_step(True, True, False, False)
+
+    #     serial_state = state
+    #     parallel_state = state
+    #     serial_state = serial_train_step(serial_state, batch)[0]
+    #     parallel_state = parallel_train_step(parallel_state, batch)[0]
+    #     assert_allclose(serial_state.params, parallel_state.params, 1e-3, 1e-3)
+
+    #     # Checkpoint (TODO: remove hard-coded path)
+    #     # ckpt_dir1 = "/home/ubuntu/efs/ckpt1"
+    #     # subprocess.run(["rm", "-rf", ckpt_dir1])
+    #     # save_checkpoint(ckpt_dir1, parallel_state, 1)
+
+    #     # Restore checkpoint
+    #     # train_step_parallel_restore = parallelize(train_step)
+    #     # executable = train_step_parallel_restore.get_executable(optimizer, batch, model.apply)
+    #     # optimizer_parallel_load = restore_checkpoint(ckpt_dir1, 1)
+
+    #     # Check results
+    #     # assert_allclose(optimizer_serial.target, optimizer_parallel_load.target)
+
+    #     # Cleanup
+    #     # executable.shutdown()
+
+    def test_distributed_mlp_save_load(self):
+        virtual_mesh = DeviceCluster().get_virtual_physical_mesh()
+        set_parallelize_options(devices=virtual_mesh,
+                                strategy="pipeshard_parallel",
+                                pipeline_stage_mode="uniform_stage")
+
+        # Init model and optimizer
+        batch_size = 64
+        hidden_dim = 16
+        input_dim = output_dim = hidden_dim
+        model = MLPModel(hidden_dim=hidden_dim,
+                         output_dim=output_dim,
+                         manual_pipeline_layer=True)
+        rngkey = jax.random.PRNGKey(0)
+        x = jax.random.normal(rngkey, (batch_size, input_dim))
+        y = jax.random.normal(rngkey, (batch_size, output_dim))
+        batch = {'x': x, 'y': y}
+        state = create_train_state(rngkey, model, [x])
+
+        # Compile
+        global_config.num_micro_batches = 2
+        serial_train_step = get_mlp_train_step(False, None, None, False)
+        parallel_train_step = get_mlp_train_step(True, True, False, False)
+        executable = parallel_train_step.get_executable(state, batch)
+
+        serial_state = state
+        parallel_state = state
+        serial_state = serial_train_step(serial_state, batch)[0]
+        parallel_state = parallel_train_step(parallel_state, batch)[0]
+        assert_allclose(serial_state.params, parallel_state.params, 1e-3, 1e-3)
+
+        # Checkpoint (TODO: remove hard-coded path)
+        ckpt_dir1 = "/home/ubuntu/efs/ckpt1"
+        subprocess.run(["rm", "-rf", ckpt_dir1])
+        save_checkpoint(ckpt_dir1, parallel_state, 1)
+
+        # Restore checkpoint
+        # train_step_parallel_restore = parallelize(train_step)
+        # executable = train_step_parallel_restore.get_executable(optimizer, batch, model.apply)
+        # optimizer_parallel_load = restore_checkpoint(ckpt_dir1, 1)
+
+        # Check results
+        # assert_allclose(optimizer_serial.target, optimizer_parallel_load.target)
+
+        # Cleanup
+        executable.shutdown()
 
 def suite():
     suite = unittest.TestSuite()
-    suite.addTest(DistSaveLoadTest("test_distributed_array_save_load"))
+    # suite.addTest(DistSaveLoadTest("test_distributed_array_save_load"))
+    suite.addTest(DistSaveLoadTest("test_distributed_mlp_save_load"))
     return suite
 
 


### PR DESCRIPTION
I added two top-level APIs for Alpa: 
- save_checkpoint(ckpt_dir, target, step): the `target` is usually the trainState. This function (1) replaces the leaves of trainState (DistributedArray or ReplicatedDistributedArray) with the path to which the array is saved and saves this metadata for restore. (2) saves one replica for all the DistributedArrays/ReplicatedDistributedArrays in `target`.
- restore_checkpoint(executable, ckpt_dir, target, step): This function requires the DecentralizedRuntime which contains all the shardingSpec and mesh allocation info to load and reshard the DistributedArrays/ReplicatedDistributedArrays. 

Current version contains a defect that the trainState must be the first argument in the parallelized function (i.e. train_step). One possible fix requires the user to explicitly provide the index of the trainState in train_step's argument list. Any suggestion for a more elegant implementation?