### PR TITLE
[Refactor] Clean up the compliation in distributed pipeline runtime

### DIFF
--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -664,7 +664,7 @@ class MeshHostWorker:
 
     @staticmethod
     def check_alive():
-        return 0
+        return True
 
     def shutdown(self):
         self.sync()

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -195,7 +195,8 @@ class MeshHostWorker:
         self.executables[uuid] = executable_class(self, uuid, *args)
 
     def delete_executable(self, uuid: int):
-        del self.executables[uuid]
+        if uuid in self.executables:
+            del self.executables[uuid]
 
     def run_executable(self, uuid: int, *args, **kwargs):
         self.executables[uuid].execute_on_worker(*args, **kwargs)
@@ -668,8 +669,8 @@ class MeshHostWorker:
 
     def shutdown(self):
         self.sync()
-        del self.buffers
-        del self.executables
+        self.buffers.clear()
+        self.executables.clear()
         self.distributed_client.shutdown()
 
 

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -104,72 +104,6 @@ class MeshHostWorker:
                         jnp.ones((1,), dtype=jnp.int8), d),
                         take_ownership=True))
 
-    ##### TensorStore Related Functions #####
-    def get_ts_spec(self, ckpt_path: str):
-        spec = {
-            'driver': 'zarr',
-            'kvstore': {},
-            'metadata_key': f".zarray{self.host_id}"
-        }
-        if ckpt_path.startswith('gs://'):
-            m = re.fullmatch('^gs://([^/]*)/(.*)$', ckpt_path, re.DOTALL)
-            if m is None:
-                raise ValueError(
-                    'The ckpt_path should contain the bucket name and the '
-                    f'file path inside the bucket. Got: {ckpt_path}')
-            gcs_bucket = m.group(1)
-            path_without_bucket = m.group(2)
-            spec['kvstore'] = {
-                'driver': 'gcs',
-                'bucket': gcs_bucket,
-                'path': path_without_bucket
-            }
-        else:
-            spec['kvstore'] = {'driver': 'file', 'path': ckpt_path}
-        return spec
-
-    def load_buffers_from_ts(self, ckpt_dir: str, uuids: Sequence[int],
-                             shard_indices: Sequence[Index],
-                             device_ids: Sequence[int]):
-        ts_spec = self.get_ts_spec(ckpt_dir)
-        t = ts.open(ts.Spec(ts_spec), open=True).result()
-
-        for index, uuid, device_id in zip(shard_indices, uuids, device_ids):
-            data = t[index].read().result()
-            self.put_buffer(uuid, device_id, data)
-
-    def save_buffers_to_ts(self, ckpt_dir: str, uuids: Sequence[int],
-                           shard_indices: Sequence[Index],
-                           global_shape: Sequence[int]):
-        for uuid in uuids:
-            assert uuid in self.buffers
-
-        ts_spec = self.get_ts_spec(ckpt_dir)
-        dtype = self.buffers[uuids[0]].dtype
-        if dtype == jnp.bfloat16:
-            # Tensorstore uses 'bfloat16', not '<V2'.
-            dtype = 'bfloat16'
-        else:
-            dtype = np.dtype(dtype).str
-        metadata = {
-            'compressor': {
-                'id': 'gzip'
-            },
-            'shape': global_shape,
-            'chunks': self.buffers[uuids[0]].shape,
-            'dtype': dtype,
-        }
-        ts_spec['metadata'] = metadata
-        t = ts.open(ts.Spec(ts_spec),
-                    create=True,
-                    open=True,
-                    context=ts.Context({'file_io_concurrency': {
-                        'limit': 128
-                    }})).result()
-
-        for index, uuid in zip(shard_indices, uuids):
-            t[index].write(self.buffers[uuid]).result()
-
     ##### Buffer Related Functions #####
     def put_buffer(self, uuid: int, device_id: int, data: np.ndarray):
         assert uuid not in self.buffers
@@ -274,6 +208,72 @@ class MeshHostWorker:
 
     def get_exec_grad_sync_channel_ids(self, uuid: int):
         return self.executables[uuid].grad_sync_channel_ids
+
+    ##### TensorStore Related Functions #####
+    def get_ts_spec(self, ckpt_path: str):
+        spec = {
+            'driver': 'zarr',
+            'kvstore': {},
+            'metadata_key': f".zarray{self.host_id}"
+        }
+        if ckpt_path.startswith('gs://'):
+            m = re.fullmatch('^gs://([^/]*)/(.*)$', ckpt_path, re.DOTALL)
+            if m is None:
+                raise ValueError(
+                    'The ckpt_path should contain the bucket name and the '
+                    f'file path inside the bucket. Got: {ckpt_path}')
+            gcs_bucket = m.group(1)
+            path_without_bucket = m.group(2)
+            spec['kvstore'] = {
+                'driver': 'gcs',
+                'bucket': gcs_bucket,
+                'path': path_without_bucket
+            }
+        else:
+            spec['kvstore'] = {'driver': 'file', 'path': ckpt_path}
+        return spec
+
+    def load_buffers_from_ts(self, ckpt_dir: str, uuids: Sequence[int],
+                             shard_indices: Sequence[Index],
+                             device_ids: Sequence[int]):
+        ts_spec = self.get_ts_spec(ckpt_dir)
+        t = ts.open(ts.Spec(ts_spec), open=True).result()
+
+        for index, uuid, device_id in zip(shard_indices, uuids, device_ids):
+            data = t[index].read().result()
+            self.put_buffer(uuid, device_id, data)
+
+    def save_buffers_to_ts(self, ckpt_dir: str, uuids: Sequence[int],
+                           shard_indices: Sequence[Index],
+                           global_shape: Sequence[int]):
+        for uuid in uuids:
+            assert uuid in self.buffers
+
+        ts_spec = self.get_ts_spec(ckpt_dir)
+        dtype = self.buffers[uuids[0]].dtype
+        if dtype == jnp.bfloat16:
+            # Tensorstore uses 'bfloat16', not '<V2'.
+            dtype = 'bfloat16'
+        else:
+            dtype = np.dtype(dtype).str
+        metadata = {
+            'compressor': {
+                'id': 'gzip'
+            },
+            'shape': global_shape,
+            'chunks': self.buffers[uuids[0]].shape,
+            'dtype': dtype,
+        }
+        ts_spec['metadata'] = metadata
+        t = ts.open(ts.Spec(ts_spec),
+                    create=True,
+                    open=True,
+                    context=ts.Context({'file_io_concurrency': {
+                        'limit': 128
+                    }})).result()
+
+        for index, uuid in zip(shard_indices, uuids):
+            t[index].write(self.buffers[uuid]).result()
 
     ##### Data loader Related Functions #####
     def put_data_loader(self, uuid: int, *args):

--- a/alpa/global_env.py
+++ b/alpa/global_env.py
@@ -100,7 +100,7 @@ class GlobalConfig:
         self.overwrite_submesh_choices = None
 
         ########## Options of pipeline runtime ##########
-        self.pipeline_runtime_mode = "paper"  # or "production"
+        self.pipeline_check_alive = True
         self.pipeline_distributed_compile = True  # Whether to use distributed compilation
         # in pipeline parallel for each stage. Disabling it helps debug.
         self.pipeline_use_signal_send_recv = False

--- a/alpa/global_env.py
+++ b/alpa/global_env.py
@@ -100,6 +100,7 @@ class GlobalConfig:
         self.overwrite_submesh_choices = None
 
         ########## Options of pipeline runtime ##########
+        self.pipeline_check_alive = True
         self.pipeline_distributed_compile = True  # Whether to use distributed compilation
         # in pipeline parallel for each stage. Disabling it helps debug.
         self.pipeline_use_signal_send_recv = False

--- a/alpa/global_env.py
+++ b/alpa/global_env.py
@@ -100,7 +100,6 @@ class GlobalConfig:
         self.overwrite_submesh_choices = None
 
         ########## Options of pipeline runtime ##########
-        self.pipeline_check_alive = True
         self.pipeline_distributed_compile = True  # Whether to use distributed compilation
         # in pipeline parallel for each stage. Disabling it helps debug.
         self.pipeline_use_signal_send_recv = False

--- a/alpa/mesh_executable.py
+++ b/alpa/mesh_executable.py
@@ -894,8 +894,6 @@ class GradAccMeshWorkerExecutable(MeshWorkerExecutable):
 
 class PartialGradAccMeshDriverExecutable(NormalMeshDriverExecutable):
     """
-    The driver part of a mesh executable that
-    only computes and accumulates gradients, but does not apply it.
     """
 
     def __init__(self, physical_mesh: "PhysicalDeviceMesh",
@@ -945,8 +943,6 @@ class PartialGradAccMeshDriverExecutable(NormalMeshDriverExecutable):
 
 class PartialGradAccMeshWorkerExecutable(NormalMeshWorkerExecutable):
     """
-    The worker part of a mesh executable that
-    only computes and accumulates grads, but does not apply it
     """
 
     def __init__(self, worker: "MeshHostWorker", uuid: int, hlo_proto: bytes,

--- a/alpa/mesh_executable.py
+++ b/alpa/mesh_executable.py
@@ -894,6 +894,11 @@ class GradAccMeshWorkerExecutable(MeshWorkerExecutable):
 
 class PartialGradAccMeshDriverExecutable(NormalMeshDriverExecutable):
     """
+    The driver part of a mesh executable that can optionally skip
+    the gradient synchronization step.
+
+    This executable is used for computation stages in pipeline,
+    such as forward, backward and apply_grad
     """
 
     def __init__(self, physical_mesh: "PhysicalDeviceMesh",
@@ -943,6 +948,11 @@ class PartialGradAccMeshDriverExecutable(NormalMeshDriverExecutable):
 
 class PartialGradAccMeshWorkerExecutable(NormalMeshWorkerExecutable):
     """
+    The worker part of a mesh executable that can optionally skip
+    the gradient synchronization step.
+
+    This executable is used for computation stages in pipeline,
+    such as forward, backward and apply_grad
     """
 
     def __init__(self, worker: "MeshHostWorker", uuid: int, hlo_proto: bytes,

--- a/alpa/pipeline_parallel/base_runtime.py
+++ b/alpa/pipeline_parallel/base_runtime.py
@@ -3,16 +3,19 @@ import logging
 import time
 
 from abc import ABCMeta, abstractmethod
-from typing import List
+from typing import Sequence, Union
 
 from jax.core import Var
+import numpy as np
 import ray
 from alpa.global_env import global_config
 from alpa.util import OrderedSet
-from alpa.pipeline_parallel.cross_mesh_resharding import \
-    (CrossMeshCommunicator, SymbolicReshardingTask, SymbolicBroadcastReshardingTask)
+from alpa.pipeline_parallel.cross_mesh_resharding import (CrossMeshCommunicator,
+    SymbolicReshardingTask, SymbolicBroadcastReshardingTask)
+from alpa.pipeline_parallel.schedules import PipelineSchedule
 from alpa.pipeline_parallel.device_mesh_group import DistributedPhysicalDeviceMeshGroup
-from alpa.pipeline_parallel.computation import XlaShardedPipelineComputation
+from alpa.pipeline_parallel.computation import (PipelineComputation,
+    XlaShardedPipelineComputation)
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -21,16 +24,21 @@ logger.setLevel(logging.INFO)
 class BaseRuntime(metaclass=ABCMeta):
     """Abstract class for pipeline runtime."""
 
-    def __init__(self, *, pipeline_stages, global_invars, global_outvars,
-                 physical_meshes, **kwargs):
+    def __init__(self,
+                 *,
+                 pipeline_stages: Sequence[Union[PipelineComputation,
+                                                 XlaShardedPipelineComputation]],
+                 global_invars: Sequence[Var],
+                 global_outvars: Sequence[Var],
+                 physical_meshes: Sequence[Var]):
         """
         An abstract class for pipeline-parallel runtime.
 
         Args:
-            pipeline_stages (Sequence[PipelineComputation, XlaShardedPipelineComputation]): pipeline stages.
-            global_invars (Sequence[Var]): input variables.
-            global_outvars (Sequence[Var]): output varialbes.
-            physical_meshes (Sequence[PhysicalDeviceMesh]): input physical meshes.
+            pipeline_stages: pipeline stages.
+            global_invars: input variables.
+            global_outvars: output varialbes.
+            physical_meshes: input physical meshes.
         """
         self.global_invars = global_invars
         self.global_outvars = global_outvars
@@ -65,16 +73,15 @@ class BaseDistributedRuntime(BaseRuntime):
 
     def __init__(self,
                  *,
-                 pipeline_stages: List[XlaShardedPipelineComputation],
-                 global_invars: List[Var],
-                 grad_dummy_invars,
-                 global_outvars: List[Var],
+                 pipeline_stages: Sequence[XlaShardedPipelineComputation],
+                 global_invars: Sequence[Var],
+                 grad_dummy_invars: Sequence[Var],
+                 global_outvars: Sequence[Var],
                  physical_meshes: DistributedPhysicalDeviceMeshGroup,
-                 dependency,
-                 schedule,
-                 is_batch,
-                 num_batch=1,
-                 **kwargs):
+                 dependency: np.ndarray,
+                 schedule: PipelineSchedule,
+                 is_batch: Sequence[bool],
+                 num_batch: int):
         """
         A base class of distributed pipeline-parallel runtime.
 
@@ -82,17 +89,15 @@ class BaseDistributedRuntime(BaseRuntime):
         across different distributed runtime implementations.
 
         Args:
-            pipeline_stages (List[XlaShardedPipelineComputation]): list of pipeline stage programs.
-            global_invars (List[Var]): input variables.
-            grad_dummy_invars (List[Var]): vars for gradient accumulation.
-            global_outvars (List[Var]): output variables.
-            physical_meshes (DistributedPhysicalDeviceMeshGroup): the cluster meshes to pipeline over.
-            dependency (np.array): dependency between stages as an adjacency matrix.
-            schedule (GpipeSchedule): schedule to follow to execute the pipeline.
-            is_batch (): indicator of the batch dimension.
-            num_batch (int): number of microbatches.
-            kwargs (dict): a dict of keyword arguments as the sharding
-                compilation parameters.
+            pipeline_stages: list of pipeline stage programs.
+            global_invars: input variables.
+            grad_dummy_invars: vars for gradient accumulation.
+            global_outvars: output variables.
+            physical_meshes: the cluster meshes to pipeline over.
+            dependency: dependency between stages as an adjacency matrix.
+            schedule: schedule to follow to execute the pipeline.
+            is_batch: indicators of the batch variables.
+            num_batch: number of microbatches.
         """
         super().__init__(pipeline_stages=pipeline_stages,
                          global_invars=global_invars,
@@ -114,7 +119,6 @@ class BaseDistributedRuntime(BaseRuntime):
             [{} for _ in range(self.num_mesh)] for _ in range(self.num_mesh)
         ]
 
-        # TODO(Hao): this establish_nccl_groups needs to be improved to cover allgather.
         self._establish_nccl_groups()
 
         start_time = time.time()
@@ -165,7 +169,6 @@ class BaseDistributedRuntime(BaseRuntime):
 
         We establish one collective group between two physical meshes, covering all the devices in
         these two meshes that require NCCL communication.
-        TODO(Hao): we might need to improve this part later for adding scatter-gather optimization.
 
         Returns:
             device_str_groups (List[List[set]]): a num_mesh x num_mesh matrix. Only entries at

--- a/alpa/pipeline_parallel/base_runtime.py
+++ b/alpa/pipeline_parallel/base_runtime.py
@@ -10,12 +10,12 @@ import numpy as np
 import ray
 from alpa.global_env import global_config
 from alpa.util import OrderedSet
-from alpa.pipeline_parallel.cross_mesh_resharding import (CrossMeshCommunicator,
-    SymbolicReshardingTask, SymbolicBroadcastReshardingTask)
+from alpa.pipeline_parallel.cross_mesh_resharding import (
+    CrossMeshCommunicator, SymbolicReshardingTask, SymbolicBroadcastReshardingTask)
 from alpa.pipeline_parallel.schedules import PipelineSchedule
 from alpa.pipeline_parallel.device_mesh_group import DistributedPhysicalDeviceMeshGroup
 from alpa.pipeline_parallel.computation import (PipelineComputation,
-    XlaShardedPipelineComputation)
+                                                XlaShardedPipelineComputation)
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -63,7 +63,7 @@ class BaseRuntime(metaclass=ABCMeta):
         raise NotImplementedError()
 
     @abstractmethod
-    def run(self, *args, **kwargs):
+    def run(self, *args):
         """Run function."""
         raise NotImplementedError()
 
@@ -127,7 +127,7 @@ class BaseDistributedRuntime(BaseRuntime):
         logger.debug(
             f"Compile resharding tasks takes {end_time - start_time:.2f}")
 
-    def run(self, *args, **kwargs):
+    def run(self, *args):
         """The runtime invocation interface."""
         raise NotImplementedError()
 

--- a/alpa/pipeline_parallel/centralized_distributerd_runtime.py
+++ b/alpa/pipeline_parallel/centralized_distributerd_runtime.py
@@ -147,11 +147,9 @@ class CentralizedDistributedRuntime(BaseDistributedRuntime):  # pylint: disable=
                 key = (0, repr(var))
                 self._initial_var_reference_count[key] += 1
 
-    def run(self, *args, **kwargs):
+    def run(self, *args):
         """Run the training with pipelining."""
         # pylint: disable=too-many-locals
-        assert not kwargs, "kwargs not supported"
-
         timers("overall").start(sync_func=self.sync)
 
         # timers("overall").start()

--- a/alpa/pipeline_parallel/decentralized_distributed_runtime.py
+++ b/alpa/pipeline_parallel/decentralized_distributed_runtime.py
@@ -438,7 +438,7 @@ class DecentralizedDistributedRuntime(BaseDistributedRuntime):
 
         # Insert buffer free instructions
         accumulated_uuid_lists = {}
-        for worker in instruction_lists.keys():
+        for worker in instruction_lists: # pylint: disable=umodified-iterating-dict
             used_outside = flatten_uuid_set(self.output_local_uuid_list[worker])
             mesh_idx, worker_idx = worker_to_idx[worker]
             accumulated_uuids = grad_uuids[mesh_idx]
@@ -702,8 +702,6 @@ class DecentralizedDistributedRuntime(BaseDistributedRuntime):
             key = keys[var_idx]
             _get_dict(var_at, key)[mesh_idx] = transposed[var_idx]
         return output_uuids
-
-
 
     # TODO(yonghao): set empty buffer is not compatiable with local allgather
     @staticmethod

--- a/alpa/pipeline_parallel/decentralized_distributed_runtime.py
+++ b/alpa/pipeline_parallel/decentralized_distributed_runtime.py
@@ -451,7 +451,7 @@ class DecentralizedDistributedRuntime(BaseDistributedRuntime):
             donated = set(donation_mapping[mesh_idx].keys())
             used_outside.update(flatten_uuid_set(accumulated_uuids))
             accumulated_uuid_lists[worker] = accumulated_uuids
-            # pylint: disable=umodified-iterating-dict
+            # pylint: disable=modified-iterating-dict
             instruction_lists[worker] = self._compile_free(
                 worker, used_outside, donated, instruction_lists)
 

--- a/alpa/pipeline_parallel/decentralized_distributed_runtime.py
+++ b/alpa/pipeline_parallel/decentralized_distributed_runtime.py
@@ -438,7 +438,7 @@ class DecentralizedDistributedRuntime(BaseDistributedRuntime):
 
         # Insert buffer free instructions
         accumulated_uuid_lists = {}
-        for worker in instruction_lists: # pylint: disable=umodified-iterating-dict
+        for worker in instruction_lists:
             used_outside = flatten_uuid_set(self.output_local_uuid_list[worker])
             mesh_idx, worker_idx = worker_to_idx[worker]
             accumulated_uuids = grad_uuids[mesh_idx]
@@ -451,6 +451,7 @@ class DecentralizedDistributedRuntime(BaseDistributedRuntime):
             donated = set(donation_mapping[mesh_idx].keys())
             used_outside.update(flatten_uuid_set(accumulated_uuids))
             accumulated_uuid_lists[worker] = accumulated_uuids
+            # pylint: disable=umodified-iterating-dict
             instruction_lists[worker] = self._compile_free(
                 worker, used_outside, donated, instruction_lists)
 

--- a/alpa/pipeline_parallel/decentralized_distributed_runtime.py
+++ b/alpa/pipeline_parallel/decentralized_distributed_runtime.py
@@ -1119,17 +1119,12 @@ class PipelineMeshWorkerExecutable:
         # Buffer management
         self.worker = worker
         self.global_buffers = worker.buffers
-
-        self.global_executables = worker.executables
-        self.global_send_tasks = worker.send_tasks
-        self.global_recv_tasks = worker.recv_tasks
-
-        # Related executables
-        self._related_exec_uuids = []
-
         self.acc_grad_buffers = {}
         self.acc_in_uuids = [list(uuids) for uuids in list(acc_local_uuids)]
         self.acc_out_uuids = acc_out_uuids
+
+        # Executable management
+        self._related_exec_uuids = []
         self.partial_grad_exec_uuids = OrderedSet()
         self.use_memzero = False
 

--- a/alpa/pipeline_parallel/local_pipeline_parallel.py
+++ b/alpa/pipeline_parallel/local_pipeline_parallel.py
@@ -97,9 +97,8 @@ class LocalRuntime(BaseRuntime):
                 self.hlo_texts_after_spmd_partitioner.append(
                     hlo_module.to_string())
 
-    def run(self, *args, **kwargs):
+    def run(self, *args):
         """Run function."""
-        assert not kwargs, "kwargs not supported"
         global_invals = dict(zip(self.global_invars, args))
         runners = {}
 

--- a/alpa/pipeline_parallel/pipeshard_parallel.py
+++ b/alpa/pipeline_parallel/pipeshard_parallel.py
@@ -193,8 +193,8 @@ def pipeshard_parallel_callable(fun: lu.WrappedFun, in_tree, out_tree_thunk,
                                          num_batch=num_micro_batches,
                                          flop_count=total_flops)
 
-    def ret_func(*args, **kwargs):
-        return jp.run(*args, **kwargs)
+    def ret_func(*args):
+        return jp.run(*args)
 
     ret_func.get_executable = lambda: jp
     return ret_func  # pylint: disable=unnecessary-lambda

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,7 +1,7 @@
 # Unit test
 
 ## Requirement
-A machine with at least 4 gpus
+A machine with at least 4 gpus.
 
 ## Run all test cases
 
@@ -9,12 +9,20 @@ A machine with at least 4 gpus
 ```
 ray start --head
 ```
+
 2. Run all tests
 ```
 python3 run_all.py
 ```
 
 ## Run a specific file
+
+- For debug usage:
 ```
 python3 test_auto_sharding_basic.py
+```
+
+- More similar to how CI runs a file
+```
+python3 run_all.py --filter test_auto_sharding_basic.py
 ```

--- a/tests/test_cross_mesh_resharding.py
+++ b/tests/test_cross_mesh_resharding.py
@@ -143,10 +143,12 @@ def test_resharding(var,
     # timers("overall_resharding_time").start()
     for worker_idx, worker in enumerate(src_mesh.workers):
         worker.run_executable.remote(exec_uuids[worker],
-                                    [input_uuids[worker_idx]], [])
+                                    [input_uuids[worker_idx]], [],
+                                    sync_for_timer=True)
     for worker_idx, worker in enumerate(dst_mesh.workers):
         worker.run_executable.remote(exec_uuids[worker], [],
-                                    [output_uuids[worker_idx]])
+                                    [output_uuids[worker_idx]],
+                                    sync_for_timer=True)
     output_array = DistributedArray(dst_mesh, var.aval, dst_sharding_spec,
                                     output_refs)
     # dst_mesh.sync_workers()


### PR DESCRIPTION
No functional change.

- do not use `self.xxx` to pass arguments or return values when unnecessary.
- remove unnecessary `list(x)` around np arrays
- fix wrong or outdated comments
