### PR TITLE
Fix support for shape-only input

### DIFF
--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -1163,7 +1163,8 @@ class DistributedPhysicalDeviceMesh(PhysicalDeviceMesh):
 
             if is_batch_var:
                 slow_path = True
-                arg = np.asarray(arg)
+                if not isinstance(arg, ShapedArray):
+                    arg = np.asarray(arg)
                 bufs = _shard_array(arg, self, indices, num_micro_batches)
                 bufs = np.array(bufs).reshape(self.num_hosts, self.num_devices_per_host,
                                               num_micro_batches)

--- a/alpa/mesh_executable.py
+++ b/alpa/mesh_executable.py
@@ -984,7 +984,7 @@ class PartialGradAccMeshWorkerExecutable(NormalMeshWorkerExecutable):
         return super().execute_on_worker(input_uuids, output_uuids,
                                          sync_before, sync_after)
 
-    def profile_with_dummy_inputs(self, backend, local_devices, skip_grad_sync):
+    def profile_with_dummy_inputs(self, backend, local_devices, skip_grad_sync=False):
         """Profile the time cost of this executable with dummy inputs."""
         os.environ[self.skip_allreduce_env_name] = (self.grad_sync_channel_ids
                                                     if skip_grad_sync else "")


### PR DESCRIPTION
Probably missing unit test for shape-only input when benchmark mode is on.