### PR TITLE
Allow using CUDA_HOME setting in xla_custom_call_marker build

### DIFF
--- a/alpa/pipeline_parallel/xla_custom_call_marker/build.sh
+++ b/alpa/pipeline_parallel/xla_custom_call_marker/build.sh
@@ -1,6 +1,8 @@
 mkdir -p build
 cd build
 cmake .. -DPYTHON_EXECUTABLE=$(which python3) -Dpybind11_ROOT=$(pybind11-config --cmakedir)
-export PATH=/usr/local/cuda/bin:$PATH
-export CPATH=/usr/local/cuda/targets/x86_64-linux/include/:$CPATH
+# Set `CUDA_HOME` to /usr/local/cuda only if it's not already set
+export CUDA_HOME="${CUDA_HOME:=/usr/local/cuda}"
+export PATH=$CUDA_HOME/bin:$PATH
+export CPATH=$CUDA_HOME/targets/x86_64-linux/include/:$CPATH
 make


### PR DESCRIPTION
This PR allows user to specify their CUDA install location for xla_custom_call_marker build.