### PR TITLE
[RUNTIME] Save normal jax model into tensorstore for distributed loading

### DIFF
--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -235,12 +235,34 @@ class MeshHostWorker:
         return self.executables[uuid].grad_sync_channel_ids
 
     ##### TensorStore Related Functions #####
+    def get_ts_spec(self, ckpt_path: str):
+        spec = {
+            'driver': 'zarr',
+            'kvstore': {},
+            'metadata_key': f".zarray{self.host_id}"
+        }
+        if ckpt_path.startswith('gs://'):
+            m = re.fullmatch('^gs://([^/]*)/(.*)$', ckpt_path, re.DOTALL)
+            if m is None:
+                raise ValueError(
+                    'The ckpt_path should contain the bucket name and the '
+                    f'file path inside the bucket. Got: {ckpt_path}')
+            gcs_bucket = m.group(1)
+            path_without_bucket = m.group(2)
+            spec['kvstore'] = {
+                'driver': 'gcs',
+                'bucket': gcs_bucket,
+                'path': path_without_bucket
+            }
+        else:
+            spec['kvstore'] = {'driver': 'file', 'path': ckpt_path}
+        return spec
+
     def load_buffers_from_ts(self, ckpt_dir: str, uuids: Sequence[int],
                              shard_indices: Sequence[Index],
                              device_ids: Sequence[int]):
         assert len(uuids) > 0
-        from alpa.serialization import get_ts_spec
-        ts_spec = get_ts_spec(ckpt_dir)
+        ts_spec = self.get_ts_spec(ckpt_dir)
         t = ts.open(ts.Spec(ts_spec), open=True).result()
 
         for index, uuid, device_id in zip(shard_indices, uuids, device_ids):
@@ -254,8 +276,7 @@ class MeshHostWorker:
         for uuid in uuids:
             assert uuid in self.buffers
 
-        from alpa.serialization import get_ts_spec
-        ts_spec = get_ts_spec(ckpt_dir)
+        ts_spec = self.get_ts_spec(ckpt_dir)
         dtype = self.buffers[uuids[0]].dtype
         if dtype == jnp.bfloat16:
             # Tensorstore uses 'bfloat16', not '<V2'.

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -235,34 +235,12 @@ class MeshHostWorker:
         return self.executables[uuid].grad_sync_channel_ids
 
     ##### TensorStore Related Functions #####
-    def get_ts_spec(self, ckpt_path: str):
-        spec = {
-            'driver': 'zarr',
-            'kvstore': {},
-            'metadata_key': f".zarray{self.host_id}"
-        }
-        if ckpt_path.startswith('gs://'):
-            m = re.fullmatch('^gs://([^/]*)/(.*)$', ckpt_path, re.DOTALL)
-            if m is None:
-                raise ValueError(
-                    'The ckpt_path should contain the bucket name and the '
-                    f'file path inside the bucket. Got: {ckpt_path}')
-            gcs_bucket = m.group(1)
-            path_without_bucket = m.group(2)
-            spec['kvstore'] = {
-                'driver': 'gcs',
-                'bucket': gcs_bucket,
-                'path': path_without_bucket
-            }
-        else:
-            spec['kvstore'] = {'driver': 'file', 'path': ckpt_path}
-        return spec
-
     def load_buffers_from_ts(self, ckpt_dir: str, uuids: Sequence[int],
                              shard_indices: Sequence[Index],
                              device_ids: Sequence[int]):
         assert len(uuids) > 0
-        ts_spec = self.get_ts_spec(ckpt_dir)
+        from alpa.serialization import get_ts_spec
+        ts_spec = get_ts_spec(ckpt_dir)
         t = ts.open(ts.Spec(ts_spec), open=True).result()
 
         for index, uuid, device_id in zip(shard_indices, uuids, device_ids):
@@ -276,7 +254,8 @@ class MeshHostWorker:
         for uuid in uuids:
             assert uuid in self.buffers
 
-        ts_spec = self.get_ts_spec(ckpt_dir)
+        from alpa.serialization import get_ts_spec
+        ts_spec = get_ts_spec(ckpt_dir)
         dtype = self.buffers[uuids[0]].dtype
         if dtype == jnp.bfloat16:
             # Tensorstore uses 'bfloat16', not '<V2'.

--- a/alpa/serialization.py
+++ b/alpa/serialization.py
@@ -83,11 +83,12 @@ def _msgpack_ext_unpack(code, data):
         return msgpack.unpackb(data)
     return msgpack.ExtType(code, data)
 
+
 def get_ts_spec(ckpt_path: str):
     spec = {
         'driver': 'zarr',
         'kvstore': {},
-        'metadata_key': f".zarray0"
+        'metadata_key': ".zarray0"
     }
     if ckpt_path.startswith('gs://'):
         m = re.fullmatch('^gs://([^/]*)/(.*)$', ckpt_path, re.DOTALL)
@@ -105,6 +106,7 @@ def get_ts_spec(ckpt_path: str):
     else:
         spec['kvstore'] = {'driver': 'file', 'path': ckpt_path}
     return spec
+
 
 def ts_store(ckpt_dir, data: Union[np.ndarray, jax.xla.DeviceArray]):
     ts_spec = get_ts_spec(ckpt_dir)
@@ -131,6 +133,7 @@ def ts_store(ckpt_dir, data: Union[np.ndarray, jax.xla.DeviceArray]):
                 }})).result()
 
     t.write(data).result()
+
 
 def save_checkpoint(ckpt_dir: Union[str, os.PathLike], target: PyTree,
                     step: int):

--- a/alpa/serialization.py
+++ b/alpa/serialization.py
@@ -5,6 +5,7 @@ Add support for DistributedArray and ReplicatedDistributedArray serialization in
 
 import enum
 import os
+import re
 from typing import Union, Any, Sequence
 import uuid
 
@@ -12,9 +13,11 @@ from flax.serialization import to_state_dict, from_state_dict, _ndarray_from_byt
 import jax
 from jax.interpreters.pxla import ShardingSpec
 from jax.core import ShapedArray
+import jax.numpy as jnp
 from jax._src.tree_util import tree_flatten, tree_leaves, tree_unflatten
 import msgpack
 import numpy as np
+import tensorstore as ts
 
 from alpa.device_mesh import DistributedArray, ReplicatedDistributedArray, PhysicalDeviceMesh
 
@@ -32,11 +35,16 @@ class _MsgpackExtType(enum.IntEnum):
 
 def _msgpack_ext_pack_wrapper(ckpt_dir):
 
+    def _get_save_path():
+        return os.path.join(ckpt_dir, uuid.uuid4().hex)
+
     def _msgpack_ext_pack(x):
         """Messagepack encoders for custom types."""
         if isinstance(x, (np.ndarray, jax.xla.DeviceArray)):
+            save_dir = _get_save_path()
+            ts_store(save_dir, x)
             return msgpack.ExtType(_MsgpackExtType.ndarray,
-                                   _ndarray_to_bytes(x))
+                                   msgpack.packb(save_dir))
         if np.issctype(type(x)):
             # pack scalar as ndarray
             return msgpack.ExtType(_MsgpackExtType.npscalar,
@@ -45,12 +53,12 @@ def _msgpack_ext_pack_wrapper(ckpt_dir):
             return msgpack.ExtType(_MsgpackExtType.native_complex,
                                    msgpack.packb((x.real, x.imag)))
         elif isinstance(x, DistributedArray):
-            save_dir = os.path.join(ckpt_dir, uuid.uuid4().hex)
+            save_dir = _get_save_path()
             x.save(save_dir)
             return msgpack.ExtType(_MsgpackExtType.distarray,
                                    msgpack.packb(save_dir))
         elif isinstance(x, ReplicatedDistributedArray):
-            save_dir = os.path.join(ckpt_dir, uuid.uuid4().hex)
+            save_dir = _get_save_path()
             x.replica.save(save_dir)
             return msgpack.ExtType(_MsgpackExtType.replicated_distarray,
                                    msgpack.packb(save_dir))
@@ -62,7 +70,7 @@ def _msgpack_ext_pack_wrapper(ckpt_dir):
 def _msgpack_ext_unpack(code, data):
     """Messagepack decoders for custom types."""
     if code == _MsgpackExtType.ndarray:
-        return _ndarray_from_bytes(data)
+        return msgpack.unpackb(data)
     elif code == _MsgpackExtType.native_complex:
         complex_tuple = msgpack.unpackb(data)
         return complex(complex_tuple[0], complex_tuple[1])
@@ -75,6 +83,54 @@ def _msgpack_ext_unpack(code, data):
         return msgpack.unpackb(data)
     return msgpack.ExtType(code, data)
 
+def get_ts_spec(ckpt_path: str):
+    spec = {
+        'driver': 'zarr',
+        'kvstore': {},
+        'metadata_key': f".zarray0"
+    }
+    if ckpt_path.startswith('gs://'):
+        m = re.fullmatch('^gs://([^/]*)/(.*)$', ckpt_path, re.DOTALL)
+        if m is None:
+            raise ValueError(
+                'The ckpt_path should contain the bucket name and the '
+                f'file path inside the bucket. Got: {ckpt_path}')
+        gcs_bucket = m.group(1)
+        path_without_bucket = m.group(2)
+        spec['kvstore'] = {
+            'driver': 'gcs',
+            'bucket': gcs_bucket,
+            'path': path_without_bucket
+        }
+    else:
+        spec['kvstore'] = {'driver': 'file', 'path': ckpt_path}
+    return spec
+
+def ts_store(ckpt_dir, data: Union[np.ndarray, jax.xla.DeviceArray]):
+    ts_spec = get_ts_spec(ckpt_dir)
+    dtype = data.dtype
+    if dtype == jnp.bfloat16:
+        # Tensorstore uses 'bfloat16', not '<V2'.
+        dtype = 'bfloat16'
+    else:
+        dtype = np.dtype(dtype).str
+    metadata = {
+        'compressor': {
+            'id': 'gzip'
+        },
+        'shape': data.shape,
+        'chunks': data.shape,
+        'dtype': dtype,
+    }
+    ts_spec['metadata'] = metadata
+    t = ts.open(ts.Spec(ts_spec),
+                create=True,
+                open=True,
+                context=ts.Context({'file_io_concurrency': {
+                    'limit': 128
+                }})).result()
+
+    t.write(data).result()
 
 def save_checkpoint(ckpt_dir: Union[str, os.PathLike], target: PyTree,
                     step: int):

--- a/alpa/serialization.py
+++ b/alpa/serialization.py
@@ -140,8 +140,9 @@ def save_checkpoint(ckpt_dir: Union[str, os.PathLike], target: PyTree,
     """Save a checkpoint of the `target` to `path`. 
 
         Similar to flax.training.checkpoints.save_checkpoint, but support DistributedArrays 
-        and ReplicatedDistributedArray in alpa.
-        # TODO: copy all the safe-saving stuff from 
+        and ReplicatedDistributedArray in alpa. Also it will save np.ndarray and jax.xla.DeviceArray
+        into tensorstore for later distributed loading.
+        # TODO (zhongyinmin): copy all the safe-saving stuff from 
         https://flax.readthedocs.io/en/latest/_modules/flax/training/checkpoints.html#save_checkpoint
 
         Args:
@@ -193,7 +194,7 @@ def restore_checkpoint(ckpt_dir: Union[str, os.PathLike], step: int, target: PyT
 
         Similar to flax.training.checkpoints.load_checkpoint, 
         but support DistributedArrays and ReplicatedDistributedArray in alpa.
-        # TODO: copy all the safe-loading stuff from 
+        # TODO (zhongyinmin): copy all the safe-loading stuff from 
         https://flax.readthedocs.io/en/latest/_modules/flax/training/checkpoints.html#restore_checkpoint
 
         Args:


### PR DESCRIPTION
Current restore_checkpoint only supports loading from tensorstore. In order to load the 175B OPT model, we should save the model's ndarray version into tensorstore first. I modified `serialization.py` so that now `save_checkpoint` will automatically save ndarray into tensorstore.