### PR TITLE
[FIX] skip load if var is not used

### DIFF
--- a/alpa/pipeline_parallel/pipeshard_executable.py
+++ b/alpa/pipeline_parallel/pipeshard_executable.py
@@ -1158,20 +1158,19 @@ class PipeshardDriverExecutable:
     def get_load_info(self):
         assert self.in_tree is not None
 
-        # build load_info_map: flatten global index => LoadInfo object
-        load_info_map = {}
+        # build load_info_arr: flatten global index => LoadInfo object
+        load_info_arr = [None] * len(self.is_batch)
         for mesh_idx, physical_mesh in enumerate(self.mesh_group):
             for local_idx, global_idx in enumerate(self.mesh_arg_indices[mesh_idx]):
                 aval, mesh, spec = (self.global_invars[global_idx].aval, 
                                     physical_mesh, 
                                     self.input_shard_specs[mesh_idx][local_idx])
-                if load_info_map.get(global_idx) is None:
-                    load_info_map[global_idx] = LoadInfo([aval], [mesh], [spec])
+                if load_info_arr[global_idx] is None:
+                    load_info_arr[global_idx] = LoadInfo([aval], [mesh], [spec])
                 else:
-                    load_info_map[global_idx].add_replica(aval, mesh, spec)
+                    load_info_arr[global_idx].add_replica(aval, mesh, spec)
 
         # build load_info_arr
-        load_info_arr = [load_info_map[i] for i in range(len(self.is_batch))]
         return tree_unflatten(self.in_tree, load_info_arr)
 
     ##### Profiling and Debugging Related Functions #####

--- a/alpa/serialization.py
+++ b/alpa/serialization.py
@@ -4,6 +4,7 @@ Add support for DistributedArray and ReplicatedDistributedArray serialization in
 """
 
 import enum
+import logging
 import os
 from typing import Union, Any, Sequence
 import uuid
@@ -19,6 +20,9 @@ import numpy as np
 from alpa.device_mesh import DistributedArray, ReplicatedDistributedArray, PhysicalDeviceMesh
 
 PyTree = Any
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 
 class _MsgpackExtType(enum.IntEnum):
@@ -153,6 +157,9 @@ def restore_checkpoint(ckpt_dir: Union[str, os.PathLike], step: int, target: PyT
     flat_info = tree_leaves(load_info)
     flat_load_state = []
     for path, info in zip(state_paths, flat_info):
+        if info is None:
+            logger.warning("Variable is not used, skip loading it")
+            flat_load_state.append(None)
         if info.is_replicated():
             meshes, arrays = [], []
             for aval, mesh, spec in info.get_info():

--- a/tests/test_pipeline_mlp.py
+++ b/tests/test_pipeline_mlp.py
@@ -55,6 +55,8 @@ class PipelineMLPTest(unittest.TestCase):
         gradients = train_step(state, batch)
         p_train_step = parallelize(train_step, donate_argnums=(), method=method)
         gradients_with_pipeline = p_train_step(state, batch)
+        if isinstance(method, PipeshardParallel):
+            p_train_step.get_executable(state, batch).get_load_info()
 
         # Check results
         assert_allclose(gradients, gradients_with_pipeline)


### PR DESCRIPTION
A KeyError is raised when an input arg is never used. This is because load cannot find its corresponding sharding spec. This PR returns None and log a warning in case of that.