### PR TITLE
Add shard_and_apply_func_on_buffer for remote weight initialization on worker

### DIFF
--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -24,7 +24,7 @@ import os
 import re
 import threading
 import time
-from typing import Any, List, Union, Sequence, Tuple, Optional
+from typing import Any, List, Union, Sequence, Tuple, Optional, Callable
 
 import jax
 from jax import core, xla, device_put
@@ -177,6 +177,24 @@ class MeshHostWorker:
                     dim_size = len(range(*filled_slice))
                     shard_shape.append(dim_size)
                 self.put_non_zero_buffer(uuids[idx], i, shard_shape, dtype)
+
+    def shard_and_apply_func_on_buffer(self,
+                                       uuids: Sequence[int],
+                                       shape: Sequence[int],
+                                       dtype: np.dtype,
+                                       indices: Sequence,
+                                       num_batch: int,
+                                       apply_func: Callable[["MeshHostWorker", int, int, Sequence[int], np.dtype], None]):
+        assert len(uuids) == len(indices) == len(self.local_devices) * num_batch
+        for i in range(len(self.local_devices)):
+            for b in range(num_batch):
+                shard_shape = []
+                idx = i * num_batch + b
+                for j, s in enumerate(indices[idx]):
+                    filled_slice = s.indices(shape[j])
+                    dim_size = len(range(*filled_slice))
+                    shard_shape.append(dim_size)
+                apply_func(self, uuids[idx], i, shard_shape, dtype)
 
     def get_buffers(self, uuids: Union[Sequence[int], int]):
         if isinstance(uuids, Iterable):

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -184,7 +184,9 @@ class MeshHostWorker:
                                        dtype: np.dtype,
                                        indices: Sequence,
                                        num_batch: int,
-                                       apply_func: Callable[["MeshHostWorker", int, int, Sequence[int], np.dtype], None]):
+                                       apply_func: Callable[
+                                           ["MeshHostWorker", int, int, Sequence[int], np.dtype], None
+                                       ]):
         assert len(uuids) == len(indices) == len(self.local_devices) * num_batch
         for i in range(len(self.local_devices)):
             for b in range(num_batch):


### PR DESCRIPTION
With `shard_and_apply_func_on_buffer`, we can support remote weight initialization directly on the workers.

Example `apply_func` that's passed into `shard_and_apply_func_on_buffer` looks like:
```python
def init_buffer(init_func,
                init_func_kwargs,
                local_rng_seed,
                worker,
                uuid: int,
                device_id: int,
                shape: Sequence[int],
                dtype=np.dtype(np.float32)):

    torch_local_rng = torch.Generator()
    torch_local_rng.manual_seed(local_rng_seed)
    init_func_kwargs["rng"] = torch_local_rng
    init_func_kwargs["shape"] = shape
    init_func_kwargs["dtype"] = numpy_to_torch_dtype_dict[dtype]

    worker.buffers[uuid] = (worker.backend.buffer_from_pyval(
        init_func(**init_func_kwargs), worker.local_devices[device_id]))
```
and is called with
```python
device_mesh.workers[host_id].shard_and_apply_func_on_buffer.remote(
    buf_uuids[host_id * step:(host_id + 1) * step],
    array._value.shape,
    array._value.dtype,
    indices[host_id * step:(host_id + 1) * step],
    num_batch,
    functools.partial(init_buffer, init_func, kwargs, local_rng_seed)
)
```

Compared to previous design, this version moves the `init_buffer` logic out of the `alpa/device_mesh.py` file (into a `alpa/torch/...` file, not shown in this PR). This way, we keep the functions in `alpa/device_mesh.py` as generic as possible, and keep the torch-specific logic in torch folder.

This supersedes https://github.com/alpa-projects/alpa/pull/454. Could be a good short-term solution before https://github.com/alpa-projects/alpa/issues/439 is ready.