### PR TITLE
[API] Simplify manual pipeline API

### DIFF
--- a/alpa/__init__.py
+++ b/alpa/__init__.py
@@ -9,7 +9,7 @@ from alpa.device_mesh import (DeviceCluster, PhysicalDeviceMesh,
 from alpa.global_env import global_config
 from alpa.mesh_profiling import ProfilingResultDatabase
 from alpa.parallel_method import ShardParallel, PipeshardParallel, ManualPipeshardParallel
-from alpa.pipeline_parallel.primitive_def import mark_pipeline
+from alpa.pipeline_parallel.primitive_def import mark_pipeline_boundary
 from alpa.pipeline_parallel.layer_construction import (
     manual_remat, automatic_remat, automatic_layer_construction,
     manual_layer_construction)

--- a/alpa/model/bert_model.py
+++ b/alpa/model/bert_model.py
@@ -39,7 +39,7 @@ class BertConfig:
                  use_cache=True,
                  tie_word_embeddings=True,
                  add_manual_pipeline_markers=False,
-                 pipeline_mp_size=None,
+                 pipeline_mp_size=0,
                  **kwargs):
         self.vocab_size = vocab_size
         self.hidden_size = hidden_size
@@ -382,8 +382,6 @@ class FlaxBertLayerCollection(nn.Module):
                                       dtype=self.dtype)
             for i in range(self.config.num_hidden_layers)
         ]
-
-
 
     def __call__(
         self,

--- a/alpa/model/bert_model.py
+++ b/alpa/model/bert_model.py
@@ -15,8 +15,8 @@ from alpa.model.model_util import (FlaxBaseModelOutput,
                                    FlaxBaseModelOutputWithPooling,
                                    FlaxBertForPreTrainingOutput,
                                    FlaxMaskedLMOutput, TrainState)
-from alpa import mark_pipeline
 from alpa.model.model_util import TrainState
+from alpa.pipeline_parallel.primitive_def import mark_pipeline_boundary
 
 
 class BertConfig:
@@ -39,7 +39,7 @@ class BertConfig:
                  use_cache=True,
                  tie_word_embeddings=True,
                  add_manual_pipeline_markers=False,
-                 pipeline_mp_size=0,
+                 pipeline_mp_size=None,
                  **kwargs):
         self.vocab_size = vocab_size
         self.hidden_size = hidden_size
@@ -383,15 +383,7 @@ class FlaxBertLayerCollection(nn.Module):
             for i in range(self.config.num_hidden_layers)
         ]
 
-        num_layers = self.config.num_hidden_layers
-        pipeline_mp_size = self.config.pipeline_mp_size
-        self.pipeline_marker_positions = []
-        if self.config.add_manual_pipeline_markers:
-            num_layer_per_stage, remained = divmod(num_layers, pipeline_mp_size)
-            assert remained == 0
-            self.pipeline_marker_positions = [
-                num_layer_per_stage * i for i in range(1, pipeline_mp_size)
-            ]
+
 
     def __call__(
         self,
@@ -405,15 +397,7 @@ class FlaxBertLayerCollection(nn.Module):
         all_attentions = () if output_attentions else None
         all_hidden_states = () if output_hidden_states else None
 
-        id = 0
         for i, layer in enumerate(self.layers):
-            if self.config.add_manual_pipeline_markers:
-                if (id < len(self.pipeline_marker_positions) and
-                        i == self.pipeline_marker_positions[id]):
-                    mark_pipeline(name=str(id), mark_type="end")
-                    mark_pipeline(name=str(id + 1), mark_type="start")
-                    id = id + 1
-
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
 
@@ -425,6 +409,12 @@ class FlaxBertLayerCollection(nn.Module):
 
             if output_attentions:
                 all_attentions += (layer_outputs[1],)
+
+            if self.config.add_manual_pipeline_markers:
+                layers_per_stage = self.config.num_hidden_layers // self.config.pipeline_mp_size
+                assert self.config.num_hidden_layers % self.config.pipeline_mp_size == 0
+                if i % layers_per_stage == layers_per_stage - 1 and i != len(self.layers) - 1:
+                    mark_pipeline_boundary()
 
         if output_hidden_states:
             all_hidden_states += (hidden_states,)

--- a/alpa/model/moe.py
+++ b/alpa/model/moe.py
@@ -16,7 +16,6 @@ from jax import lax
 import jax.numpy as jnp
 from jax.nn import one_hot
 
-from alpa import mark_pipeline
 from alpa.model.bert_model import (FlaxBaseModelOutput,
                                    FlaxBaseModelOutputWithPooling,
                                    FlaxBertAttention, FlaxBertEmbeddings,

--- a/alpa/model/moe.py
+++ b/alpa/model/moe.py
@@ -22,6 +22,7 @@ from alpa.model.bert_model import (FlaxBaseModelOutput,
                                    FlaxBertIntermediate, FlaxBertLayer,
                                    FlaxBertOutput, FlaxMaskedLMOutput)
 from alpa.model.model_util import TrainState
+from alpa.pipeline_parallel.primitive_def import mark_pipeline_boundary
 
 
 class MoEConfig:
@@ -253,16 +254,6 @@ class FlaxMoELayerCollection(nn.Module):
                                               dtype=self.dtype))
         self.layers = layers
 
-        num_layers = self.config.num_hidden_layers
-        pipeline_mp_size = self.config.pipeline_mp_size
-        self.pipeline_marker_positions = []
-        if self.config.add_manual_pipeline_markers:
-            num_layer_per_stage, remained = divmod(num_layers, pipeline_mp_size)
-            assert remained == 0
-            self.pipeline_marker_positions = [
-                num_layer_per_stage * i for i in range(1, pipeline_mp_size)
-            ]
-
     def __call__(
         self,
         hidden_states,
@@ -275,14 +266,7 @@ class FlaxMoELayerCollection(nn.Module):
         all_attentions = () if output_attentions else None
         all_hidden_states = () if output_hidden_states else None
 
-        id = 0
         for i, layer in enumerate(self.layers):
-            if self.config.add_manual_pipeline_markers:
-                if (id < len(self.pipeline_marker_positions) and
-                        i == self.pipeline_marker_positions[id]):
-                    mark_pipeline(name=str(id), mark_type="end")
-                    mark_pipeline(name=str(id + 1), mark_type="start")
-                    id = id + 1
 
             if output_hidden_states:
                 all_hidden_states += (hidden_states,)
@@ -296,6 +280,12 @@ class FlaxMoELayerCollection(nn.Module):
 
             if output_attentions:
                 all_attentions += (layer_outputs[1],)
+
+            if self.config.add_manual_pipeline_markers:
+                layers_per_stage = self.config.num_hidden_layers // self.config.pipeline_mp_size
+                assert self.config.num_hidden_layers % self.config.pipeline_mp_size == 0
+                if i % layers_per_stage == layers_per_stage - 1 and i != len(self.layers) - 1:
+                    mark_pipeline_boundary()
 
         if output_hidden_states:
             all_hidden_states += (hidden_states,)

--- a/alpa/pipeline_parallel/layer_construction.py
+++ b/alpa/pipeline_parallel/layer_construction.py
@@ -380,7 +380,7 @@ def layer_level_jaxpr_transformation(fn: Callable,
         if layer_construction:
             jaxpr = add_pipeline_marks_for_sliced_eqns(jaxpr, sliced_eqns)
         else:
-            jaxpr = clone_jaxpr(jaxpr, eqns=[x for x in eqns for eqns in sliced_eqns])
+            jaxpr = clone_jaxpr(jaxpr, eqns=[x for eqns in sliced_eqns for x in eqns])
 
         flatten_args, _ = tree_flatten(args)
         ans = jaxpr_as_fun(jaxpr)(*flatten_args)  # pylint: disable=not-callable

--- a/alpa/pipeline_parallel/layer_construction.py
+++ b/alpa/pipeline_parallel/layer_construction.py
@@ -29,74 +29,19 @@ DEFAULT_EPS = 0.6
 DEFAULT_COST_CRITERIA = "flops"
 
 
-def slice_eqns_by_pipeline_marks(closed_jaxpr: ClosedJaxpr):
-    """Slices eqns by pipeline markers."""
+def slice_eqns_by_layer_boundary(closed_jaxpr: ClosedJaxpr):
+    """Slices eqns by layer boundary markers."""
     sliced_eqns = []
-    current_computation_eqns = None
+    current_computation_eqns = []
 
     for eqn in closed_jaxpr.jaxpr.eqns:
-        if eqn.primitive is pipeline_p and eqn.params['mark_type'] == 'start':
-            assert current_computation_eqns is None, (
-                "Defining a pipeline computation inside a pipeline "
-                "computation is not allowed.")
-            current_computation_eqns = []
-        elif eqn.primitive is pipeline_p and eqn.params['mark_type'] == 'end':
-            assert current_computation_eqns is not None, (
-                "Ending a pipeline computation before its start.")
+        if eqn.primitive is pipeline_p and eqn.params['mark_type'] == 'boundary':
             sliced_eqns.append(current_computation_eqns)
-            current_computation_eqns = None
+            current_computation_eqns = []
         else:
-            assert current_computation_eqns is not None
             current_computation_eqns.append(eqn)
-    assert current_computation_eqns is None
+    sliced_eqns.append(current_computation_eqns)
     return sliced_eqns
-
-
-def lift_pipeline_marker(jaxpr: ClosedJaxpr):
-    """Lift the first/last marker if it is not the first/last eqn."""
-    marker_idx = np.nonzero([e.primitive is pipeline_p for e in jaxpr.eqns])[0]
-    assert marker_idx.size > 1
-    start_idx = marker_idx[0]
-    end_idx = marker_idx[-1]
-    new_eqns = ([jaxpr.eqns[start_idx]] + jaxpr.eqns[0:start_idx] +
-                jaxpr.eqns[start_idx + 1:end_idx] + jaxpr.eqns[end_idx + 1:] +
-                [jaxpr.eqns[end_idx]])
-    cnt = 0
-    for eqn in new_eqns:
-        if eqn.primitive is pipeline_p:
-            eqn.params["name"] = str(cnt)
-            if eqn.params["mark_type"] == "end":
-                cnt += 1
-    return clone_jaxpr(jaxpr, eqns=new_eqns)
-
-
-def transform_pipeline_forward(fn: Callable,
-                               transform_fn,
-                               static_argnums: Sequence[int] = (),
-                               lift_markers: bool = False):
-    """TODO(zhuohan):docstring."""
-
-    def get_sliced(*args):
-        origin_jaxpr, out_shape_tree = make_jaxpr(fn,
-                                                  static_argnums=static_argnums,
-                                                  return_shape=True)(*args)
-        if lift_markers:
-            origin_jaxpr = lift_pipeline_marker(origin_jaxpr)
-        sliced_eqns = slice_eqns_by_pipeline_marks(origin_jaxpr)
-        return origin_jaxpr, sliced_eqns, out_shape_tree
-
-    @wraps(fn)
-    def wrapped(*args):
-        origin_jaxpr, sliced_eqns, out_shape_tree = get_sliced(*args)
-        #log_layer_slicing_stats(origin_jaxpr, sliced_eqns)
-        new_jaxpr = transform_fn(origin_jaxpr, sliced_eqns)
-        flatten_args, _ = tree_flatten(args)
-        ans = jaxpr_as_fun(new_jaxpr)(*flatten_args)  # pylint: disable=not-callable
-        _, out_tree = tree_flatten(out_shape_tree)
-        return tree_unflatten(out_tree, ans)
-
-    wrapped.get_sliced = get_sliced
-    return wrapped
 
 
 def add_pipeline_marks_for_sliced_eqns(closed_jaxpr: ClosedJaxpr, sliced_eqns):
@@ -177,16 +122,15 @@ def add_pipeline_marks_for_sliced_eqns(closed_jaxpr: ClosedJaxpr, sliced_eqns):
     return new_closed_jaxpr
 
 
-def remat_jaxpr(origin_jaxpr, sliced_eqns, add_pipeline_marks):
-    """The input function should be marked by markers without input."""
+def remat_sliced_eqns(origin_jaxpr, sliced_eqns):
+    """Add tensor rematerialization for sliced equations."""
+    ret_eqns = []
+
     sliced_jaxprs = slices_to_jaxpr(origin_jaxpr, sliced_eqns)
-    new_eqns = []
     for i, jaxpr in enumerate(sliced_jaxprs):
-        if add_pipeline_marks:
-            new_eqns.append(mark_pipeline_jaxpreqn([], [], str(i), 'start'))
         new_invars = jaxpr.jaxpr.invars + jaxpr.jaxpr.constvars
         new_jaxpr = Jaxpr([], new_invars, jaxpr.jaxpr.outvars, jaxpr.jaxpr.eqns)
-        new_eqns.append(
+        ret_eqns.append([
             new_jaxpr_eqn(
                 new_invars, new_jaxpr.outvars, remat_call_p,
                 dict(concrete=False,
@@ -194,21 +138,8 @@ def remat_jaxpr(origin_jaxpr, sliced_eqns, add_pipeline_marks):
                      name=str(i),
                      call_jaxpr=new_jaxpr,
                      prevent_cse=True,
-                     policy=None)))
-        if add_pipeline_marks:
-            new_eqns.append(mark_pipeline_jaxpreqn([], [], str(i), 'end'))
-    new_closed_jaxpr = clone_jaxpr(origin_jaxpr, eqns=new_eqns)
-    return new_closed_jaxpr
-
-
-def insert_marker(origin_jaxpr, sliced_eqns):
-    """Inserts pipeline markers in jaxpr."""
-    new_eqns = []
-    for i, slices in enumerate(sliced_eqns):
-        new_eqns.append(mark_pipeline_jaxpreqn([], [], str(i), 'start'))
-        new_eqns.extend(slices)
-        new_eqns.append(mark_pipeline_jaxpreqn([], [], str(i), 'end'))
-    return clone_jaxpr(origin_jaxpr, eqns=new_eqns)
+                     policy=None))])
+    return ret_eqns
 
 
 def jaxpr_eqns_input_sizes(jaxpr) -> np.ndarray:
@@ -419,8 +350,7 @@ def layer_level_jaxpr_transformation(fn: Callable,
                                      layer_num: Union[int, str] = None,
                                      eps: float = DEFAULT_EPS,
                                      cost_criteria: str = DEFAULT_COST_CRITERIA,
-                                     layer_eps: float = 0.0,
-                                     lift_markers: bool = False):
+                                     layer_eps: float = 0.0):
     """TODO(zhuohan): docstring."""
     if not remat and not layer_construction:
         return fn
@@ -442,18 +372,15 @@ def layer_level_jaxpr_transformation(fn: Callable,
                                                    costs,
                                                    cost_criteria=cost_criteria)
         else:
-            if lift_markers:
-                jaxpr = lift_pipeline_marker(jaxpr)
-            sliced_eqns = slice_eqns_by_pipeline_marks(jaxpr)
-        #log_layer_slicing_stats(jaxpr, sliced_eqns)
+            sliced_eqns = slice_eqns_by_layer_boundary(jaxpr)
+
         if remat:
-            jaxpr = remat_jaxpr(jaxpr,
-                                sliced_eqns,
-                                add_pipeline_marks=layer_construction)
-            if layer_construction:
-                sliced_eqns = slice_eqns_by_pipeline_marks(jaxpr)
+            sliced_eqns = remat_sliced_eqns(jaxpr, sliced_eqns)
+
         if layer_construction:
             jaxpr = add_pipeline_marks_for_sliced_eqns(jaxpr, sliced_eqns)
+        else:
+            jaxpr = clone_jaxpr(jaxpr, eqns=[x for x in eqns for eqns in sliced_eqns])
 
         flatten_args, _ = tree_flatten(args)
         ans = jaxpr_as_fun(jaxpr)(*flatten_args)  # pylint: disable=not-callable
@@ -465,8 +392,7 @@ def layer_level_jaxpr_transformation(fn: Callable,
 
 def manual_remat(fun: Callable = None,
                  *,
-                 static_argnums: Sequence[int] = (),
-                 lift_markers: bool = False):
+                 static_argnums: Sequence[int] = ()):
     """Rematerialize an input function with manually selected layer boundaries.
 
     Rematerialize each layer of an input function with manually selected layer
@@ -476,10 +402,7 @@ def manual_remat(fun: Callable = None,
         fun: the input function to rematerialize.
         static_argnums: An optional int or collection of ints that specify
           which positional arguments to treat as static (compile-time constant).
-          Same as in jax.
-        lift_markers: move the first pipeline marker as the first jaxpr eqn and
-          move the last pipeline marker as the last jaxpr eqn.
-
+          Same as in jax.jit
     Returns:
         A new function rematerializes each layer of the input function.
     """
@@ -489,8 +412,7 @@ def manual_remat(fun: Callable = None,
                                                 static_argnums,
                                                 remat=True,
                                                 layer_construction=False,
-                                                auto_layer_boundary=False,
-                                                lift_markers=lift_markers)
+                                                auto_layer_boundary=False)
 
     if fun is None:
         return decorate_fun
@@ -515,12 +437,12 @@ def automatic_remat(fun: Callable = None,
         fun: The input function to rematerialize.
         static_argnums: An optional int or collection of ints that specify
           which positional arguments to treat as static (compile-time constant).
-          Same as in jax.
+          Same as in jax.jit
         layer_num: The number of layers to rematerialize. If set to "auto", the
           number of layers will be automatically determined by a binary search.
           The binary search might not work for complex input functions.
         eps: The tolerance of inbalance of the costs of different layers.
-        cost_criteria: The cost criteria to use for deciding the layers
+        cost_criteria: The cost criteria to use for deciding the layers.
         layer_eps: A parameter for layer_num binary search.
 
     Returns:
@@ -548,19 +470,18 @@ def automatic_remat(fun: Callable = None,
 def manual_layer_construction(fun: Callable = None,
                               *,
                               static_argnums: Sequence[int] = (),
-                              remat_layer: bool = False,
-                              lift_markers: bool = False):
+                              remat_layer: bool = False):
     """Setup manually selected layer boundaries.
+
     Add input variables of each layer to its start pipeline marker and output
     variables of each layer to its end pipeline marker.
+
     Args:
         fun: the input function.
         static_argnums: An optional int or collection of ints that specify
           which positional arguments to treat as static (compile-time constant).
-          Same as in jax.
+          Same as in jax.jit
         remat_layer: Whether to rematerialize each layer at layer boundaries.
-        lift_markers: Move the first pipeline marker as the first jaxpr eqn and
-          move the last pipeline marker as the last jaxpr eqn.
     Returns:
         A new function with correctly setup pipeline markers.
     """
@@ -570,8 +491,7 @@ def manual_layer_construction(fun: Callable = None,
                                                 static_argnums,
                                                 remat=remat_layer,
                                                 layer_construction=True,
-                                                auto_layer_boundary=False,
-                                                lift_markers=lift_markers)
+                                                auto_layer_boundary=False)
 
     if fun is None:
         return decorate_fun
@@ -595,13 +515,13 @@ def automatic_layer_construction(fun: Callable = None,
         fun: the input function.
         static_argnums: An optional int or collection of ints that specify
           which positional arguments to treat as static (compile-time constant).
-          Same as in jax.
+          Same as in jax.jit
         remat_layer: Whether to rematerialize each layer at layer boundaries.
         layer_num: the number of layers to rematerialize. If set to "auto", the
           number of layers will be automatically determined by a binary search.
           The binary search might not work for complex input functions.
         eps: the tolerance of inbalance of the costs of different layers.
-        cost_criteria: the cost criteria to use for deciding the layers
+        cost_criteria: the cost criteria to use for deciding the layers.
         layer_eps: a parameter for layer_num binary search.
     Returns:
         A new function rematerializes each layer of the input function.

--- a/alpa/pipeline_parallel/primitive_def.py
+++ b/alpa/pipeline_parallel/primitive_def.py
@@ -13,26 +13,25 @@ xc.register_custom_call_target(b'pipeline_marker',
                                platform='gpu')
 xc.register_custom_call_target(b'identity', identity(), platform='gpu')
 
+mark_pipeline = None
+
 ########## Public APIs ##########
 
 # Define a Jax primitive to mark start/end of a pipeline computation.
-pipeline_p = Primitive('pipeline')
+pipeline_p = Primitive('pipeline_marker')
 
 
-def mark_pipeline(*args, name: str, mark_type: str):
-    """
-    Mark the start/end of a pipeline computation.
+def mark_pipeline_boundary():
+    """Mark the boundary of pipeline layers. We reuse pipeline_marker for this functionality."""
+    return pipeline_p.bind(name="boundary", mark_type="boundary")
 
-    Args:
-        *args: represents the pipeline input/output of a pipeline computation.
-        name (str): Name of the pipeline computation.
-        mark_type (str): start or end of a pipeline computation, can be "start",
-            "end", "jvp_start", or "jvp_end". The latter two are used for
-            backward pass.
-    """
-    if mark_type not in ('start', 'end', 'jvp_start', 'jvp_end'):
-        raise ValueError(f'Unknown mark type: {mark_type}')
-    return pipeline_p.bind(*args, name=name, mark_type=mark_type)
+
+def mark_gradient(grad):
+    """Mark variables as gradients. We reuse pipeline_marker for this functionality."""
+    grad_flat, tree = tree_flatten(grad)
+    grad_flat = pipeline_p.bind(*grad_flat, name='grad', mark_type='grad')
+    grad = tree_unflatten(tree, grad_flat)
+    return grad
 
 
 def mark_pipeline_jaxpreqn(invars, outvars, name: str, mark_type: str):
@@ -45,14 +44,6 @@ def mark_pipeline_jaxpreqn(invars, outvars, name: str, mark_type: str):
         'name': name,
         'mark_type': mark_type
     })
-
-
-def mark_gradient(grad):
-    """Mark variables as gradients with the pipeline marker."""
-    grad_flat, tree = tree_flatten(grad)
-    grad_flat = pipeline_p.bind(*grad_flat, name='grad', mark_type='grad')
-    grad = tree_unflatten(tree, grad_flat)
-    return grad
 
 
 def mark_hook_jaxpreqn(invars, outvars):
@@ -122,7 +113,7 @@ def _pipeline_xla_translation(c, *args, **kwargs):
 
 
 def _pipeline_value_and_jvp(arg_values, arg_tangents, name, mark_type):
-    primal_outs = mark_pipeline(*arg_values, name=name, mark_type=mark_type)
+    primal_outs = pipeline_p.bind(*arg_values, name=name, mark_type=mark_type)
     # TODO(zhuohan): Check the semantics here works for higher order gradients.
     if mark_type in ("start", "jvp_start"):
         tangent_mark_type = "jvp_start"
@@ -139,7 +130,7 @@ def _pipeline_value_and_jvp(arg_values, arg_tangents, name, mark_type):
         else:
             tan_marker_id.append(len(marker_inputs))
             marker_inputs.append(tan)
-    res = mark_pipeline(*marker_inputs, name=name, mark_type=tangent_mark_type)
+    res = pipeline_p.bind(*marker_inputs, name=name, mark_type=tangent_mark_type)
     tangent_outs = []
     for i, (val, tan) in enumerate(zip(arg_values, arg_tangents)):
         if tan_marker_id[i] == -1:
@@ -166,9 +157,9 @@ def _pipeline_transpose(ct, *args, name, mark_type):
         else:
             ctan_marker_id.append(len(marker_inputs))
             marker_inputs.append(ctan)
-    res = mark_pipeline(*marker_inputs,
-                        name=name + "_backward",
-                        mark_type=transposed_mark_type)
+    res = pipeline_p.bind(*marker_inputs,
+                          name=name + "_backward",
+                          mark_type=transposed_mark_type)
     new_ct = []
     for i, (val, ctan) in enumerate(zip(args, ct)):
         if ctan_marker_id[i] == -1:

--- a/alpa/pipeline_parallel/primitive_def.py
+++ b/alpa/pipeline_parallel/primitive_def.py
@@ -13,8 +13,6 @@ xc.register_custom_call_target(b'pipeline_marker',
                                platform='gpu')
 xc.register_custom_call_target(b'identity', identity(), platform='gpu')
 
-mark_pipeline = None
-
 ########## Public APIs ##########
 
 # Define a Jax primitive to mark start/end of a pipeline computation.

--- a/tests/test_pipeline_bert.py
+++ b/tests/test_pipeline_bert.py
@@ -6,8 +6,7 @@ import jax.numpy as jnp
 import optax
 import ray
 
-from alpa import (init, parallelize, mark_pipeline, manual_layer_construction,
-                  PipeshardParallel)
+from alpa import (init, parallelize,  manual_layer_construction, PipeshardParallel)
 from alpa.parallel_method import LocalPipelineParallel
 from alpa.model.model_util import TrainState
 from alpa.model.bert_model import BertConfig
@@ -17,6 +16,7 @@ from alpa.testing import BertLayerModel, assert_allclose
 class PipelineBERTTest(unittest.TestCase):
 
     def setUp(self):
+        os.environ["XLA_PYTHON_CLIENT_ALLOCATOR"] = "platform"
         init(cluster="ray")
 
     def train_2_layer_bert(self, method):
@@ -25,7 +25,6 @@ class PipelineBERTTest(unittest.TestCase):
             def loss_func(params, x, y, attention_mask):
                 out = state.apply_fn(params, x, attention_mask)
                 loss = jnp.mean((out - y)**2)
-                mark_pipeline(name="2", mark_type="end")
                 return loss
 
             loss_func = manual_layer_construction(loss_func)

--- a/tests/test_pipeline_inference_only.py
+++ b/tests/test_pipeline_inference_only.py
@@ -19,7 +19,7 @@ class PipelineInferenceTest(unittest.TestCase):
     def tearDown(self):
         shutdown()
 
-    def run_mlp_inference(self, manual_pipeline_layer=True):
+    def run_mlp_inference(self, manual_pipeline_layer):
         method = PipeshardParallel(num_micro_batches=4,
                                    pipeline_schedule="inference")
 
@@ -51,7 +51,7 @@ class PipelineInferenceTest(unittest.TestCase):
         hlo_text = executable.get_hlo_text()
         return hlo_text
 
-    def run_bert_layer_collection_inference(self, manual_pipeline_layer=True):
+    def run_bert_layer_collection_inference(self, manual_pipeline_layer):
         method = PipeshardParallel(num_micro_batches=4,
                                    pipeline_schedule="inference")
 
@@ -93,14 +93,17 @@ class PipelineInferenceTest(unittest.TestCase):
         hlo_text = executable.get_hlo_text()
         return hlo_text
 
-    def test_pipeline_inference_only(self):
-        self.run_mlp_inference()
-        self.run_bert_layer_collection_inference()
+    def test_mlp(self):
+        self.run_mlp_inference(True)
+
+    def test_bert(self):
+        self.run_bert_layer_collection_inference(True)
 
 
 def suite():
     suite = unittest.TestSuite()
-    suite.addTest(PipelineInferenceTest("test_pipeline_inference_only"))
+    suite.addTest(PipelineInferenceTest("test_mlp"))
+    suite.addTest(PipelineInferenceTest("test_bert"))
     return suite
 
 

--- a/tests/test_pipeline_marker.py
+++ b/tests/test_pipeline_marker.py
@@ -5,7 +5,7 @@ import jax
 from jax.lib import xla_client as xc, xla_bridge as xb
 import jax.numpy as jnp
 
-from alpa.pipeline_parallel.primitive_def import mark_pipeline, xla_pipeline_marker
+from alpa.pipeline_parallel.primitive_def import xla_pipeline_marker, pipeline_p
 from alpa.testing import assert_allclose
 
 ops = xc.ops
@@ -63,9 +63,9 @@ class PipelineMarkerTest(unittest.TestCase):
         def f(x, y):
             a = x + y
             b = x * y
-            a, b = mark_pipeline(a, b, mark_type="start", name="1")
+            a, b = pipeline_p.bind(a, b, name="1", mark_type="start")
             z = a + b
-            z, = mark_pipeline(z, mark_type="end", name="1")
+            z, = pipeline_p.bind(z, name="1", mark_type="end")
             return z
 
         z_without_jit = f(x_np, y_np)
@@ -77,7 +77,7 @@ class PipelineMarkerTest(unittest.TestCase):
     def test_transpose(self):
 
         def f(x):
-            x, = mark_pipeline(x, mark_type="start", name="1")
+            x, = pipeline_p.bind(x, name="1", mark_type="start")
             x = jnp.transpose(x, axes=(1, 0))
             return x
 

--- a/tests/test_pipeline_mlp.py
+++ b/tests/test_pipeline_mlp.py
@@ -6,8 +6,7 @@ import jax.numpy as jnp
 import optax
 import ray
 
-from alpa import (init, parallelize, mark_pipeline, manual_layer_construction,
-                  PipeshardParallel)
+from alpa import (init, parallelize, manual_layer_construction, PipeshardParallel)
 from alpa.parallel_method import LocalPipelineParallel
 from alpa.model.model_util import TrainState
 from alpa.testing import MLPModel, assert_allclose
@@ -23,13 +22,12 @@ class PipelineMLPTest(unittest.TestCase):
 
         def train_step(state, batch):
 
+            @manual_layer_construction
             def loss_func(params, x, y):
                 out = state.apply_fn(params, x)
                 loss = jnp.mean((out - y)**2)
-                mark_pipeline(name="2", mark_type="end")
                 return loss
 
-            loss_func = manual_layer_construction(loss_func)
             grads = jax.grad(loss_func)(state.params, batch["x"], batch["y"])
             return grads
 


### PR DESCRIPTION
The current manual pipeline API is tedious.

## Before
Require a "start" and an "end" marker for each stage.

```python
class MLP(nn.Module):
    @nn.compact
    def __call__(self, x):
        x = nn.Dense(features=self.hidden_dim * 4)(x)
        alpa.mark_pipeline(name='0', mark_type='end')
        alpa.mark_pipeline(name='1', mark_type='start')
        x = nn.Dense(features=self.hidden_dim * 4)(x)
        return x

@alpa.parallelize
def train_step(state, batch):

    @alpa.manual_layer_construction
    def loss_func(params):
        alpa.mark_pipeline(name='0', mark_type='start')
        out = state.apply_fn(params, batch["x"])
        loss = jnp.mean((out - batch["y"])**2)
        alpa.mark_pipeline(name='1', mark_type='end')
        return loss
```

## After
Only require a `mark_pipeline_boundary` at the stage boundary. No need to add any markers in `loss_func`.

```python
class MLP(nn.Module):

    @nn.compact
    def __call__(self, x):
        x = nn.Dense(features=self.hidden_dim * 4)(x)
        alpa.mark_pipeline_boundary()
        x = nn.Dense(features=self.hidden_dim * 4)(x)
        return x

@alpa.parallelize
def train_step(state, batch):

    @alpa.manual_layer_construction
    def loss_func(params):
        out = state.apply_fn(params, batch["x"])
        loss = jnp.mean((out - batch["y"])**2)
        return loss
```

## Changes
- deprecate `mark_pipeline`
- various improvements to `layer_construction.py`