### PR TITLE
Use HloModule instead of XlaComputation in alpa compiler's interfaces

### DIFF
--- a/alpa/__init__.py
+++ b/alpa/__init__.py
@@ -8,7 +8,7 @@ from alpa.device_mesh import (DeviceCluster, PhysicalDeviceMesh,
                               set_global_virtual_physical_mesh)
 from alpa.global_env import global_config
 from alpa.mesh_profiling import ProfilingResultDatabase
-from alpa.parallel_method import ShardParallel, PipeshardParallel, ManualPipeshardParallel
+from alpa.parallel_method import (ShardParallel, PipeshardParallel, ManualPipeshardParallel)
 from alpa.pipeline_parallel.primitive_def import mark_pipeline_boundary
 from alpa.pipeline_parallel.layer_construction import (
     manual_remat, automatic_remat, automatic_layer_construction,

--- a/alpa/pipeline_parallel/compile_executable.py
+++ b/alpa/pipeline_parallel/compile_executable.py
@@ -5,6 +5,7 @@ import time
 from typing import Callable, Sequence
 
 from jax import linear_util as lu
+from jax._src.lib import xla_extension as xe
 from jax.core import gensym, AbstractValue
 from jax.tree_util import PyTreeDef
 
@@ -15,7 +16,7 @@ from alpa.pipeline_parallel.runtime_emitter import PipelineInstEmitter
 from alpa.pipeline_parallel.schedules import (GpipeSchedule, PipeDreamFlush,
                                               InferenceSchedule)
 from alpa.pipeline_parallel.computation import (
-    create_donation_mapping, generate_computations_from_protos,
+    create_donation_mapping, generate_computations_from_modules,
     generate_sharded_xla_computations,
     generate_sharded_xla_computations_arguments, get_donatable_intermediate,
     mark_missing_vars_in_backward_computation_pipeline_marks, offload_remat,
@@ -250,14 +251,15 @@ def shard_each_stage(jax_all_stages, virtual_meshes, schedule, n_stages,
             for stage_idx in stage_id_dict[mesh_idx]
         ]
         if distributed_compile:
-            proto, jaxpr_args, flops = generate_sharded_xla_computations_arguments(
+            module, jaxpr_args, flops = generate_sharded_xla_computations_arguments(
                 str(mesh_idx), stage_dict[mesh_idx], stage_donate_invars)
             other_kwargs = {
                 "logical_mesh": logical_mesh,
-                "return_mode": "stage_protos",
+                "return_mode": "stages",
                 "as_option": autosharding_option,
                 "num_micro_batches": num_microbatch,
             }
+            proto = module.as_serialized_hlo_module_proto()
             compile_workers.submit(compile_fn,
                                    (mesh_idx, proto, jaxpr_args, other_kwargs))
             compile_intermediate[mesh_idx] = (stage_dict[mesh_idx],
@@ -275,12 +277,14 @@ def shard_each_stage(jax_all_stages, virtual_meshes, schedule, n_stages,
 
     if distributed_compile:
         for _ in range(num_meshes):
-            mesh_idx, (computation_names, computation_protos,
+            mesh_idx, (computation_names, computation_modules,
                        strategy_config) = compile_workers.get_next_unordered()
+            computation_modules = [xe.HloModule.from_serialized_hlo_module_proto(x)
+                for x in computation_modules]
             jax_computations, computation_donate_invars = compile_intermediate[
                 mesh_idx]
-            sharded_xla_stages = generate_computations_from_protos(
-                jax_computations, computation_names, computation_protos,
+            sharded_xla_stages = generate_computations_from_modules(
+                jax_computations, computation_names, computation_modules,
                 computation_donate_invars, donatable_dict[mesh_idx],
                 acc_grad_outvars, strategy_config)
             for i, xla_stage in zip(stage_id_dict[mesh_idx],

--- a/alpa/pipeline_parallel/compile_executable.py
+++ b/alpa/pipeline_parallel/compile_executable.py
@@ -280,7 +280,7 @@ def shard_each_stage(jax_all_stages, virtual_meshes, schedule, n_stages,
             mesh_idx, (computation_names, computation_modules,
                        strategy_config) = compile_workers.get_next_unordered()
             computation_modules = [xe.HloModule.from_serialized_hlo_module_proto(x)
-                for x in computation_modules]
+                                   for x in computation_modules]
             jax_computations, computation_donate_invars = compile_intermediate[
                 mesh_idx]
             sharded_xla_stages = generate_computations_from_modules(

--- a/alpa/pipeline_parallel/computation.py
+++ b/alpa/pipeline_parallel/computation.py
@@ -14,7 +14,6 @@ from jax.core import (Atom, Var, JaxprEqn, Jaxpr, ClosedJaxpr, DropVar, Literal,
                       ShapedArray, get_aval, raise_to_shaped)
 from jax.interpreters import pxla
 from jax.interpreters.partial_eval import remat_call_p
-from jaxlib import xla_extension
 import numpy as np
 
 from alpa.measure_record import StrategyConfig
@@ -28,7 +27,7 @@ from alpa.shard_parallel.auto_sharding import (run_auto_sharding_pass,
                                                hlo_sharding_to_sharding_spec)
 from alpa.global_env import global_config
 from alpa.util import (OrderedSet, clone_jaxpr, get_compile_options,
-                       jaxpr_to_hlo_computation, setup_computation_alias,
+                       jaxpr_to_hlo_module, setup_computation_alias,
                        compile_dummy_zero_constant, get_var_mapping)
 
 # pylint: disable=redefined-builtin
@@ -128,9 +127,9 @@ class JaxPipelineComputation(PipelineComputation):
 
 @dataclass
 class XlaPipelineComputation(PipelineComputation):
-    """A pipeline computation defined by XLA HLO proto."""
+    """A pipeline computation defined by XLA HLO Module."""
 
-    hlo_proto: bytes = field(default_factory=b"")
+    hlo_module: xe.HloModule = None
 
     @classmethod
     def from_jax_pipeline_computation(
@@ -144,11 +143,11 @@ class XlaPipelineComputation(PipelineComputation):
         closed_jaxpr = jax_pipeline_computation.closed_jaxpr()
         backend = xb.get_backend("gpu")
         name = f"pipeline_computation_{jax_pipeline_computation.name}"
-        built = jaxpr_to_hlo_computation(name, closed_jaxpr, None, backend)
+        hlo_module = jaxpr_to_hlo_module(name, closed_jaxpr, None, backend)
 
         return cls(
             name=jax_pipeline_computation.name,
-            hlo_proto=built.as_serialized_hlo_module_proto(),
+            hlo_module=hlo_module,
             invars=jax_pipeline_computation.invars,
             outvars=jax_pipeline_computation.outvars,
         )
@@ -156,7 +155,6 @@ class XlaPipelineComputation(PipelineComputation):
     def get_runnable(self, mesh=None):
         """Return a callable of the pipeline computation."""
         out_avals = [var.aval for var in self.outvars]
-        xla_computation = xc.XlaComputation(self.hlo_proto)
         tuple_args = len(
             self.invars) > 100  # pass long arg lists as tuple for TPU
         backend = 'gpu'
@@ -171,6 +169,8 @@ class XlaPipelineComputation(PipelineComputation):
             build_random_seed=global_config.build_random_seed,
         )
 
+        xla_computation = xc.XlaComputation(
+            self.hlo_module.as_serialized_hlo_module_proto())
         compiled = backend.compile(xla_computation, compile_options=options)
         result_handlers = map(partial(dispatch.aval_to_result_handler, device),
                               out_avals)
@@ -183,15 +183,17 @@ class XlaPipelineComputation(PipelineComputation):
 
     def get_hlo_text(self):
         """Get the HLO text."""
-        xla_computation = xc.XlaComputation(self.hlo_proto)
-        return xla_computation.as_hlo_text()
+        return self.hlo_module.to_string()
 
 
 @dataclass
 class XlaShardedPipelineComputation(PipelineComputation):
-    """A pipeline computation defined by XLA HLO proto. The XLA HLO is annotated by sharding spec."""
+    """
+    A pipeline computation defined by XLA HLO Module.
+    The XLA HLO is annotated by sharding spec.
+    """
 
-    sharding_annotated_proto: bytes = None
+    sharding_annotated_module: xe.HloModule = None
     donated_invars: Sequence[bool] = None
     strategy_config: StrategyConfig = None
     input_sharding_specs: Sequence[pxla.ShardingSpec] = None
@@ -209,12 +211,11 @@ class XlaShardedPipelineComputation(PipelineComputation):
                                          logical_mesh_shape, 1, 1, None, 0)
         compiled = compile_dummy_zero_constant(backend,
                                                np.prod(logical_mesh_shape))
-        sharding_annotated_proto = compiled.hlo_modules(
-        )[0].as_serialized_hlo_module_proto()
+        sharding_annotated_module = compiled.hlo_modules()[0]
         outvar = gensym_func(ShapedArray((), np.dtype(np.int32)))
         return cls(
             name=name,
-            sharding_annotated_proto=sharding_annotated_proto,
+            sharding_annotated_module=sharding_annotated_module,
             strategy_config=strategy_config,
             donated_invars=[],
             invars=[],
@@ -228,7 +229,7 @@ class XlaShardedPipelineComputation(PipelineComputation):
             cls,
             *,
             jax_pipeline_computation: JaxPipelineComputation,
-            sharding_annotated_proto: xc.XlaComputation,
+            sharding_annotated_module: xe.HloModule,
             strategy_config: StrategyConfig,
             donated_invars: Sequence[bool] = None,
             acc_grad_outvars: Sequence[Var] = (),
@@ -247,7 +248,7 @@ class XlaShardedPipelineComputation(PipelineComputation):
         ]
 
         return cls(name=jax_pipeline_computation.name,
-                   sharding_annotated_proto=sharding_annotated_proto,
+                   sharding_annotated_module=sharding_annotated_module,
                    strategy_config=strategy_config,
                    donated_invars=donated_invars,
                    invars=jax_pipeline_computation.invars,
@@ -309,13 +310,13 @@ class XlaShardedPipelineComputation(PipelineComputation):
 
         strategy_config = self.strategy_config
         logical_mesh_shape = strategy_config.logical_mesh_shape
-        xla_computation = xc.XlaComputation(self.sharding_annotated_proto)
-        setup_computation_alias(xla_computation, self.donated_invars)
+        hlo_module = self.sharding_annotated_module
+        setup_computation_alias(hlo_module, self.donated_invars)
 
         num_devices = np.prod(logical_mesh_shape)
         rewrite_for_grad_acc = len(self.output_acc_grad_indices) > 0
         spmd_partitioned_hlo_module = run_spmd_partitioner_pass(
-            xla_computation,
+            hlo_module,
             num_devices,
             rewrite_for_grad_acc=rewrite_for_grad_acc,
             rewrite_grad_acc_indices=self.output_acc_grad_indices)
@@ -345,8 +346,7 @@ class XlaShardedPipelineComputation(PipelineComputation):
 
     def get_hlo_text(self):
         """Get the HLO text."""
-        xla_computation = xc.XlaComputation(self.sharding_annotated_proto)
-        return xla_computation.as_hlo_text()
+        return self.sharding_annotated_module.to_string()
 
 
 def slice_closed_jaxpr_by_full_pipeline_marks(
@@ -787,15 +787,15 @@ def rearrange_vars(vars,
     return new_vars, new_marker
 
 
-def generate_computations_from_protos(jax_computations, computation_names,
-                                      computation_protos, donate_invars,
-                                      donatable_lists, acc_grad_outvars,
-                                      strategy_config):
-    """Generate XLA computation from protos."""
-    proto_dict = dict(zip(computation_names, computation_protos))
+def generate_computations_from_modules(jax_computations, computation_names,
+                                       computation_modules, donate_invars,
+                                       donatable_lists, acc_grad_outvars,
+                                       strategy_config):
+    """Generate pipeline computation from HLO modules."""
+    module_dict = dict(zip(computation_names, computation_modules))
     computations = [
         XlaShardedPipelineComputation.from_auto_sharded_computation(
-            sharding_annotated_proto=proto_dict[computation.name],
+            sharding_annotated_module=module_dict[computation.name],
             jax_pipeline_computation=computation,
             strategy_config=strategy_config,
             donated_invars=donate_invars,
@@ -846,15 +846,12 @@ def generate_sharded_xla_computations_arguments(
     closed_jaxpr = ClosedJaxpr(jaxpr, consts_dir.values())
     backend_name = "gpu"
     backend = xb.get_backend(backend_name)
-    built = jaxpr_to_hlo_computation(name, closed_jaxpr, dummy_donated_invars,
-                                     backend)
-    flops = xla_extension.hlo_module_count_flop_dot_conv_only(
-        built.as_hlo_module())
+    hlo_module = jaxpr_to_hlo_module(name, closed_jaxpr, dummy_donated_invars, backend)
+    flops = xe.hlo_module_count_flop_dot_conv_only(hlo_module)
     in_avals = [var.aval for var in invars]
     out_avals = [var.aval for var in outvars]
     jaxpr_args = in_avals, out_avals, dummy_donated_invars
-    proto = built.as_serialized_hlo_module_proto()
-    return proto, jaxpr_args, flops
+    return hlo_module, jaxpr_args, flops
 
 
 def generate_sharded_xla_computations(
@@ -868,23 +865,22 @@ def generate_sharded_xla_computations(
     Note: we merge the co-located forward and backward computation and compile
     them together to get a sharding strategy config.
     """
-    proto, jaxpr_args, flops = generate_sharded_xla_computations_arguments(
+    hlo_module, jaxpr_args, flops = generate_sharded_xla_computations_arguments(
         name, jax_computations, computation_donate_invars)
-    built = xc.XlaComputation(proto)
     in_avals, out_avals, donated_invars = jaxpr_args
 
     #  pylint: disable=unbalanced-tuple-unpacking
-    computation_names, computation_protos, strategy_config = run_auto_sharding_pass(
-        built,
+    computation_names, computation_modules, strategy_config = run_auto_sharding_pass(
+        hlo_module,
         in_avals,
         out_avals,
         donated_invars,
         logical_mesh,
-        "stage_protos",
+        "stages",
         num_micro_batches,
         autosharding_option)
-    computations = generate_computations_from_protos(
-        jax_computations, computation_names, computation_protos,
+    computations = generate_computations_from_modules(
+        jax_computations, computation_names, computation_modules,
         computation_donate_invars, donatable_lists, acc_grad_outvars,
         strategy_config)
     return computations, flops

--- a/alpa/pipeline_parallel/stage_profiling.py
+++ b/alpa/pipeline_parallel/stage_profiling.py
@@ -9,7 +9,7 @@ from typing import Dict, Sequence
 import jax.numpy as jnp
 from jax.core import (ClosedJaxpr, Var, gensym)
 from jax.interpreters import pxla
-from jax.lib import xla_bridge, xla_client, xla_extension as _xla
+from jax._src.lib import xla_bridge as xb, xla_client as xc, xla_extension as xe
 import numpy as np
 import tqdm
 import ray
@@ -34,7 +34,7 @@ from alpa.shard_parallel.auto_sharding import (run_auto_sharding_pass,
                                                run_spmd_partitioner_pass,
                                                run_backend_compilation,
                                                hlo_sharding_to_sharding_spec)
-from alpa.util import (clone_jaxpr, get_shard_shape, jaxpr_to_hlo_computation,
+from alpa.util import (clone_jaxpr, get_shard_shape, jaxpr_to_hlo_module,
                        OrderedSet)
 
 logger = logging.getLogger(__name__)
@@ -102,12 +102,10 @@ class BaseWorkerPoolWrapper(ABC):
             self.shutdown()
 
 
-def get_input_output_sharding_proto(proto, num_devices):
+def get_input_output_sharding_proto(hlo_module, num_devices):
     """Given proto of XlaComputation, return its input and output sharding."""
     if num_devices <= 1:
         return None, None
-    computation = xla_client.XlaComputation(proto)
-    hlo_module = computation.as_hlo_module()
     hlo_module.infer_spmd_shardings()
     input_shardings = hlo_module.spmd_parameters_shardings()
     output_sharding = hlo_module.spmd_output_sharding()
@@ -152,43 +150,40 @@ class CompileWorker:
                       config.donate_invars)
         other_kwargs = {
             "logical_mesh": logical_mesh,
-            "return_mode": "stage_and_hook_protos",
+            "return_mode": "stages_and_hook",
             "as_option": autosharding_option,
             "num_micro_batches": num_micro_batches,
             "memory_budget_per_device": None,
         }
         try:
-            computation = xla_client.XlaComputation(config.model_proto)
+            hlo_module = xe.HloModule.from_serialized_hlo_module_proto(config.model_proto)
             # pylint: disable=unbalanced-tuple-unpacking
-            proto_names, protos, hooked_proto, strategy_config = run_auto_sharding_pass(
-                computation, *jaxpr_args, **other_kwargs)
+            module_names, modules, hooked_proto, strategy_config = run_auto_sharding_pass(
+                hlo_module, *jaxpr_args, **other_kwargs)
         except RuntimeError as e:
             logger.warning(f"Compilation error (auto-sharding pass) "
                            f"for stage {stage_id} : {e}")
             return stage_id, None
 
-        assert (len(protos) <=
+        assert (len(modules) <=
                 2), "Can only compile no more than two stages (compute+(apply))"
 
         # Read input/output shardings
 
-        if len(protos) > 1:
-            if proto_names[0].endswith(APPLY_GRAD_MARKER_SUFFIX):
-                proto_names[0], proto_names[1] = proto_names[1], proto_names[0]
-                protos[0], protos[1] = protos[1], protos[0]
-            assert proto_names[1].endswith(APPLY_GRAD_MARKER_SUFFIX)
+        if len(modules) > 1:
+            if module_names[0].endswith(APPLY_GRAD_MARKER_SUFFIX):
+                module_names[0], module_names[1] = module_names[1], module_names[0]
+                modules[0], modules[1] = modules[1], modules[0]
+            assert module_names[1].endswith(APPLY_GRAD_MARKER_SUFFIX)
 
-        acc_grad_proto = protos[0]
-        sharding_annotated_computation = xla_client.XlaComputation(
-            acc_grad_proto)
+        acc_grad_module = modules[0]
         (input_sharding_protos,
          output_sharding_proto) = get_input_output_sharding_proto(
-             acc_grad_proto, logical_mesh.num_devices)
+             acc_grad_module, logical_mesh.num_devices)
 
-        if len(protos) > 1:
-            apply_grad_proto = protos[1]
+        if len(modules) > 1:
             apply_grad_input_sharding_protos, _ = get_input_output_sharding_proto(
-                apply_grad_proto, logical_mesh.num_devices)
+                modules[1], logical_mesh.num_devices)
         else:
             apply_grad_input_sharding_protos = None
 
@@ -196,7 +191,7 @@ class CompileWorker:
         rewrite_for_grad_acc = len(config.output_acc_grad_indices) > 0
         try:
             hlo_module = run_spmd_partitioner_pass(
-                sharding_annotated_computation,
+                acc_grad_module,
                 logical_mesh.num_devices,
                 rewrite_for_grad_acc=rewrite_for_grad_acc,
                 rewrite_grad_acc_indices=config.output_acc_grad_indices)
@@ -214,9 +209,12 @@ class CompileWorker:
     @staticmethod
     def run_auto_sharding_pass(stage_id, proto, jaxpr_args, other_kwargs):
         """Run auto-sharding pass on a proto."""
-        computation = xla_client.XlaComputation(proto)
-        return stage_id, run_auto_sharding_pass(computation, *jaxpr_args,
-                                                **other_kwargs)
+        hlo_module = xe.HloModule.from_serialized_hlo_module_proto(proto)
+        assert other_kwargs["return_mode"] == "stages"
+        hlo_stage_names, hlo_stages, strategy_config = run_auto_sharding_pass(
+            hlo_module, *jaxpr_args, **other_kwargs)
+        hlo_stages = [x.as_serialized_hlo_module_proto() for x in hlo_stages]
+        return stage_id, (hlo_stage_names, hlo_stages, strategy_config)
 
 
 class CompileWorkerPool(BaseWorkerPoolWrapper):
@@ -280,13 +278,13 @@ class ProfileWorker:
         output_sharding = compiled_output.output_sharding_proto
         donated_invars = (True,) * len(tot_donation) + (False,) * (
             len(avals) - len(tot_donation))
-        hlo_module = xla_client.XlaComputation(
+        hlo_module = xc.XlaComputation(
             compiled_output.model_proto).as_hlo_module()
         if input_shardings is not None:
             hlo_module.set_spmd_parameters_shardings(
-                [_xla.HloSharding(x) for x in input_shardings])
+                [xe.HloSharding(x) for x in input_shardings])
             hlo_module.set_spmd_output_sharding(
-                _xla.HloSharding(output_sharding))
+                xe.HloSharding(output_sharding))
         executable = PartialGradAccMeshDriverExecutable(
             self.mesh, hlo_module, compiled_output.strategy_config, avals,
             out_avals, donated_invars, output_acc_grad_indices)
@@ -354,7 +352,7 @@ class HloCostModelProfileWorker:
     """A ray actor to estimate the cost of HLO Proto based on cost model."""
 
     def __init__(self, prof_result, num_devices, num_micro_batches):
-        self.backend = xla_bridge.get_backend("gpu")
+        self.backend = xb.get_backend("gpu")
         self.prof_result = prof_result
         self.num_devices = num_devices
         self.num_micro_batches = num_micro_batches
@@ -616,7 +614,7 @@ def generate_stage_info(all_layers, selected_indices, donation_mapping,
                         global_outvars, name, insert_hook_after,
                         apply_grad_layers, apply_grad_info):
     """Combine selected layers together for profiling."""
-    backend = xla_bridge.get_backend("gpu")
+    backend = xb.get_backend("gpu")
 
     # TODO(yonghao): clean up code here
     (selected_donation_mapping, used_outside,
@@ -679,8 +677,8 @@ def generate_stage_info(all_layers, selected_indices, donation_mapping,
     avals = [var.aval for var in merged.jaxpr.invars]
     out_avals = [var.aval for var in merged.jaxpr.outvars]
 
-    built = jaxpr_to_hlo_computation(name, merged, is_donated, backend)
-    proto = built.as_serialized_hlo_module_proto()
+    hlo_module = jaxpr_to_hlo_module(name, merged, is_donated, backend)
+    proto = hlo_module.as_serialized_hlo_module_proto()
     compile_config = CompileConfig(proto, avals, out_avals, is_donated,
                                    output_acc_grad_indices)
     stage_config = StageConfig(compile_config, profile_config, apply_info)
@@ -815,7 +813,7 @@ def compute_intermediate_size(serialized_proto, intermediate_vars,
     if np.prod(logical_mesh_shape) == 1:
         sharding_specs = None
     else:
-        hlo_sharding = _xla.HloSharding(serialized_proto[0])
+        hlo_sharding = xe.HloSharding(serialized_proto[0])
         sharding_specs = hlo_sharding_to_sharding_spec(hlo_sharding, avals,
                                                        logical_mesh_shape)
     return _compute_vars_size(sharding_specs, intermediate_vars,
@@ -839,7 +837,7 @@ def compute_apply_grad_invar_size(input_sharding_protos,
     else:
         assert len(input_sharding_protos) == len(config.invars)
         sharding_specs = [
-            hlo_sharding_to_sharding_spec(_xla.HloSharding(sharding_proto),
+            hlo_sharding_to_sharding_spec(xe.HloSharding(sharding_proto),
                                           aval, logical_mesh_shape)
             for sharding_proto, aval in zip(input_sharding_protos, avals)
         ]

--- a/alpa/pipeline_parallel/stage_profiling.py
+++ b/alpa/pipeline_parallel/stage_profiling.py
@@ -211,6 +211,7 @@ class CompileWorker:
         """Run auto-sharding pass on a proto."""
         hlo_module = xe.HloModule.from_serialized_hlo_module_proto(proto)
         assert other_kwargs["return_mode"] == "stages"
+        # pylint: disable=unbalanced-tuple-unpacking
         hlo_stage_names, hlo_stages, strategy_config = run_auto_sharding_pass(
             hlo_module, *jaxpr_args, **other_kwargs)
         hlo_stages = [x.as_serialized_hlo_module_proto() for x in hlo_stages]

--- a/alpa/shard_parallel/compile_executable.py
+++ b/alpa/shard_parallel/compile_executable.py
@@ -5,12 +5,11 @@ from typing import Callable, Sequence, Optional, Union
 
 import numpy as np
 from jax import linear_util as lu
-from jax._src.lib import xla_bridge as xb
+from jax._src.lib import xla_bridge as xb, xla_extension as xe
 from jax.core import (Jaxpr, ClosedJaxpr, Literal, new_jaxpr_eqn, gensym,
                       get_aval, raise_to_shaped, AbstractValue)
 from jax.interpreters import partial_eval as pe
 from jax.lax import add_p, div_p
-from jax.lib import xla_client as xc, xla_extension as xe
 from jax.tree_util import PyTreeDef
 
 from alpa.device_mesh import LogicalDeviceMesh, PhysicalDeviceMesh

--- a/alpa/shard_parallel/compile_executable.py
+++ b/alpa/shard_parallel/compile_executable.py
@@ -10,7 +10,7 @@ from jax.core import (Jaxpr, ClosedJaxpr, Literal, new_jaxpr_eqn, gensym,
                       get_aval, raise_to_shaped, AbstractValue)
 from jax.interpreters import partial_eval as pe
 from jax.lax import add_p, div_p
-from jax.lib import xla_client as xc, xla_extension
+from jax.lib import xla_client as xc, xla_extension as xe
 from jax.tree_util import PyTreeDef
 
 from alpa.device_mesh import LogicalDeviceMesh, PhysicalDeviceMesh
@@ -20,7 +20,7 @@ from alpa.pipeline_parallel.apply_grad import APPLY_GRAD_MARKER_SUFFIX
 from alpa.shard_parallel.auto_sharding import (run_auto_sharding_pass,
                                                run_spmd_partitioner_pass,
                                                AutoShardingOption)
-from alpa.util import (jaxpr_to_hlo_computation, trace_jaxpr_with_micro_batch,
+from alpa.util import (jaxpr_to_hlo_module, trace_jaxpr_with_micro_batch,
                        setup_computation_alias, OrderedSet)
 
 
@@ -105,14 +105,13 @@ def shard_parallel_internal(
     # Convert jaxpr to XLA HLO
     name = f"{fun.__name__}_shard_parallel"
     backend = xb.get_backend("gpu")
-    built = jaxpr_to_hlo_computation(name, ClosedJaxpr(jaxpr, consts),
+    hlo_module = jaxpr_to_hlo_module(name, ClosedJaxpr(jaxpr, consts),
                                      donated_invars, backend)
-    flop_count = xla_extension.hlo_module_count_flop_dot_conv_only(
-        built.as_hlo_module())
+    flop_count = xe.hlo_module_count_flop_dot_conv_only(hlo_module)
 
     # Compile a XLA executable
     hlo_module, strategy_config = run_auto_sharding_pass(
-        built,
+        hlo_module,
         avals,
         out_avals,
         donated_invars,
@@ -155,33 +154,31 @@ def shard_parallel_internal_gradient_accumulation(
     backend = xb.get_backend("gpu")
     donated_invars = donated_invars + (False,) * num_grads
     name = f"{fun.__name__}_shard_parallel"
-    built = jaxpr_to_hlo_computation(name, closed_jaxpr, donated_invars,
+    hlo_module = jaxpr_to_hlo_module(name, closed_jaxpr, donated_invars,
                                      backend)
-    flop_count = xla_extension.hlo_module_count_flop_dot_conv_only(
-        built.as_hlo_module())
+    flop_count = xe.hlo_module_count_flop_dot_conv_only(hlo_module)
     flop_count *= num_micro_batches
 
     # pylint: disable=unbalanced-tuple-unpacking
-    hlo_proto_names, hlo_protos, strategy_config = run_auto_sharding_pass(
-        built,
+    hlo_stage_names, hlo_stages, strategy_config = run_auto_sharding_pass(
+        hlo_module,
         avals,
         out_avals,
         donated_invars,
         logical_mesh_choices[0],
-        "stage_protos",
+        "stages",
         num_micro_batches,
         as_option)
-    assert len(hlo_protos) == 2
+    assert len(hlo_stages) == 2
 
-    if hlo_proto_names[0].endswith(APPLY_GRAD_MARKER_SUFFIX):
-        hlo_proto_names[0], hlo_protos[0], hlo_proto_names[1], hlo_protos[1] = (
-            hlo_proto_names[1], hlo_protos[1], hlo_proto_names[0],
-            hlo_protos[0])
-    assert hlo_proto_names[1].endswith(APPLY_GRAD_MARKER_SUFFIX)
+    if hlo_stage_names[0].endswith(APPLY_GRAD_MARKER_SUFFIX):
+        hlo_stage_names[0], hlo_stages[0], hlo_stage_names[1], hlo_stages[1] = (
+            hlo_stage_names[1], hlo_stages[1], hlo_stage_names[0],
+            hlo_stages[0])
+    assert hlo_stage_names[1].endswith(APPLY_GRAD_MARKER_SUFFIX)
 
     # Compile these two HLOs separately to get two XLA executables
-    accumulate_grad = xc.XlaComputation(hlo_protos[0])
-    apply_grad = xc.XlaComputation(hlo_protos[1])
+    accumulate_grad, apply_grad = hlo_stages
 
     ## donate old_grad to make the gradient accumulation in-place
     tmp_donate_invars = ((False,) * len(accumulate_grad_invar_indices) +

--- a/alpa/util.py
+++ b/alpa/util.py
@@ -9,7 +9,7 @@ from collections import OrderedDict
 from datetime import datetime
 from functools import partial, partialmethod
 import threading
-from typing import Sequence, Any
+from typing import Sequence, Any, Union
 from warnings import warn
 
 import jax
@@ -321,9 +321,9 @@ def get_compile_options(num_replicas: int, num_partitions: int,
     return compile_options
 
 
-def jaxpr_to_hlo_computation(name: str, closed_jaxpr: ClosedJaxpr,
-                             donated_invars: Sequence[bool], backend):
-    """Convert a jaxpr to a XLA HLO computation.
+def jaxpr_to_hlo_module(name: str, closed_jaxpr: ClosedJaxpr,
+                        donated_invars: Sequence[bool], backend):
+    """Convert a jaxpr to an XLA HloModule.
 
     Reference code: jax/jax/_src/dispatch.py::lower_xla_callable
     """
@@ -361,10 +361,10 @@ def jaxpr_to_hlo_computation(name: str, closed_jaxpr: ClosedJaxpr,
             warn_msg = ", ".join(unused_donations)
             warn(f"Some donated buffers were not usable: {warn_msg}")
 
-    return c.build(out_tuple)
+    return c.build(out_tuple).as_hlo_module()
 
 
-def setup_computation_alias(xla_computation: xc.XlaComputation,
+def setup_computation_alias(xla_computation: Union[xc.XlaComputation, xe.HloModule],
                             donated_invars: Sequence[bool]):
     """Set input/output alias in xla computation.
 


### PR DESCRIPTION
`HloModule` is more flexible than `XlaComputation`. This PR modifies most of alpa compiler's interfaces such as `run_auto_sharding_pass`, `run_spmd_partitioner_pass` and `slice_auto_sharded_stages` to take HloModule as input and return HloModule.