### PR TITLE
[RUNTIME] Model Checkpoint Improvements

### DIFF
--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -84,7 +84,10 @@ ReshardingBroadcastTask = namedtuple("ReshardingBroadcastTask",
 
 
 class DaemonMoveWorker:
-    """A ray actor that moves local checkpoint into the shared filesystem in the background."""
+    """
+        A ray actor that moves local checkpoint into the shared
+        filesystem in the background.
+    """
 
     def move(self, from_dir: str, to_dir: str):
         os.makedirs(to_dir, exist_ok=True)
@@ -287,10 +290,10 @@ class MeshHostWorker:
         ]
 
         metadata = {
-            'global_shape': global_shape,
-            'dtype': self.buffers[uuids[0]].dtype,
-            'shard_names': shard_names,
-            'shard_indices': shard_indices,
+            "global_shape": global_shape,
+            "dtype": self.buffers[uuids[0]].dtype,
+            "shard_names": shard_names,
+            "shard_indices": shard_indices,
         }
 
         # create directories if not exist
@@ -1428,10 +1431,13 @@ class DistributedArray:
             Save one replica of the array to `ckpt_dir` distributedly.
 
             Args:
-                ckpt_dir: The directory where all the shards of this array will be saved.
-                local_cache_dir: If not None, `ckpt_dir` should be a shared filesystem path, and this function 
-                                 will return as soon as the shards have been saved to this local directory. 
-                                 DaemonMoveWorkers will move these shards into `ckpt_dir` in the background.
+                ckpt_dir: The directory where all the shards of
+                this array will be saved.
+                local_cache_dir: If not None, `ckpt_dir` should be a shared
+                filesystem path, and this function will return as soon as the
+                shards have been saved to this local directory.
+                DaemonMoveWorkers will move these shards into `ckpt_dir`
+                in the background.
 
         """
         one_replica_buffers = [
@@ -1459,7 +1465,8 @@ class DistributedArray:
     def load(cls, path: str, aval: ShapedArray, device_mesh: PhysicalDeviceMesh,
              sharding_spec: ShardingSpec):
         """
-            Load the data from `path` distributedly with `aval` and return a new DistributedArray
+            Load the data from `path` distributedly with `aval` and
+            return a new DistributedArray
         """
         # pylint: disable=import-outside-toplevel
         from alpa.mesh_executable import create_remote_buffer_refs

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -90,7 +90,7 @@ class DaemonMoveWorker:
         for file in os.listdir(from_dir):
             from_path = os.path.join(from_dir, file)
             to_path = os.path.join(to_dir, file)
-            subprocess.run(["mv", from_path, to_path])
+            subprocess.run(["mv", from_path, to_path], check=True)
 
     def shutdown(self):
         """Noop function used to synchronized."""

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -281,6 +281,8 @@ class MeshHostWorker:
         assert len(metadatas) > 0
         with open(os.path.join(ckpt_dir, metadatas[0]), "rb") as metafile:
             meta = pickle.load(metafile)
+        if meta["shard_indices"] is None:
+            return np.load(os.path.join(ckpt_dir, meta["shard_names"][0]))
         entire_arr = np.empty(meta["global_shape"], meta['dtype'])
         for metadata in metadatas:
             with open(os.path.join(ckpt_dir, metadata), "rb") as metafile:

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -1426,7 +1426,8 @@ class DistributedArray:
                 obj_refs.append(
                     self.device_mesh.workers[host_id].save_buffers_to_ts.remote(
                         path, uuids, indices_per_host[host_id], self.shape))
-        return ray.get(obj_refs)
+        ray.get(obj_refs)
+        return 
 
     @classmethod
     def load(cls, path: str, aval: ShapedArray, device_mesh: PhysicalDeviceMesh,

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -1401,7 +1401,7 @@ class DistributedArray:
                     self.device_mesh.workers[host_id].save_buffers.remote(
                         path, uuids, indices_per_host[host_id], self.shape))
         if synchronized:
-            ray.get(obj_refs)
+            return ray.get(obj_refs)
         else:
             return obj_refs
 
@@ -1438,11 +1438,9 @@ class DistributedArray:
                         device_ids_per_host[host_id]))
         if synchronized:
             ray.get(obj_refs)
-            return DistributedArray(device_mesh, aval, sharding_spec, buf_refs,
-                                indices)
+            return DistributedArray(device_mesh, aval, sharding_spec, buf_refs, indices)
         else:
-            return obj_refs, DistributedArray(device_mesh, aval, sharding_spec, 
-                                buf_refs, indices)
+            return obj_refs, DistributedArray(device_mesh, aval, sharding_spec, buf_refs, indices)
 
 
     @property

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -24,7 +24,7 @@ import logging
 from operator import attrgetter
 import os
 import pickle
-import subprocess
+import shutil
 import threading
 import time
 from typing import Any, List, Union, Sequence, Tuple, Optional, Callable
@@ -84,13 +84,13 @@ ReshardingBroadcastTask = namedtuple("ReshardingBroadcastTask",
 
 
 class DaemonMoveWorker:
-    """A ray actor that moves local checkpoint into EFS in the background."""
+    """A ray actor that moves local checkpoint into the shared filesystem in the background."""
     def move(self, from_dir: str, to_dir: str):
         os.makedirs(to_dir, exist_ok=True)
         for file in os.listdir(from_dir):
             from_path = os.path.join(from_dir, file)
             to_path = os.path.join(to_dir, file)
-            subprocess.run(["mv", from_path, to_path], check=True)
+            shutil.move(from_path, to_path)
 
     def shutdown(self):
         """Noop function used to synchronized."""

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -100,12 +100,7 @@ class MeshHostWorker:
     """A ray actor that manages the xla computation and buffers on a single
     host."""
 
-<<<<<<< HEAD
-    def __init__(self, server_address: str, num_hosts: int, host_id: int,
-                 mesh_id: int):
-=======
     def __init__(self, server_address: str, num_hosts: int, host_id: int, mesh_id: int, node_resource: str):
->>>>>>> reorganize the checkpoint interfaces
         self.num_hosts = num_hosts
         self.host_id = host_id
         self.mesh_id = mesh_id

--- a/alpa/pipeline_parallel/pipeshard_executable.py
+++ b/alpa/pipeline_parallel/pipeshard_executable.py
@@ -345,6 +345,10 @@ class PipeshardDriverExecutable:
     def sync(self):
         """Sync device activities on all workers."""
         self.mesh_group.sync_workers()
+    
+    def sync_move_workers(self):
+        """Sync moveworkers on all meshes."""
+        self.mesh_group.sync_move_workers()
 
     def _check_alive(self):
         try:

--- a/alpa/pipeline_parallel/pipeshard_executable.py
+++ b/alpa/pipeline_parallel/pipeshard_executable.py
@@ -345,7 +345,7 @@ class PipeshardDriverExecutable:
     def sync(self):
         """Sync device activities on all workers."""
         self.mesh_group.sync_workers()
-    
+
     def sync_move_workers(self):
         """Sync moveworkers on all meshes."""
         self.mesh_group.sync_move_workers()

--- a/alpa/pipeline_parallel/runtime_emitter.py
+++ b/alpa/pipeline_parallel/runtime_emitter.py
@@ -991,9 +991,9 @@ class PipelineInstEmitter:
                                     physical_mesh,
                                     input_shard_specs[mesh_idx][local_idx])
                 if load_info_arr[global_idx] is None:
-                    load_info_arr[global_idx] = LoadInfo([aval], [mesh], [spec])
+                    load_info_arr[global_idx] = LoadInfo(aval, [mesh], [spec])
                 else:
-                    load_info_arr[global_idx].add_replica(aval, mesh, spec)
+                    load_info_arr[global_idx].add_replica(mesh, spec)
 
         # build load_info_arr
         return tree_unflatten(self.in_tree, load_info_arr)

--- a/alpa/serialization.py
+++ b/alpa/serialization.py
@@ -15,7 +15,6 @@ from jax.core import ShapedArray
 from jax._src.tree_util import tree_flatten, tree_leaves, tree_unflatten
 import msgpack
 import numpy as np
-import ray
 
 from alpa.device_mesh import (DistributedArray, ReplicatedDistributedArray,
                               PhysicalDeviceMesh)
@@ -75,7 +74,7 @@ def load_sharded_array(ckpt_dir, metadatas):
 
 
 def save_checkpoint(ckpt_dir: Union[str, os.PathLike], target: PyTree,
-                    step: int, local_cache_dir: Union[str, os.PathLike, None]=None):
+                    step: int, local_cache_dir: Union[str, os.PathLike, None] = None):
     """
         Save a checkpoint of the `target` to `ckpt_dir`. 
 

--- a/alpa/serialization.py
+++ b/alpa/serialization.py
@@ -8,6 +8,7 @@ in Alpa.
 import enum
 import logging
 import os
+import pickle
 import re
 from typing import Union, Any, Sequence
 import uuid
@@ -154,15 +155,14 @@ def save_checkpoint(ckpt_dir: Union[str, os.PathLike], target: PyTree,
            target: serializable flax object, usually a trainState
            step: training step number or other metric number
     """
-    state_dict = to_state_dict(target)
     os.makedirs(ckpt_dir, exist_ok=True)
-    ckpt_path = os.path.join(ckpt_dir, f'checkpoint_{step}')
+    ckpt_path = os.path.join(ckpt_dir, f"checkpoint_{step}")
+    state_dict = to_state_dict(target)
     with open(ckpt_path, 'wb') as fp:
         fp.write(
             msgpack.packb(state_dict,
                           default=_msgpack_ext_pack_wrapper(ckpt_dir),
                           strict_types=True))
-
 
 class LoadInfo:
     """

--- a/alpa/serialization.py
+++ b/alpa/serialization.py
@@ -91,7 +91,7 @@ def save_checkpoint(ckpt_dir: Union[str, os.PathLike], target: PyTree,
            ckpt_dir: the directory where this checkpoint will be saved.
            target: serializable flax object, usually a trainState.
            step: training step number or other metric number
-           local_cache_dir: If not None, `ckpt_dir` should be a shard filesystem path, and this function 
+           local_cache_dir: If not None, `ckpt_dir` should be a shared filesystem path, and this function 
                             will return as soon as the shards have been saved to this local directory. 
                             DaemonMoveWorkers will move these shards into `ckpt_dir` in the background.
     """

--- a/alpa/serialization.py
+++ b/alpa/serialization.py
@@ -1,8 +1,6 @@
-"""Serialization utilities for Alpa.
-Adapted from
-https://flax.readthedocs.io/en/latest/_modules/flax/serialization.html
-Add support for DistributedArray and ReplicatedDistributedArray serialization
-in Alpa.
+"""
+Serialization utilities for Alpa.
+Support DistributedArray and ReplicatedDistributedArray serialization in Alpa.
 """
 
 import logging

--- a/alpa/serialization.py
+++ b/alpa/serialization.py
@@ -15,8 +15,7 @@ import jax
 from jax.interpreters.pxla import ShardingSpec
 from jax.core import ShapedArray
 from jax._src.tree_util import tree_flatten, tree_leaves, tree_unflatten
-from flax.serialization import (to_state_dict, from_state_dict,
-                                _ndarray_from_bytes, _ndarray_to_bytes)
+from flax.serialization import to_state_dict, from_state_dict
 import msgpack
 import numpy as np
 import ray

--- a/alpa/serialization.py
+++ b/alpa/serialization.py
@@ -5,24 +5,20 @@ Add support for DistributedArray and ReplicatedDistributedArray serialization
 in Alpa.
 """
 
-import enum
 import logging
 import os
-import pickle
-import re
+import subprocess
 from typing import Union, Any, Sequence
 import uuid
 
-import numpy as np
-import jax
+from flax.serialization import to_state_dict, from_state_dict
 from jax.interpreters.pxla import ShardingSpec
 from jax.core import ShapedArray
-import jax.numpy as jnp
 from jax._src.tree_util import tree_flatten, tree_leaves, tree_unflatten
 from flax.serialization import (to_state_dict, from_state_dict,
                                 _ndarray_from_bytes, _ndarray_to_bytes)
 import msgpack
-import tensorstore as ts
+import numpy as np
 
 from alpa.device_mesh import (DistributedArray, ReplicatedDistributedArray,
                               PhysicalDeviceMesh)
@@ -33,136 +29,62 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 
-class _MsgpackExtType(enum.IntEnum):
-    """Messagepack custom type ids."""
-    # pylint: disable=invalid-name
-    ndarray = 1
-    native_complex = 2
-    npscalar = 3
-    distarray = 4
-    replicated_distarray = 5
+def save_checkpoint(nfs_dir: Union[str, os.PathLike], target: PyTree,
+                    step: int, local_cache_dir=None):
+    """Save a checkpoint of the `target` to `path`. 
 
-
-def _msgpack_ext_pack_wrapper(ckpt_dir):
-
-    def _get_save_path():
-        return os.path.join(ckpt_dir, uuid.uuid4().hex)
-
-    def _msgpack_ext_pack(x):
-        """Messagepack encoders for custom types."""
-        if isinstance(x, (np.ndarray, jax.xla.DeviceArray)):
-            save_dir = _get_save_path()
-            ts_store(save_dir, x)
-            return msgpack.ExtType(_MsgpackExtType.ndarray,
-                                   msgpack.packb(save_dir))
-        if np.issctype(type(x)):
-            # pack scalar as ndarray
-            return msgpack.ExtType(_MsgpackExtType.npscalar,
-                                   _ndarray_to_bytes(np.asarray(x)))
-        elif isinstance(x, complex):
-            return msgpack.ExtType(_MsgpackExtType.native_complex,
-                                   msgpack.packb((x.real, x.imag)))
-        elif isinstance(x, DistributedArray):
-            save_dir = _get_save_path()
-            x.save(save_dir)
-            return msgpack.ExtType(_MsgpackExtType.distarray,
-                                   msgpack.packb(save_dir))
-        elif isinstance(x, ReplicatedDistributedArray):
-            save_dir = _get_save_path()
-            x.replica.save(save_dir)
-            return msgpack.ExtType(_MsgpackExtType.replicated_distarray,
-                                   msgpack.packb(save_dir))
-        return x
-
-    return _msgpack_ext_pack
-
-
-def _msgpack_ext_unpack(code, data):
-    """Messagepack decoders for custom types."""
-    if code == _MsgpackExtType.ndarray:
-        return msgpack.unpackb(data)
-    elif code == _MsgpackExtType.native_complex:
-        complex_tuple = msgpack.unpackb(data)
-        return complex(complex_tuple[0], complex_tuple[1])
-    elif code == _MsgpackExtType.npscalar:
-        ar = _ndarray_from_bytes(data)
-        return ar[()]  # unpack ndarray to scalar
-    elif code == _MsgpackExtType.distarray:
-        return msgpack.unpackb(data)
-    elif code == _MsgpackExtType.replicated_distarray:
-        return msgpack.unpackb(data)
-    return msgpack.ExtType(code, data)
-
-
-def get_ts_spec(ckpt_path: str):
-    spec = {'driver': 'zarr', 'kvstore': {}, 'metadata_key': '.zarray0'}
-    if ckpt_path.startswith('gs://'):
-        m = re.fullmatch('^gs://([^/]*)/(.*)$', ckpt_path, re.DOTALL)
-        if m is None:
-            raise ValueError(
-                'The ckpt_path should contain the bucket name and the '
-                f'file path inside the bucket. Got: {ckpt_path}')
-        gcs_bucket = m.group(1)
-        path_without_bucket = m.group(2)
-        spec['kvstore'] = {
-            'driver': 'gcs',
-            'bucket': gcs_bucket,
-            'path': path_without_bucket
-        }
-    else:
-        spec['kvstore'] = {'driver': 'file', 'path': ckpt_path}
-    return spec
-
-
-def ts_store(ckpt_dir, data: Union[np.ndarray, jax.xla.DeviceArray]):
-    ts_spec = get_ts_spec(ckpt_dir)
-    dtype = data.dtype
-    if dtype == jnp.bfloat16:
-        # Tensorstore uses 'bfloat16', not '<V2'.
-        dtype = 'bfloat16'
-    else:
-        dtype = np.dtype(dtype).str
-    metadata = {
-        'shape': data.shape,
-        'chunks': data.shape,
-        'dtype': dtype,
-    }
-    ts_spec['metadata'] = metadata
-    t = ts.open(ts.Spec(ts_spec),
-                create=True,
-                open=True,
-                context=ts.Context({'file_io_concurrency': {
-                    'limit': 128
-                }})).result()
-
-    t.write(data).result()
-
-
-def save_checkpoint(ckpt_dir: Union[str, os.PathLike], target: PyTree,
-                    step: int):
-    """Save a checkpoint of the `target` to `path`.
-
-        Similar to flax.training.checkpoints.save_checkpoint, but support
-        DistributedArrays and ReplicatedDistributedArray in alpa. Also it will
-        save np.ndarray and jax.xla.DeviceArray into tensorstore for later
-        distributed loading.
-        # TODO (zhongyinmin): copy all the safe-saving stuff from
+        Similar to flax.training.checkpoints.save_checkpoint, but support DistributedArrays 
+        and ReplicatedDistributedArray in alpa. 
+        # TODO (zhongyinmin): copy all the safe-saving stuff from 
         https://flax.readthedocs.io/en/latest/_modules/flax/training/checkpoints.html#save_checkpoint
 
         Args:
-           ckpt_dir: str or pathlib-like path to store checkpoint directories
-             in.
-           target: serializable flax object, usually a trainState
+           nfs_dir: shared filesystem path to store checkpoint. 
+           target: serializable flax object, usually a trainState.
            step: training step number or other metric number
+           local_cache_dir: If not None, `save_checkpoint` will return immediately after each host saving
+           its part of the model into this cache directory. There will be background processes moving these
+           local data into `nfs_dir`.
     """
-    os.makedirs(ckpt_dir, exist_ok=True)
-    ckpt_path = os.path.join(ckpt_dir, f"checkpoint_{step}")
-    state_dict = to_state_dict(target)
-    with open(ckpt_path, 'wb') as fp:
-        fp.write(
-            msgpack.packb(state_dict,
-                          default=_msgpack_ext_pack_wrapper(ckpt_dir),
-                          strict_types=True))
+    def _get_save_path():
+        # TODO: remove random path
+        return uuid.uuid4().hex
+
+    # create directories if not exist
+    os.makedirs(nfs_dir, exist_ok=True)
+
+    if local_cache_dir is not None:
+        save_dir = local_cache_dir
+    else:
+        save_dir = nfs_dir
+
+    flat_target, target_tree = tree_flatten(target)
+    flat_metadata = []
+    background_proc_pool = []
+    for x in flat_target:
+        if isinstance(x, DistributedArray):
+            arr_dir = _get_save_path()
+            x.save(os.path.join(save_dir, arr_dir))
+            flat_metadata.append(arr_dir)
+            ## TODO: background process
+            # if local_cache_dir is not None:
+            #     p = subprocess.Popen(["mv", save_dir, nfs_dir], stdin=None, 
+            #                           stdout=None, stderr=None, shell=False)
+            #     background_proc_pool.append(p)
+
+        elif isinstance(x, ReplicatedDistributedArray):
+            arr_dir = _get_save_path()
+            x.replica.save(os.path.join(save_dir, arr_dir))
+            flat_metadata.append(arr_dir)
+            ## TODO: background process
+        else:
+            flat_metadata.append(x)
+
+    metapath = os.path.join(nfs_dir, f"checkpoint_{step}")
+    metadata = tree_unflatten(target_tree, flat_metadata)
+    with open(metapath, "wb") as metafile:
+        metafile.write(msgpack.packb(to_state_dict(metadata)))
+        
 
 class LoadInfo:
     """
@@ -210,14 +132,11 @@ def restore_checkpoint(ckpt_dir: Union[str, os.PathLike], step: int,
             step: step number to load.
             load_info: shardingSpec and deviceMesh allocation info for loading.
     """
-    ckpt_path = os.path.join(ckpt_dir, f'checkpoint_{step}')
-    with open(ckpt_path, 'rb') as fp:
-        ckpt_contents = fp.read()
-    state_dict_content = msgpack.unpackb(ckpt_contents,
-                                         ext_hook=_msgpack_ext_unpack,
-                                         raw=False)
-    state_paths, state_tree = tree_flatten(
-        from_state_dict(load_info, state_dict_content))
+    metapath = os.path.join(ckpt_dir, f"checkpoint_{step}")
+    with open(metapath, 'rb') as metafile:
+        metadata = from_state_dict(load_info, msgpack.unpackb(metafile.read()))
+
+    state_paths, state_tree = tree_flatten(metadata)
     flat_info = tree_leaves(load_info)
     flat_load_state = []
     for path, info in zip(state_paths, flat_info):
@@ -228,10 +147,9 @@ def restore_checkpoint(ckpt_dir: Union[str, os.PathLike], step: int,
             meshes, arrays = [], []
             for aval, mesh, spec in info.get_info():
                 meshes.append(mesh)
-                arrays.append(DistributedArray.load(path, aval, mesh, spec))
-            flat_load_state.append(ReplicatedDistributedArray(meshes, arrays))
+                arrays.append(DistributedArray.load(os.path.join(ckpt_dir, path), aval, mesh, spec))
+            flat_load_state.append(ReplicatedDistributedArray(meshes, arrays)) 
         else:
             aval, mesh, spec = info.get_info()
-            flat_load_state.append(DistributedArray.load(
-                path, aval, mesh, spec))
+            flat_load_state.append(DistributedArray.load(os.path.join(ckpt_dir, path), aval, mesh, spec))
     return tree_unflatten(state_tree, flat_load_state)

--- a/playground/alpa_micro_benchmark/benchmark_dist_save_load.py
+++ b/playground/alpa_micro_benchmark/benchmark_dist_save_load.py
@@ -274,8 +274,9 @@ def benchmark_mlp_dist_save():
     
     Benchmark results on local disk:
     - Two hosts:
-        TensorStore: save average run time: 19.9880 seconds, save average throughput: 1.2009 Gbps
-        np.save:     save average run time:  2.4631 seconds, save average throughput: 9.7452 Gbps
+        TensorStore:            save average run time: 19.9880 seconds, save average throughput: 1.2009 Gbps
+        np.save:                save average run time:  2.4631 seconds, save average throughput: 9.7452 Gbps
+        np.save (batch version) save average run time: 1.2081 seconds, save average throughput: 19.8683 Gbps
     """
     # Init model and optimizer
     batch_size = 64
@@ -322,8 +323,9 @@ def benchmark_mlp_dist_load():
     """
     Benchmark results on local disk:
     - two hosts:
-        TensorStore: load average run time: 4.4443 seconds, load average throughput: 5.4008 Gbps
-        np.load:     load average run time: 3.2214 seconds, load average throughput: 7.4511 Gbps
+        TensorStore:            load average run time: 4.4443 seconds, load average throughput: 5.4008 Gbps
+        np.load:                load average run time: 3.2214 seconds, load average throughput: 7.4511 Gbps
+        np.load (batch version) load average run time: 1.6163 seconds, load average throughput: 14.8510 Gbps
     """
     # Init model and optimizer
     batch_size = 64

--- a/playground/alpa_micro_benchmark/benchmark_dist_save_load.py
+++ b/playground/alpa_micro_benchmark/benchmark_dist_save_load.py
@@ -319,8 +319,8 @@ def benchmark_mlp_dist_save():
             alpa_save_checkpoint("/tmp/warmup", parallel_state, 1)
             jax.block_until_ready(parallel_state)
         else:
-            #alpa_save_checkpoint(outdir, parallel_state, 1, cachedir)
-            alpa_save_checkpoint("/tmp/warmup", parallel_state, 1)
+            alpa_save_checkpoint(outdir, parallel_state, 1, cachedir)
+            #alpa_save_checkpoint("/tmp/warmup", parallel_state, 1)
             jax.block_until_ready(parallel_state)
         duration = time.time() - start
         throughput = model_size * 32 / 1024 / 1024 / 1024 / duration
@@ -423,8 +423,8 @@ if __name__ == "__main__":
     # benchmark_dist_arr_load()
 
     # print("mlp dist save/load benchmark:")
-    benchmark_mlp_dist_save()
-    # benchmark_mlp_dist_load()
+    # benchmark_mlp_dist_save()
+    benchmark_mlp_dist_load()
     alpa.shutdown()
     
 

--- a/playground/alpa_micro_benchmark/benchmark_dist_save_load.py
+++ b/playground/alpa_micro_benchmark/benchmark_dist_save_load.py
@@ -110,7 +110,8 @@ def benchmark_ndarray_save_load(mode="flax", to_efs=True):
                 print("alpa skip load array benchmark")
                 continue
             else:
-                np.load(ckpt_path)
+                _ = jax.device_put(np.load(ckpt_path))
+                
             duration = time.time() - start
             throughput = arr.size * 32 / 1024 / 1024 / 1024 / duration
             load_tot_duration += duration
@@ -231,7 +232,7 @@ def benchmark_dist_arr_load():
     
     - two hosts:
         TensorStore: load average run time: 3.6650 seconds, load average throughput: 2.1828 Gbps
-        np.load:        
+        np.load:     load average run time: 0.7644 seconds, load average throughput: 10.4655 Gbps
 
     """
     device_cluster = get_global_cluster()
@@ -252,7 +253,9 @@ def benchmark_dist_arr_load():
 
         # load benchmark
         start = time.time()
+        print("start", time.time())
         _ = DistributedArray.load(outdir, jax.ShapedArray(arr.shape, jnp.int32), physical_mesh, sharding_spec)
+        print("end", time.time())
         duration = time.time() - start
         throughput = arr.size * 32 / 1024 / 1024 / 1024 / duration
         if i >= 1:
@@ -272,7 +275,7 @@ def benchmark_mlp_dist_save():
     Benchmark results on local disk:
     - Two hosts:
         TensorStore: save average run time: 19.9880 seconds, save average throughput: 1.2009 Gbps
-        np.save:    
+        np.save:     save average run time:  2.4631 seconds, save average throughput: 9.7452 Gbps
     """
     # Init model and optimizer
     batch_size = 64
@@ -320,7 +323,7 @@ def benchmark_mlp_dist_load():
     Benchmark results on local disk:
     - two hosts:
         TensorStore: load average run time: 4.4443 seconds, load average throughput: 5.4008 Gbps
-        np.load:    
+        np.load:     load average run time: 3.2214 seconds, load average throughput: 7.4511 Gbps
     """
     # Init model and optimizer
     batch_size = 64

--- a/playground/alpa_micro_benchmark/benchmark_dist_save_load.py
+++ b/playground/alpa_micro_benchmark/benchmark_dist_save_load.py
@@ -1,0 +1,172 @@
+import os
+import subprocess
+import time
+import timeit
+from tempfile import TemporaryFile, TemporaryDirectory
+
+from flax.training.checkpoints import save_checkpoint 
+import jax
+import jax.numpy as jnp
+from jax import random
+import numpy as np
+
+
+import alpa
+from alpa import save_checkpoint as alpa_save_checkpoint
+from alpa import restore_checkpoint as alpa_restore_checkpoint
+from alpa.testing import (MLPModel, BertLayerModel, create_train_state,
+                          get_bert_layer_train_step, get_mlp_train_step,
+                          assert_allclose)
+from alpa.device_mesh import get_global_cluster
+
+def _get_efs_mount_point():
+    # Hacky function to get the EFS mount point
+    for line in subprocess.check_output("df -h", shell=True).decode().split('\n'):
+        cols = line.split(' ')
+        if "efs" in cols[0]:
+            return cols[-1]+"/"
+    return None
+
+def _get_save_prefix():
+    device_cluster = get_global_cluster()
+    if len(device_cluster.host_info) > 1:
+        # Get EFS mount point for the multi-host test
+        save_prefix = _get_efs_mount_point()
+    else:
+        # Use tmp dir for the single-host test
+        save_prefix = "/tmp/"
+    return save_prefix
+
+LOOP_CNT=5
+
+def benchmark_ndarray_save_load(mode="flax", to_efs=True):
+    """
+    Save/Load path is set under the EFS filesystem.
+    EFS performance: https://docs.aws.amazon.com/efs/latest/ug/performance.html
+
+    if mode == "flax": use flax.training.checkpoints.save_checkpoint/restore_checkpoint
+    elif mode == "numpy: use np.save/load
+
+    Benchmark results on EFS: 
+    - flax.save_checkpoint: average run time: 1.482362699508667 seconds, average throughput: 0.6749969769443334 Gbps
+    - alpa.save_checkpoint: average run time: 1.336690330505371 seconds, average throughput: 0.7484693878347961 Gbps
+    - np.save: average run time: 1.2787351608276367 seconds, average throughput: 0.7874443325181828 Gbps
+
+    Benchmark results on local filesystem:
+    - flax.save_checkpoint: average run time: 0.6772919178009034 seconds, average throughput: 1.4764804301530936 Gbps
+    - alpa.save_checkpoint: average run time: 0.8362024784088135 seconds, average throughput: 1.2280585577116316 Gbps
+    - np.save: average run time: 0.09975528717041016 seconds, average throughput: 10.024606837849765 Gbps
+    """
+    rngkey = random.PRNGKey(0)
+    #arr_sizes = [1024*1024, 4*1024*1024, 16*1024*1024, 32*1024*1024] # 4M, 16M, 64M, 128M
+    arr_sizes = [32*1024*1024] # 128M
+    benchmark_arrs = [random.normal(rngkey, (arr_size,)) for arr_size in arr_sizes]
+    for arr in benchmark_arrs:
+        tot_duration = 0.0
+        tot_throughput = 0.0
+        for i in range(LOOP_CNT):
+            if to_efs:
+                outdir = TemporaryDirectory(prefix=_get_save_prefix()).name
+            else:
+                outdir = TemporaryDirectory().name
+            print (f"save to {outdir}")
+
+            start = time.time()
+            if mode == "flax":
+                save_checkpoint(outdir, arr, i)
+            elif mode == "alpa":
+                alpa_save_checkpoint(outdir, arr, i)
+            else:
+                os.makedirs(outdir, exist_ok=True)
+                ckpt_path = os.path.join(outdir, f"checkpoint_1")
+                np.save(ckpt_path, arr)
+            duration = time.time() - start
+
+            throughput = arr.size * 32 / 1024 / 1024 / 1024 / duration
+            tot_duration += duration
+            tot_throughput += throughput
+            print(f"loop {i}, time: {duration} seconds, throughput: {throughput} Gbps")
+        print(f"average run time: {tot_duration/LOOP_CNT} seconds, average throughput: {tot_throughput/LOOP_CNT} Gbps")
+
+def count_params(model):
+    return sum(x.size for x in jax.tree_leaves(model))
+
+def benchmark_mlp_save_load(mode="flax", to_efs=True):
+    """
+    Benchmark results on EFS: 
+    - flax.save_checkpoint: average run time: 45.19087886810303 seconds, average throughput: 0.5313484040513637 Gbps
+    - alpa.save_checkpoint: average run time: 16.15189399719238, average throughput: 1.4860819837013484 Gbps
+
+    Benchmark results on local disk:
+    - flax.save_checkpoint: average run time: 16.1341721534729, average throughput: 1.4877078603042466 Gbps
+    - alpa.save_checkpoint: average run time: 10.663438653945922, average throughput: 2.2509621962263244 Gbps
+    """
+    # Init model and optimizer
+    batch_size = 64
+    hidden_dim = 8192 # 3072M
+    input_dim = output_dim = hidden_dim
+    model = MLPModel(hidden_dim=hidden_dim,
+                        output_dim=output_dim,
+                        manual_pipeline_layer=True)
+
+    # Init batch args
+    rngkey = random.PRNGKey(0)
+    x = random.normal(rngkey, (batch_size, input_dim), jnp.float32)
+    state = create_train_state(rngkey, model, [x])
+    model_size = count_params(state)
+    print(f"model size: {model_size * 4 / 1024 / 1024} MB")
+
+    tot_duration = 0.0
+    tot_throughput = 0.0
+    for i in range(LOOP_CNT):
+        outdir = TemporaryDirectory(prefix=_get_save_prefix()).name
+        if to_efs:
+            outdir = TemporaryDirectory(prefix=_get_save_prefix()).name
+        else:
+            outdir = TemporaryDirectory().name
+
+        start = time.time()
+        if mode == "flax":
+            save_checkpoint(outdir, state, i)
+        else:
+            alpa_save_checkpoint(outdir, state, i)
+        duration = time.time() - start
+
+        throughput = model_size * 32 / 1024 / 1024 / 1024 / duration
+        tot_duration += duration
+        tot_throughput += throughput
+        print(f"loop {i}, time: {duration} seconds, throughput: {throughput} Gbps")
+    print(f"average run time: {tot_duration/LOOP_CNT}, average throughput: {tot_throughput/LOOP_CNT} Gbps")
+
+
+
+if __name__ == "__main__":
+    alpa.init(cluster="ray")
+    # print("ndarray benchmark on EFS:")
+    # print("flax")
+    # benchmark_ndarray_save_load(mode="flax")
+    # print("\nalpa")
+    # benchmark_ndarray_save_load(mode="alpa")
+    # print("\nnumpy")
+    # benchmark_ndarray_save_load(mode="numpy")
+
+    print("ndarray benchmark on local disk:") 
+    print("flax")
+    benchmark_ndarray_save_load(mode="flax", to_efs=False)
+    print("\nalpa")
+    benchmark_ndarray_save_load(mode="alpa", to_efs=False)
+    print("\nnumpy")
+    benchmark_ndarray_save_load(mode="numpy", to_efs=False)
+
+    # print("mlp benchmark on EFS:")
+    # benchmark_mlp_save_load(mode="flax")
+    # benchmark_mlp_save_load(mode="alpa")
+
+    # print("mlp benchmark on local disk:")
+    # benchmark_mlp_save_load(mode="flax", to_efs=False)
+    # benchmark_mlp_save_load(mode="alpa", to_efs=False)
+
+
+    alpa.shutdown()
+    
+

--- a/playground/alpa_micro_benchmark/benchmark_dist_save_load.py
+++ b/playground/alpa_micro_benchmark/benchmark_dist_save_load.py
@@ -14,7 +14,7 @@ import numpy as np
 import alpa
 from alpa import save_checkpoint as alpa_save_checkpoint
 from alpa import restore_checkpoint as alpa_restore_checkpoint
-from alpa import PipeshardParallel  
+from alpa import PipeshardParallel, DistributedArray
 from alpa.testing import (MLPModel, BertLayerModel, create_train_state,
                           get_bert_layer_train_step, get_mlp_train_step,
                           assert_allclose)
@@ -37,7 +37,7 @@ def _get_save_prefix(to_efs):
         save_prefix = "/tmp/"
     return save_prefix
 
-LOOP_CNT=5
+LOOP_CNT=1
 
 def benchmark_ndarray_save_load(mode="flax", to_efs=True):
     """
@@ -52,6 +52,7 @@ def benchmark_ndarray_save_load(mode="flax", to_efs=True):
     - flax.restore_checkpoint: load average run time:  6.8287 seconds, load average throughput: 1.2225 Gbps
 
     - alpa.save_checkpoint:    save average run time: 12.8583 seconds, save average throughput: 0.6222 Gbps
+                 use cache:    
     - alpa.restore_checkpoint: N/A
 
     - np.save:                 save average run time: 10.4157 seconds, save average throughput: 0.7682 Gbps
@@ -92,7 +93,7 @@ def benchmark_ndarray_save_load(mode="flax", to_efs=True):
             if mode == "flax":
                 save_checkpoint(outdir, arr, i)
             elif mode == "alpa":
-                alpa_save_checkpoint(outdir, arr, i)
+                alpa_save_checkpoint(outdir, arr, i, "/tmp")
             else:
                 np.save(ckpt_path, arr)
             duration = time.time() - start
@@ -127,6 +128,7 @@ def benchmark_mlp_save(mode="flax", to_efs=True):
     Benchmark results on EFS: 
     - flax.save_checkpoint: average run time: 45.19087886810303 seconds, average throughput: 0.5313484040513637 Gbps
     - alpa.save_checkpoint: average run time: 16.15189399719238, average throughput: 1.4860819837013484 Gbps
+                 use cache: 
     - np.save:              average run time: 20.618193340301513, average throughput: 1.1642373201358331 Gbps
 
     Benchmark results on local disk:
@@ -166,7 +168,7 @@ def benchmark_mlp_save(mode="flax", to_efs=True):
         if mode == "flax":
             save_checkpoint(outdir, state, i)
         elif mode == "alpa":
-            alpa_save_checkpoint(outdir, state, i)
+            alpa_save_checkpoint(outdir, state, i, "/tmp")
         else:
             np.save(ckpt_path, state.params)
             np.save(ckpt_path, state.opt_state)
@@ -177,6 +179,62 @@ def benchmark_mlp_save(mode="flax", to_efs=True):
         tot_throughput += throughput
         print(f"loop {i}, time: {duration} seconds, throughput: {throughput} Gbps")
     print(f"average run time: {tot_duration/LOOP_CNT}, average throughput: {tot_throughput/LOOP_CNT} Gbps")
+
+def benchmark_dist_arr_save_load(to_efs=False):
+    """
+    Benchmark results on local disk:
+    - one host:
+        save average run time: 28.0506 seconds, save average throughput: 0.2852 Gbps
+        load average run time: 2.3506 seconds, load average throughput: 3.4035 Gbps
+
+    - two hosts:
+        save average run time: 16.3754 seconds, save average throughput: 0.4885 Gbps
+        load average run time: 1.2287 seconds, load average throughput: 6.5110 Gbps
+    """
+    device_cluster = get_global_cluster()
+    physical_mesh = device_cluster.get_physical_mesh()
+    logical_mesh = physical_mesh.get_logical_mesh()
+
+    rngkey = random.PRNGKey(0)
+    arr_shape = (16*1024, 16*1024) #1GB
+    arr = random.normal(rngkey, arr_shape)
+
+    sharding_spec = logical_mesh.make_tile_spec(arr, [0, 1], [0, 1])
+    input_indices = sharding_spec.indices(arr.shape).flatten()
+    (dist_arr,) = physical_mesh.shard_args_to_arrays(
+        (jax.ShapedArray(arr.shape, jnp.int32),),
+        (input_indices,), (sharding_spec,), (arr,))
+
+    save_prefix = _get_save_prefix(to_efs)
+    save_tot_duration = 0.0
+    save_tot_throughput = 0.0
+    load_tot_duration = 0.0
+    load_tot_throughput = 0.0
+    for i in range(LOOP_CNT):
+        # Save the DistributedArray (one replica only)
+        outdir = TemporaryDirectory(prefix=save_prefix)
+        subprocess.run(["rm", "-rf", outdir.name])
+        print(f"save to {outdir}")
+
+        # save benchmark
+        start = time.time()
+        dist_arr.save(outdir.name)
+        duration = time.time() - start
+        throughput = arr.size * 32 / 1024 / 1024 / 1024 / duration
+        save_tot_duration += duration
+        save_tot_throughput += throughput
+        print(f"loop {i} save, time: {duration:.4f} seconds, throughput: {throughput:.4f} Gbps")
+
+        # load benchmark
+        start = time.time()
+        _ = DistributedArray.load(outdir.name, jax.ShapedArray(arr.shape, jnp.int32), physical_mesh, sharding_spec)
+        duration = time.time() - start
+        throughput = arr.size * 32 / 1024 / 1024 / 1024 / duration
+        load_tot_duration += duration
+        load_tot_throughput += throughput
+        print(f"loop {i} load, time: {duration:.4f} seconds, throughput: {throughput:.4f} Gbps")
+    print(f"save average run time: {save_tot_duration/LOOP_CNT:.4f} seconds, save average throughput: {save_tot_throughput/LOOP_CNT:.4f} Gbps")
+    print(f"load average run time: {load_tot_duration/LOOP_CNT:.4f} seconds, load average throughput: {load_tot_throughput/LOOP_CNT:.4f} Gbps")
 
 def benchmark_mlp_dist_save_load():
     """
@@ -271,8 +329,9 @@ if __name__ == "__main__":
     # benchmark_mlp_save(mode="numpy", to_efs=False)
 
     # print("mlp dist save/load benchmark:")
-    benchmark_mlp_dist_save_load()
+    # benchmark_mlp_dist_save_load()
 
+    benchmark_dist_arr_save_load()
     alpa.shutdown()
     
 

--- a/tests/test_dist_save_load.py
+++ b/tests/test_dist_save_load.py
@@ -95,25 +95,30 @@ class DistSaveLoadTest(unittest.TestCase):
                                      [[5], [7]]])
         self.check_dist_array_eq(desired_buffers1, dist_input_data1)
 
-        with tempfile.TemporaryDirectory(prefix=save_prefix) as tmpdir:
-            # Save the DistributedArray (one replica only)
-            dist_input_data1.save(tmpdir)
+        # cached save/load
+        with tempfile.TemporaryDirectory(prefix=save_prefix) as ckpt_dir:
+            with tempfile.TemporaryDirectory(prefix="/tmp/") as cache_dir:
+                # Save the DistributedArray (one replica only)
+                dist_input_data1.save(ckpt_dir, cache_dir)
 
-            # Load previously saved DistributedArray with a different shardingSpec
-            # [[0,1],          [[0,1],  [[0,1],
-            #  [2,3],  shard    [2,3]]   [2,3]]
-            #  [4,5],  ====>   [[4,5],  [[4,5],
-            #  [6,7]]           [6,7]]   [6,7]]
-            load_sharding_spec = logical_mesh.make_tile_spec(
-                global_input_data1, [0, 1], [0])
-            dist_load_data1 = DistributedArray.load(
-                tmpdir, jax.ShapedArray(global_input_data1.shape, jnp.int32),
-                physical_mesh, load_sharding_spec)
+                # Sync all the move workers 
+                physical_mesh.sync_move_workers()
 
-            # Check the DistributedArray's remote buffers
-            desired_buffers2 = np.array([[[0, 1], [2, 3]], [[0, 1], [2, 3]],
-                                        [[4, 5], [6, 7]], [[4, 5], [6, 7]]])
-            self.check_dist_array_eq(desired_buffers2, dist_load_data1)
+                # Load previously saved DistributedArray with a different shardingSpec
+                # [[0,1],          [[0,1],  [[0,1],
+                #  [2,3],  shard    [2,3]]   [2,3]]
+                #  [4,5],  ====>   [[4,5],  [[4,5],
+                #  [6,7]]           [6,7]]   [6,7]]
+                load_sharding_spec = logical_mesh.make_tile_spec(
+                    global_input_data1, [0, 1], [0])
+                dist_load_data1 = DistributedArray.load(
+                    ckpt_dir, jax.ShapedArray(global_input_data1.shape, jnp.int32),
+                    physical_mesh, load_sharding_spec)
+
+                # Check the DistributedArray's remote buffers
+                desired_buffers2 = np.array([[[0, 1], [2, 3]], [[0, 1], [2, 3]],
+                                            [[4, 5], [6, 7]], [[4, 5], [6, 7]]])
+                self.check_dist_array_eq(desired_buffers2, dist_load_data1)
 
         # Cleanup
         physical_mesh.shutdown()
@@ -157,7 +162,7 @@ class DistSaveLoadTest(unittest.TestCase):
         # Check results
         assert_allclose(serial_state.params, load_state.params, 1e-3, 1e-3)
 
-    def test_distributed_mlp_save_load(self):
+    def test_distributed_mlp_uncached_save_load(self):
         save_prefix = self._get_save_prefix()
 
         # Init model and optimizer
@@ -188,6 +193,7 @@ class DistSaveLoadTest(unittest.TestCase):
         parallel_state = parallel_train_step(parallel_state, batch)[0]
         assert_allclose(serial_state.params, parallel_state.params, 1e-3, 1e-3)
 
+        # uncached save/load
         with tempfile.TemporaryDirectory(prefix=save_prefix) as ckpt_dir:
             # Save checkpoint
             save_checkpoint(ckpt_dir, parallel_state, 1)
@@ -199,11 +205,10 @@ class DistSaveLoadTest(unittest.TestCase):
             # Run after load
             serial_state = serial_train_step(serial_state, batch)[0]
             load_state = parallel_train_step(load_state, batch)[0]
-
         # Check results
         assert_allclose(serial_state.params, load_state.params, 1e-3, 1e-3)
 
-    def test_distributed_bert_save_load(self):
+    def test_distributed_bert_cached_save_load(self):
         save_prefix = self._get_save_prefix()
 
         # Config
@@ -252,18 +257,22 @@ class DistSaveLoadTest(unittest.TestCase):
         parallel_state = parallel_train_step(parallel_state, batch)[0]
         assert_allclose(serial_state.params, parallel_state.params, 1e-3, 1e-3)
 
+        # cached save/load
         with tempfile.TemporaryDirectory(prefix=save_prefix) as ckpt_dir:
-            # Save checkpoint
-            save_checkpoint(ckpt_dir, parallel_state, 1)
+            with tempfile.TemporaryDirectory(prefix="/tmp/") as cache_dir:
+                # Save checkpoint
+                save_checkpoint(ckpt_dir, parallel_state, 1, cache_dir)
 
-            # Restore checkpoint
-            state_ss, _ = executable.get_load_info()
-            load_state = restore_checkpoint(ckpt_dir, 1, state_ss)
+                # Sync all the move workers 
+                executable.sync_move_workers()
 
-            # Run after load
-            serial_state = serial_train_step(serial_state, batch)[0]
-            load_state = parallel_train_step(load_state, batch)[0]
+                # Restore checkpoint
+                state_ss, _ = executable.get_load_info()
+                load_state = restore_checkpoint(ckpt_dir, 1, state_ss)
 
+                # Run after load
+                serial_state = serial_train_step(serial_state, batch)[0]
+                load_state = parallel_train_step(load_state, batch)[0]
         # Check results
         assert_allclose(serial_state.params, load_state.params, 1e-3, 1e-3)
 
@@ -272,8 +281,8 @@ def suite():
     suite = unittest.TestSuite()
     suite.addTest(DistSaveLoadTest("test_distributed_array_save_load"))
     suite.addTest(DistSaveLoadTest("test_jax_mlp_save_dist_load"))
-    suite.addTest(DistSaveLoadTest("test_distributed_mlp_save_load"))
-    suite.addTest(DistSaveLoadTest("test_distributed_bert_save_load"))
+    suite.addTest(DistSaveLoadTest("test_distributed_mlp_uncached_save_load"))
+    suite.addTest(DistSaveLoadTest("test_distributed_bert_cached_save_load"))
     return suite
 
 

--- a/tests/test_dist_save_load.py
+++ b/tests/test_dist_save_load.py
@@ -101,7 +101,7 @@ class DistSaveLoadTest(unittest.TestCase):
                 # Save the DistributedArray (one replica only)
                 dist_input_data1.save(ckpt_dir, cache_dir)
 
-                # Sync all the move workers 
+                # Sync all the move workers
                 physical_mesh.sync_move_workers()
 
                 # Load previously saved DistributedArray with a different shardingSpec
@@ -112,12 +112,14 @@ class DistSaveLoadTest(unittest.TestCase):
                 load_sharding_spec = logical_mesh.make_tile_spec(
                     global_input_data1, [0, 1], [0])
                 dist_load_data1 = DistributedArray.load(
-                    ckpt_dir, jax.ShapedArray(global_input_data1.shape, jnp.int32),
+                    ckpt_dir,
+                    jax.ShapedArray(global_input_data1.shape, jnp.int32),
                     physical_mesh, load_sharding_spec)
 
                 # Check the DistributedArray's remote buffers
                 desired_buffers2 = np.array([[[0, 1], [2, 3]], [[0, 1], [2, 3]],
-                                            [[4, 5], [6, 7]], [[4, 5], [6, 7]]])
+                                             [[4, 5], [6, 7]], [[4, 5], [6,
+                                                                         7]]])
                 self.check_dist_array_eq(desired_buffers2, dist_load_data1)
 
         # Cleanup
@@ -263,7 +265,7 @@ class DistSaveLoadTest(unittest.TestCase):
                 # Save checkpoint
                 save_checkpoint(ckpt_dir, parallel_state, 1, cache_dir)
 
-                # Sync all the move workers 
+                # Sync all the move workers
                 executable.sync_move_workers()
 
                 # Restore checkpoint


### PR DESCRIPTION
This PR improves alpa's model checkpoint functions according to #466.
# Format
- The on-disk file names are readable and deterministic.
I dfs the pytree and construct the filename according to the path from the root to leaf. 
For example: 
```
state = {"step": 1, "params": {"x": arr1, "b": arr2}, "list": [elem1, elem2]}
```
The paths for each element will be:
```
1 => state.step
arr1 => state.params.x
arr2 => state.params.b
elem1 => state.list.0
elem2 => state.list.1
```
- The paths stored in metadata are relative paths.

# Speed
All the benchmark results are in `alpa/playground/alpa_micro_benchmark/benchmark_dist_save_load.py`.
The peak bandwidth of load is measured by running a jax program that reads a 1GB numpy array from disk to local GPU memory. Ditto for save. The results are as followed:
```
np.save:                 save average run time: 0.8104 seconds, save average throughput:  9.8718 Gbps
np.load:                load average run time: 0.7327 seconds, load average throughput: 10.9179 Gbps
```
To achieve the peak bandwidth, I applied several optimizations: (1) I replaced tensorstore with np.save/load (2) batch the ray remote calls (3) write all the data into local disk instead of EFS.
To compare with the peak bandwidth, I shard a 1GB numpy array on a 1x4 mesh to get a DistributedArray, and save it to disk. Ditto for load. The results are as followed:
```
alpa.save:      save average run time: 0.8113 seconds, save average throughput: 9.8601 Gbps
alpa.load:     load average run time: 1.5235 seconds, load average throughput: 5.2512 Gbps
```
The alpa.load is two times slower than the peek bandwidth because the array is saved into several shards during alpa.save. To load the array, I need to read all the shards, construct the complete array and get the new shard according to the new shardingspec. I profile the code, and find [this assignment](https://github.com/PKUFlyingPig/alpa/blob/81855da44b3888e5506a11a365d479875be4a88f/alpa/serialization.py#L69) is which the overhead comes from (not np.load, but just the assignment). 
I also benchmarked the alpa.save/load on a 3GB MLP model which parallelled on a 2x4 mesh. The results are as followed:
```
alpa.save:  save average run time: 1.2081 seconds, save average throughput: 19.8683 Gbp
alpa.load: load average run time: 1.6163 seconds, load average throughput: 14.8510 Gbps
```
I may do more experiments to further improve the performance, but current version is much faster than the previous version. It should save/load the 170GB OPT model in 2-3 minutes.