### PR TITLE
[FEATURE] Support beam sample

### DIFF
--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -47,12 +47,11 @@ import ray
 from alpa import mesh_profiling
 import alpa.collective as col
 from alpa.global_env import global_config
-from alpa.parallel_plan import StagePlan
 from alpa.monkey_patch import set_override_backend
 from alpa.shard_parallel.auto_sharding import (AutoShardingOption,
                                                LogicalDeviceMesh,
                                                run_spmd_partitioner_pass)
-from alpa.parallel_plan import PlacementSpec
+from alpa.parallel_plan import PlacementSpec, StagePlan
 from alpa.timer import timers
 from alpa.util import (benchmark_func, list_gpu_info, OrderedSet,
                        update_jax_platform, is_ray_node_resource,

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -1552,7 +1552,7 @@ class DistributedArray:
                                                    self.device_mesh.num_devices)
 
             as_option = AutoShardingOption()
-            strategy_config = StagePlan(global_config.build_random_seed,
+            strategy_config = StagePlan(global_config.compile_random_seed,
                                         self.device_mesh.shape, 1 << 60,
                                         as_option.all_reduce_threshold, None,
                                         -1)

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -32,7 +32,7 @@ from typing import Any, List, Union, Sequence, Tuple, Optional
 import jax
 from jax import core, xla, device_put
 from jax._src.api import ShapeDtypeStruct
-from jax._src.lib import xla_bridge as xb, xla_extension as xe
+from jax._src.lib import xla_bridge as xb, xla_client as xc, xla_extension as xe
 from jax._src.tree_util import tree_leaves
 from jax.abstract_arrays import array_types
 from jax.core import ShapedArray
@@ -47,12 +47,16 @@ import ray
 from alpa import mesh_profiling
 import alpa.collective as col
 from alpa.global_env import global_config
+from alpa.parallel_plan import StagePlan
 from alpa.monkey_patch import set_override_backend
-from alpa.shard_parallel.auto_sharding import LogicalDeviceMesh
+from alpa.shard_parallel.auto_sharding import (AutoShardingOption,
+                                               LogicalDeviceMesh,
+                                               run_spmd_partitioner_pass)
 from alpa.parallel_plan import PlacementSpec
 from alpa.timer import timers
 from alpa.util import (benchmark_func, list_gpu_info, OrderedSet,
-                       update_jax_platform, is_ray_node_resource)
+                       update_jax_platform, is_ray_node_resource,
+                       get_index_select_computation)
 
 if global_config.nccl_mode == "cupy":
     import alpa.collective.worker_nccl_util_cupy as worker_nccl_util
@@ -608,6 +612,7 @@ class PhysicalDeviceMesh(ABC):
     num_hosts: int
     num_devices_per_host: int
     mesh_id: int
+    operation_executables: dict
 
     def get_signature(self) -> str:
         """Return a signature string that contains the mesh shape and GPU
@@ -810,6 +815,7 @@ class LocalPhysicalDeviceMesh(PhysicalDeviceMesh):
         self.num_devices_per_host = len(self.devices)
         self.mesh_id = 0
         self.device_strs = []
+        self.operation_executables = {}
 
         self.set_runtime_random_seed(global_config.runtime_random_seed)
 
@@ -898,6 +904,7 @@ class LocalPhysicalDeviceMesh(PhysicalDeviceMesh):
 
     def shutdown(self, forced=False):
         self.sync_workers()
+        self.operation_executables.clear()
 
 
 def device_id_to_str(host_ip, device_id, device_type="gpu"):
@@ -934,6 +941,7 @@ class DistributedPhysicalDeviceMesh(PhysicalDeviceMesh):
         self.workers = None
         self.launched = False
         self.service_server = None
+        self.operation_executables = {}
 
         if devices is not None:
             if len(devices) != len(host_ids):
@@ -1301,6 +1309,7 @@ class DistributedPhysicalDeviceMesh(PhysicalDeviceMesh):
         if not self.launched:
             return
         if not forced:
+            self.operation_executables.clear()
             ray.get([w.shutdown.remote() for w in self.workers])
         for worker in self.workers:
             ray.kill(worker)
@@ -1309,6 +1318,7 @@ class DistributedPhysicalDeviceMesh(PhysicalDeviceMesh):
         self.service_server.shutdown()
         self.service_server = None
         self.launched = False
+        self.operation_executables.clear()  # clear with forced shutdown
 
 
 ########################################
@@ -1525,6 +1535,34 @@ class DistributedArray:
 
     # TODO(lmzheng): copy more functions from DeviceArray
     #   (jax/_src/device_array.py)
+    def index_select(self, dim, index):
+        """Compile and run index select operation."""
+        # pylint: disable=import-outside-toplevel
+        from alpa.mesh_executable import NormalMeshDriverExecutable
+        if type(index) not in [ShapedArray, ShapeDtypeStruct]:
+            index = xla.canonicalize_dtype(index)
+        index_shape = xc.shape_from_pyval(index)
+        key = hash(("index_select", self.aval, dim, index_shape))
+        if key in self.device_mesh.operation_executables:
+            executable = self.device_mesh.operation_executables[key]
+        else:
+            index_aval = ShapedArray(index.shape, index.dtype)
+            c = get_index_select_computation(self.sharding_spec, dim, self.aval,
+                                             index_shape).as_hlo_module()
+            hlo_module = run_spmd_partitioner_pass(c,
+                                                   self.device_mesh.num_devices)
+
+            as_option = AutoShardingOption()
+            strategy_config = StagePlan(global_config.build_random_seed,
+                                        self.device_mesh.shape, 1 << 60,
+                                        as_option.all_reduce_threshold, None,
+                                        -1)
+            executable = NormalMeshDriverExecutable(self.device_mesh,
+                                                    hlo_module, strategy_config,
+                                                    [self.aval, index_aval],
+                                                    [self.aval], [False, False])
+            self.device_mesh.operation_executables[key] = executable
+        return executable.launch_on_driver(self, index)
 
     def __str__(self):
         return (f"DistributedArray(sharding_spec={self.sharding_spec}, "

--- a/alpa/util.py
+++ b/alpa/util.py
@@ -543,6 +543,23 @@ def compile_concatenate(backend, mesh_shape, sharding_spec, batch_size,
     return hlo_proto
 
 
+def get_index_select_computation(sharding_spec, dim, aval, index_shape):
+    sharding = pxla.sharding_spec_sharding_proto(sharding_spec)
+    c = xc.XlaBuilder("index_select")
+    c.set_sharding(sharding)
+    operand = xc.ops.Parameter(
+        c, 0, xc.shape_from_pyval(np.ones(aval.shape, aval.dtype)))
+    c.clear_sharding()
+    index = xc.ops.Parameter(c, 1, index_shape)
+    index_selected = xc.ops.IndexSelect(operand, index, dim)
+    sharding2 = xc.OpSharding()
+    sharding2.type = sharding.type.TUPLE
+    sharding2.tuple_shardings = [sharding]
+    c.set_sharding(sharding2)
+    c = c.build(xc.ops.Tuple(c, [index_selected]))
+    return c
+
+
 def get_shard_shape(aval: ShapedArray, sharding_spec: pxla.ShardingSpec):
     """Return the shape of a shard."""
     shape = []

--- a/examples/opt_serving/model/opt_model.py
+++ b/examples/opt_serving/model/opt_model.py
@@ -679,9 +679,6 @@ def get_pipeshard_executable(config,
                              support_output_attentions=False,
                              support_output_hidden_states=False,
                              autoregressive=True):
-    if autoregressive:
-        assert num_micro_batches == 1, "we only support num_micro_batches=1 for autoregressive!"
-        assert batch_size == 1, "we only support batch_sie = 1 for autoregressive!"
 
     # Init model
     model, params = init_model_aval(config)

--- a/examples/opt_serving/model/opt_model.py
+++ b/examples/opt_serving/model/opt_model.py
@@ -529,7 +529,7 @@ def init_model_aval(config):
 
 
 def init_cache_aval(config, batch_size):
-    dtype = jnp.float32
+    dtype = config.dtype
     head_dim = config.decoder_embed_dim // config.decoder_attention_heads
 
     all_cache = []

--- a/examples/opt_serving/model/wrapper.py
+++ b/examples/opt_serving/model/wrapper.py
@@ -240,8 +240,7 @@ def get_model(model_name: str,
         config = get_opt_config(name,
                                 num_pp_stages=None,
                                 mark_boundary=False,
-                                dtype=dtype,
-                                batch_size=batch_size * num_beams)
+                                dtype=dtype)
         transformer_config = TransformerModelConfig(
             H=config.decoder_embed_dim,
             L=config.decoder_layers,
@@ -266,8 +265,7 @@ def get_model(model_name: str,
 
         alpa.init()
         num_pp_stages = max(2, alpa.get_global_cluster().num_hosts)
-        config = get_opt_config(name, num_pp_stages=num_pp_stages, dtype=dtype,
-                                batch_size=batch_size * num_beams)
+        config = get_opt_config(name, num_pp_stages=num_pp_stages, dtype=dtype)
         transformer_config = TransformerModelConfig(
             H=config.decoder_embed_dim,
             L=config.decoder_layers,
@@ -290,6 +288,7 @@ def get_model(model_name: str,
         if autoregressive:
             init_cache = init_cache_dis_array(executable,
                                               config,
+                                              batch_size,
                                               dummy=dummy)
             set_skip_shard_args_check(init_cache)
         executable.sync()

--- a/examples/opt_serving/model/wrapper.py
+++ b/examples/opt_serving/model/wrapper.py
@@ -241,7 +241,7 @@ def get_model(model_name: str,
                                 num_pp_stages=None,
                                 mark_boundary=False,
                                 dtype=dtype,
-                                num_batch=batch_size * num_beams)
+                                batch_size=batch_size * num_beams)
         transformer_config = TransformerModelConfig(
             H=config.decoder_embed_dim,
             L=config.decoder_layers,
@@ -267,7 +267,7 @@ def get_model(model_name: str,
         alpa.init()
         num_pp_stages = max(2, alpa.get_global_cluster().num_hosts)
         config = get_opt_config(name, num_pp_stages=num_pp_stages, dtype=dtype,
-                                num_batch=batch_size * num_beams)
+                                batch_size=batch_size * num_beams)
         transformer_config = TransformerModelConfig(
             H=config.decoder_embed_dim,
             L=config.decoder_layers,
@@ -290,7 +290,6 @@ def get_model(model_name: str,
         if autoregressive:
             init_cache = init_cache_dis_array(executable,
                                               config,
-                                              1,
                                               dummy=dummy)
             set_skip_shard_args_check(init_cache)
         executable.sync()

--- a/examples/opt_serving/textgen_demo.py
+++ b/examples/opt_serving/textgen_demo.py
@@ -7,16 +7,21 @@ from examples.opt_serving.model.wrapper import get_model
 tokenizer = AutoTokenizer.from_pretrained("facebook/opt-30b", use_fast=False)
 tokenizer.add_bos_token = False
 
+num_beams = 1
 # Load the model
 model = get_model(model_name="alpa/opt-2.7b",
                   device="cuda",
-                  path="/home/ubuntu/opt_weights/")
+                  path="/home/ubuntu/efs/parax-proj/",
+                  num_beams=num_beams)
 
 # Generate
 prompt = "Paris is the capital city of"
 
 input_ids = tokenizer(prompt, return_tensors="pt").input_ids.to("cuda")
-output = model.generate(input_ids=input_ids, max_length=256, do_sample=True)
+output = model.generate(input_ids=input_ids,
+                        max_length=256,
+                        do_sample=True,
+                        num_beams=num_beams)
 generated_string = tokenizer.batch_decode(output, skip_special_tokens=True)
 
 print(generated_string)


### PR DESCRIPTION
This PR adds reorder cache function to support the beam sample. It modifies some apis in `opt_serving/model/wrapper.py` to add config for beam number.