### PR TITLE
fix `num_host`

### DIFF
--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -1987,7 +1987,7 @@ class DeviceCluster:
 
     @property
     def num_hosts(self):
-        return sum(self.host_info)
+        return len(self.host_info)
 
     def get_physical_mesh(self,
                           host_ids: Sequence[int] = None,


### PR DESCRIPTION
```python
host_info = [{'NodeID': '7a4a9521b1e383121a6af17718cba9154729f1eb0d344af35cb11959', 'Alive': True, 'NodeManagerAddress': '10.0.1.138', 'NodeManagerHostname': 'ip-10-0-1-138', 'NodeManagerPort': 34745, 'ObjectManagerPort': 46437, 'ObjectStoreSocketName': '/tmp/ray/session_2022-06-09_16-34-44_778463_7642/sockets/plasma_store', 'RayletSocketName': '/tmp/ray/session_2022-06-09_16-34-44_778463_7642/sockets/raylet', 'MetricsExportPort': 44366, 'NodeName': '10.0.1.138', 'alive': True, 'Resources': {'node:10.0.1.138': 1.0, 'object_store_memory': 59759950233.0, 'accelerator_type:T4': 1.0, 'GPU': 4.0, 'CPU': 48.0, 'memory': 129439883879.0}}]
```

Then, `sum(host_info)` reports the error `TypeError: unsupported operand type(s) for +: 'int' and 'dict'`

I guess, this is a typo.