### PR TITLE
Use torchdistx.fake.meta_like for fake->meta conversion

### DIFF
--- a/alpa/torch/nn/__init__.py
+++ b/alpa/torch/nn/__init__.py
@@ -464,4 +464,5 @@ def materialize(*tensor_dicts):
 def meta_init(module_fn: Callable[..., torch.nn.Module], *args, **kwargs):
     pt_module = torchdistx_deferred_init.deferred_init(module_fn, *args,
                                                        **kwargs)
-    return pt_module._apply(lambda t: meta_like(t))
+    # pylint: disable=protected-access
+    return pt_module._apply(meta_like)

--- a/alpa/torch/nn/__init__.py
+++ b/alpa/torch/nn/__init__.py
@@ -7,6 +7,7 @@ import torch
 from torch import Tensor, nn
 from torch.fx.experimental.normalize import NormalizeOperators
 from torchdistx import deferred_init as torchdistx_deferred_init
+from torchdistx.fake import meta_like
 import alpa.torch as atorch
 from alpa.torch.tensor_utils import make_shaped_array_from_pt_tensor
 from alpa.torch.ops.mapping import zeros_like_on_device
@@ -463,5 +464,4 @@ def materialize(*tensor_dicts):
 def meta_init(module_fn: Callable[..., torch.nn.Module], *args, **kwargs):
     pt_module = torchdistx_deferred_init.deferred_init(module_fn, *args,
                                                        **kwargs)
-    pt_module = pt_module.to(device="meta")
-    return pt_module
+    return pt_module._apply(lambda t: meta_like(t))

--- a/tests/torch/test_torch_reshape.py
+++ b/tests/torch/test_torch_reshape.py
@@ -35,7 +35,6 @@ class TorchReshapeTest(unittest.TestCase):
     def test_reshape(self):
         B = 64
 
-        # `meta_init` allows a PyTorch model to be created with shape-only tensors as weights.
         pt_module_gen = lambda: MyModule()
 
         dataloader = [


### PR DESCRIPTION
`meta_like` is the better approach which is recently added to torchdistx (https://github.com/pytorch/torchdistx/pull/24).

We need this to enable PyTorch CI test.