### PR TITLE
[Feature]Deprecate cupy nccl api and change to use nccl imported from tensorflow-alpa

### DIFF
--- a/alpa/collective/collective.py
+++ b/alpa/collective/collective.py
@@ -25,6 +25,7 @@ if global_config.nccl_mode == "cupy":
                        "following the guide at: "
                        "https://docs.cupy.dev/en/stable/install.html.")
 else:
+    assert global_config.nccl_mode == "xla_extension"
     try:
         from alpa.collective.collective_group.xla_nccl_collective_group import (
             XLANCCLGroup as NCCLGroup)
@@ -418,8 +419,8 @@ def broadcast_partialgpu(tensor_list,
         devices_ids: local devices in this cross-host collective group.
         devices_global_rank: the corresponding global rank for local devices.
         group_name (str): the collective group name to perform broadcast.
-        local_start_pos_list (list[int]): the list contains starting positions of the
-        contiguous data to be sent in every tensor.
+        local_start_pos_list (list[int]): the list contains starting positions
+        of the contiguous data to be sent in every tensor.
 
     Returns:
         None
@@ -436,7 +437,7 @@ def broadcast_partialgpu(tensor_list,
     opts.devices_ids = devices_ids
     opts.devices_global_rank = devices_global_rank
     opts.local_start_pos_list = (local_start_pos_list
-            if local_start_pos_list is not None else [])
+                                 if local_start_pos_list is not None else [])
     g.broadcast_partialgpu(tensor_list, opts)
 
 

--- a/alpa/collective/collective.py
+++ b/alpa/collective/collective.py
@@ -9,6 +9,7 @@ from jax._src.lib import xla_extension as xe
 
 from alpa.collective import types
 from alpa.global_env import global_config
+
 _NCCL_AVAILABLE = True
 _GLOO_AVAILABLE = True
 
@@ -21,8 +22,8 @@ if global_config.nccl_mode == "from_cupy":
     except ImportError:
         _NCCL_AVAILABLE = False
         logger.warning("NCCL seems unavailable. Please install Cupy "
-                    "following the guide at: "
-                    "https://docs.cupy.dev/en/stable/install.html.")
+                       "following the guide at: "
+                       "https://docs.cupy.dev/en/stable/install.html.")
 else:
     try:
         from alpa.collective.collective_group.xla_nccl_collective_group import (
@@ -407,7 +408,7 @@ def broadcast_partialgpu(tensor_list,
                          devices_ids,
                          devices_global_rank,
                          group_name: str = "default",
-                         local_start_pos_list = None):
+                         local_start_pos_list=None):
     """Broadcast the tensor from a source GPU to some other GPUs.
     This function is different from broadcast_multigpu that it only
     uses a subset of gpus in one host.
@@ -599,8 +600,8 @@ def send_multigpu(tensor,
                   dst_rank: int,
                   dst_gpu_index: int,
                   group_name: str = "default",
-                  start_pos = 0, 
-                  n_elements = 0):
+                  start_pos=0,
+                  n_elements=0):
     """Send a tensor to a remote GPU synchronously.
 
     The function asssume each process owns >1 GPUs, and the sender
@@ -660,8 +661,8 @@ def recv_multigpu(tensor,
                   src_rank: int,
                   src_gpu_index: int,
                   group_name: str = "default",
-                  start_pos = 0,
-                  n_elements = 0):
+                  start_pos=0,
+                  n_elements=0):
     """Receive a tensor from a remote GPU synchronously.
 
     The function asssume each process owns >1 GPUs, and the sender

--- a/alpa/collective/collective.py
+++ b/alpa/collective/collective.py
@@ -31,13 +31,13 @@ else:
             XLANCCLGroup as NCCLGroup)
         from alpa.collective.collective_group.xla_nccl_util import get_nccl_runtime_version
         nccl_version = get_nccl_runtime_version()
-    except ImportError:
+    except AttributeError:
         _NCCL_AVAILABLE = False
-        print("NCCL from xla_extention seems unavailable! "
-              "Please check whether your local tensorflow-alpa "
-              "has already been up-to-date. You could also set "
-              "global_config.nccl_mode == \"cupy\" to "
-              "use another set of nccl apis from cupy. ")
+        logger.warning("NCCL from xla_extention seems unavailable! "
+                       "Please check whether your local tensorflow-alpa "
+                       "has already been up-to-date. You could also set "
+                       "global_config.nccl_mode == \"cupy\" to "
+                       "use another set of nccl apis from cupy. ")
 
 try:
     from alpa.collective.collective_group.gloo_collective_group import (

--- a/alpa/collective/collective.py
+++ b/alpa/collective/collective.py
@@ -7,7 +7,7 @@ import numpy as np
 import ray
 from alpa.collective import types
 from alpa.global_env import global_config
-
+from jax._src.lib import xla_extension as xe
 _NCCL_AVAILABLE = True
 _GLOO_AVAILABLE = True
 
@@ -76,7 +76,7 @@ class GroupManager:
             self._group_name_map[g] = group_name
         if backend == types.Backend.NCCL:
             logger.debug(f"Creating NCCL group: '{group_name}'...")
-            if global_config.nccl_mode == "xla_nccl":
+            if global_config.nccl_mode == "from_xla_extension":
                 g = XLANCCLGroup(world_size, rank, group_name)
             else:
                 g = NCCLGroup(world_size, rank, group_name)
@@ -749,7 +749,7 @@ check_and_get_group = _check_and_get_group
 
 def _check_single_tensor_input(tensor):
     """Check if the tensor is with a supported type."""
-    if isinstance(tensor, np.ndarray):
+    if isinstance(tensor, np.ndarray) or isinstance(tensor, xe.DeviceArray):
         return
     if types.cupy_available():
         if isinstance(tensor, types.cp.ndarray):

--- a/alpa/collective/collective_group/base_collective_group.py
+++ b/alpa/collective/collective_group/base_collective_group.py
@@ -14,6 +14,7 @@ from alpa.collective.types import (AllReduceOptions, BarrierOptions,
 
 logger = logging.getLogger(__name__)
 
+
 class Rendezvous:
     """A rendezvous class for different actor/task processes to meet.
 
@@ -113,6 +114,7 @@ class Rendezvous:
         """Delete the named actor."""
         ray.kill(self._store)
         self._store = None
+
 
 class BaseGroup(metaclass=ABCMeta):
     """Abstract class for collective groups."""

--- a/alpa/collective/collective_group/base_collective_group.py
+++ b/alpa/collective/collective_group/base_collective_group.py
@@ -1,11 +1,118 @@
 """Abstract class for collective groups."""
 from abc import ABCMeta
 from abc import abstractmethod
+import logging
+import datetime
+import time
 
+import ray
+
+from alpa.collective.const import get_store_name
 from alpa.collective.types import (AllReduceOptions, BarrierOptions,
                                    ReduceOptions, AllGatherOptions,
                                    BroadcastOptions, ReduceScatterOptions)
 
+logger = logging.getLogger(__name__)
+
+class Rendezvous:
+    """A rendezvous class for different actor/task processes to meet.
+
+    To initialize an NCCL collective communication group, different
+    actors/tasks spawned in Ray in a collective group needs to meet
+    each other to synchronize the NCCLUniqueID. This class guarantees
+    they meet via the NCCLUniqueIDStore, initialized on the rank=0
+    process.
+
+    Args:
+        store_key (str): the unique store key, usually as a concatanation
+            of group_name and communicator key. See `get_nccl_communicator`
+            for more details.
+    """
+
+    def __init__(self, store_key):
+        if not store_key:
+            raise ValueError(
+                "Invalid store_key. The store_key is a concatenation of "
+                "'group_name' and the 'communicator_key'. See the "
+                "docstring of `get_nccl_communicator` for details.")
+        self._store_key = store_key
+        self._store_name = None
+        self._store = None
+
+    def meet(self, timeout_s=180):
+        """Meet at the named actor store.
+
+        Args:
+            timeout_s (int): timeout in seconds.
+
+        Return:
+            None
+        """
+        if timeout_s <= 0:
+            raise ValueError("The 'timeout' argument must be positive. "
+                             f"Got '{timeout_s}'.")
+        self._store_name = get_store_name(self._store_key)
+        timeout_delta = datetime.timedelta(seconds=timeout_s)
+        elapsed = datetime.timedelta(seconds=0)
+        start_time = datetime.datetime.now()
+        while elapsed < timeout_delta:
+            try:
+                logger.debug(
+                    f"Trying to meet at the store '{self._store_name}'")
+                self._store = ray.get_actor(self._store_name)
+            except ValueError:
+                logger.debug(
+                    f"Failed to meet at the store '{self._store_name}'. "
+                    "Trying again...")
+                time.sleep(1)
+                elapsed = datetime.datetime.now() - start_time
+                continue
+            logger.debug("Successful rendezvous!")
+            break
+        if not self._store:
+            raise RuntimeError("Unable to meet other processes "
+                               "at the rendezvous store. If you are using "
+                               "P2P communication, please check if tensors "
+                               "are put in the correct GPU. ")
+
+    @property
+    def store(self):
+        return self._store
+
+    def get_nccl_id(self, timeout_s=180):
+        """Get the NCCLUniqueID from the store through Ray.
+
+        Args:
+            timeout_s: timeout in seconds.
+
+        Return:
+            uid (str): the NCCLUniqueID if successful.
+        """
+        if not self._store:
+            raise ValueError("Rendezvous store is not setup.")
+        uid = None
+        timeout_delta = datetime.timedelta(seconds=timeout_s)
+        elapsed = datetime.timedelta(seconds=0)
+        start_time = datetime.datetime.now()
+        while elapsed < timeout_delta:
+            uid = ray.get(self._store.get_id.remote())
+            if not uid:
+                time.sleep(1)
+                elapsed = datetime.datetime.now() - start_time
+                continue
+            break
+        if not uid:
+            raise RuntimeError("Unable to get the NCCLUniqueID from the store.")
+        return uid
+
+    def get_access_counter(self):
+        """Return how many times the NCCLUniqueID has been accessed."""
+        return ray.get(self._store.get_access_counter.remote())
+
+    def destroy_store(self):
+        """Delete the named actor."""
+        ray.kill(self._store)
+        self._store = None
 
 class BaseGroup(metaclass=ABCMeta):
     """Abstract class for collective groups."""

--- a/alpa/collective/collective_group/nccl_collective_group.py
+++ b/alpa/collective/collective_group/nccl_collective_group.py
@@ -17,7 +17,6 @@ from alpa.collective.collective_group.cuda_stream import get_stream_pool
 logger = logging.getLogger(__name__)
 
 
-
 class NCCLGroup(BaseGroup):
     """NCCL-based collective operations."""
 

--- a/alpa/collective/collective_group/nccl_collective_group.py
+++ b/alpa/collective/collective_group/nccl_collective_group.py
@@ -1,14 +1,12 @@
 """NCCL-based collective operations."""
 import logging
-import datetime
-import time
 
 import ray
 import cupy
 
 from alpa.collective.const import ENV
 from alpa.collective.collective_group import nccl_util
-from alpa.collective.collective_group.base_collective_group import BaseGroup
+from alpa.collective.collective_group.base_collective_group import BaseGroup, Rendezvous
 from alpa.collective.const import get_store_name
 from alpa.collective.types import (AllReduceOptions, BarrierOptions, Backend,
                                    ReduceOptions, BroadcastOptions,
@@ -18,106 +16,6 @@ from alpa.collective.collective_group.cuda_stream import get_stream_pool
 
 logger = logging.getLogger(__name__)
 
-
-class Rendezvous:
-    """A rendezvous class for different actor/task processes to meet.
-
-    To initialize an NCCL collective communication group, different
-    actors/tasks spawned in Ray in a collective group needs to meet
-    each other to synchronize the NCCLUniqueID. This class guarantees
-    they meet via the NCCLUniqueIDStore, initialized on the rank=0
-    process.
-
-    Args:
-        store_key (str): the unique store key, usually as a concatanation
-            of group_name and communicator key. See `get_nccl_communicator`
-            for more details.
-    """
-
-    def __init__(self, store_key):
-        if not store_key:
-            raise ValueError(
-                "Invalid store_key. The store_key is a concatenation of "
-                "'group_name' and the 'communicator_key'. See the "
-                "docstring of `get_nccl_communicator` for details.")
-        self._store_key = store_key
-        self._store_name = None
-        self._store = None
-
-    def meet(self, timeout_s=180):
-        """Meet at the named actor store.
-
-        Args:
-            timeout_s (int): timeout in seconds.
-
-        Return:
-            None
-        """
-        if timeout_s <= 0:
-            raise ValueError("The 'timeout' argument must be positive. "
-                             f"Got '{timeout_s}'.")
-        self._store_name = get_store_name(self._store_key)
-        timeout_delta = datetime.timedelta(seconds=timeout_s)
-        elapsed = datetime.timedelta(seconds=0)
-        start_time = datetime.datetime.now()
-        while elapsed < timeout_delta:
-            try:
-                logger.debug(
-                    f"Trying to meet at the store '{self._store_name}'")
-                self._store = ray.get_actor(self._store_name)
-            except ValueError:
-                logger.debug(
-                    f"Failed to meet at the store '{self._store_name}'. "
-                    "Trying again...")
-                time.sleep(1)
-                elapsed = datetime.datetime.now() - start_time
-                continue
-            logger.debug("Successful rendezvous!")
-            break
-        if not self._store:
-            raise RuntimeError("Unable to meet other processes "
-                               "at the rendezvous store. If you are using "
-                               "P2P communication, please check if tensors "
-                               "are put in the correct GPU. ")
-
-    @property
-    def store(self):
-        return self._store
-
-    def get_nccl_id(self, timeout_s=180):
-        """Get the NCCLUniqueID from the store through Ray.
-
-        Args:
-            timeout_s: timeout in seconds.
-
-        Return:
-            uid (str): the NCCLUniqueID if successful.
-        """
-        if not self._store:
-            raise ValueError("Rendezvous store is not setup.")
-        uid = None
-        timeout_delta = datetime.timedelta(seconds=timeout_s)
-        elapsed = datetime.timedelta(seconds=0)
-        start_time = datetime.datetime.now()
-        while elapsed < timeout_delta:
-            uid = ray.get(self._store.get_id.remote())
-            if not uid:
-                time.sleep(1)
-                elapsed = datetime.datetime.now() - start_time
-                continue
-            break
-        if not uid:
-            raise RuntimeError("Unable to get the NCCLUniqueID from the store.")
-        return uid
-
-    def get_access_counter(self):
-        """Return how many times the NCCLUniqueID has been accessed."""
-        return ray.get(self._store.get_access_counter.remote())
-
-    def destroy_store(self):
-        """Delete the named actor."""
-        ray.kill(self._store)
-        self._store = None
 
 
 class NCCLGroup(BaseGroup):

--- a/alpa/collective/collective_group/xla_nccl_collective_group.py
+++ b/alpa/collective/collective_group/xla_nccl_collective_group.py
@@ -257,8 +257,9 @@ class XLANCCLGroup(BaseGroup):
                         "destroyed.")
                     rendezvous.destroy_store()
 
+        nccl_use_multistream = True if ENV.NCCL_USE_MULTISTREAM.val else False
         comms = xe.nccl_create_communicators(2, [my_p2p_rank], [my_gpu_idx],
-                                             nccl_uid)
+                                             nccl_uid, nccl_use_multistream)
         self._dev_comm_map[comm_key] = comms
         return comms
 

--- a/alpa/collective/collective_group/xla_nccl_collective_group.py
+++ b/alpa/collective/collective_group/xla_nccl_collective_group.py
@@ -7,7 +7,7 @@ from jax._src.lib import xla_extension as xe
 from alpa.collective.collective_group import xla_nccl_util
 from alpa.collective.collective_group.nccl_collective_group import Rendezvous
 from alpa.collective.collective_group.base_collective_group import BaseGroup
-from alpa.collective.const import get_store_name
+from alpa.collective.const import get_store_name, ENV
 from alpa.collective.types import (Backend, BroadcastOptions, AllReduceOptions,
                                    BarrierOptions, ReduceOptions,
                                    AllGatherOptions, ReduceScatterOptions,
@@ -138,8 +138,10 @@ class XLANCCLGroup(BaseGroup):
                         "destroyed.")
                     rendezvous.destroy_store()
 
+        nccl_use_multistream = True if ENV.NCCL_USE_MULTISTREAM.val else False
         comms = xe.nccl_create_communicators(world_size, devices_global_rank,
-                                             devices_ids, nccl_uid)
+                                             devices_ids, nccl_uid,
+                                             nccl_use_multistream)
         self._dev_comm_map[comm_key] = comms
         return comms
 

--- a/alpa/collective/collective_group/xla_nccl_collective_group.py
+++ b/alpa/collective/collective_group/xla_nccl_collective_group.py
@@ -5,8 +5,7 @@ import ray
 from jax._src.lib import xla_extension as xe
 
 from alpa.collective.collective_group import xla_nccl_util
-from alpa.collective.collective_group.nccl_collective_group import Rendezvous
-from alpa.collective.collective_group.base_collective_group import BaseGroup
+from alpa.collective.collective_group.base_collective_group import BaseGroup, Rendezvous
 from alpa.collective.const import get_store_name, ENV
 from alpa.collective.types import (Backend, BroadcastOptions, AllReduceOptions,
                                    BarrierOptions, ReduceOptions,

--- a/alpa/collective/collective_group/xla_nccl_collective_group.py
+++ b/alpa/collective/collective_group/xla_nccl_collective_group.py
@@ -1,0 +1,365 @@
+"""NCCL-based collective operations."""
+import logging
+
+import ray
+
+from alpa.collective.collective_group import xla_nccl_util
+from alpa.collective.collective_group.nccl_collective_group import Rendezvous
+from alpa.collective.collective_group.base_collective_group import BaseGroup
+from alpa.collective.const import get_store_name
+from alpa.collective.types import (Backend, BroadcastOptions, 
+                                   SendOptions, RecvOptions)
+
+from jax._src.lib import xla_extension as xe
+
+logger = logging.getLogger(__name__)
+
+class XLANCCLGroup(BaseGroup):
+    """NCCL-based collective operations."""
+
+    def __init__(self, world_size, rank, group_name):
+        """Init an NCCL collective group."""
+        super().__init__(world_size, rank, group_name)
+
+        # communicator and stream cache.
+        # TODO (Hao): we need a lock here...
+        self._barrier_tensor = None
+        self._dev_comm_map = {}
+        self._dev_streams_map = {}
+
+        # record the used GPU IDs.
+        self._used_gpu_indices = set()
+
+        # TODO(Fu): might need an event map
+        self._dev_event_map = {}
+
+        if xla_nccl_util.get_nccl_runtime_version() < 2704:
+            logger.warning("NCCL send/recv calls requires NCCL>=2.7.4")
+
+    def destroy_group(self):
+        """Destroy the group and release NCCL communicators."""
+        if len(self._dev_comm_map.keys()) > 0:
+
+            # Destroy the communicators and streams.
+            for comm_key, comms in self._dev_comm_map.items():
+                xe.nccl_DestroyComms(comms)
+                self._dev_comm_map[comm_key] = None
+
+        if self.rank == 0:
+            for comm_key in self._dev_comm_map:
+                assert not self._dev_comm_map[comm_key]
+                group_key = self._generate_group_key(comm_key)
+                self._destroy_store(group_key)
+        self._barrier_tensor = None
+        self._dev_comm_map = None
+        self._dev_streams_map = None
+
+    @classmethod
+    def backend(cls):
+        return Backend.NCCL
+
+    def broadcast_partialgpu(self,
+                             tensors,
+                             broadcast_options=BroadcastOptions()):
+        """Broadcast tensors to all other gpus following options.
+        It will only involve subset of gpu in this worker.
+
+        Args:
+            tensors (List): tensors to be broadcast or received.
+            broadcast_options: broadcast options.
+
+        Returns:
+            None
+        """
+        root_rank = 0
+
+        key = broadcast_options.comm_key
+        comms = self._get_nccl_broadcast_communicator(
+            key, broadcast_options.world_size, broadcast_options.devices_ids,
+            broadcast_options.devices_global_rank)
+        xe.nccl_BroadcastPartialGPUs(len(comms), 
+                                     comms, 
+                                     tensors, 
+                                     broadcast_options.local_start_pos_list, 
+                                     broadcast_options.n_elements, 
+                                     root_rank)
+
+    def _get_nccl_broadcast_communicator(self,
+                                         comm_key,
+                                         world_size,
+                                         devices_ids,
+                                         devices_global_rank,
+                                         nccl_uid=None):
+        """Create or retrieve an NCCL communicator for broadcast from cache.
+        Here we only use partial devices in a host, so we create this function
+        besides _get_nccl_collective_communicator.
+
+        If the communicator is found in cache, return the communicator. If not,
+        a communicator and a stream will be created and put in cache.
+
+        Args:
+            comm_key (str): the key to query the communicator cache.
+            world_size (int): the number of devices in this collective
+                              communicator.
+            devices_ids (List): a list of GPU devices of the current process
+                                that participates into the collective.
+            devices_global_rank (List): the corresponding global rank for device
+                                        in devices_ids.
+            nccl_uid : If it is None, we will create a nccl_uid here.
+
+        Returns:
+            communicator: the NCCL communicator corresponded to the devices.
+        """
+        if not comm_key:
+            raise RuntimeError("Got empty communicator key.")
+
+        for d in devices_ids:
+            self._used_gpu_indices.add(d)
+
+        # TODO(Hao): lock the _dev_comm_map here.
+        if comm_key in self._dev_comm_map:
+            return self._dev_comm_map[comm_key]
+
+        group_key = self._generate_group_key(comm_key)
+        if devices_global_rank[0] == 0:
+            if nccl_uid is None:
+                nccl_uid = self._generate_nccl_uid(group_key)
+        else:
+            if nccl_uid is None:
+                rendezvous = Rendezvous(group_key)
+                rendezvous.meet()
+                nccl_uid = rendezvous.get_nccl_id()
+
+                # Recycle the NCCLUniqueIDStore named actor *pro-activately* to
+                # avoid named actor leak.
+                if rendezvous.get_access_counter() == self.world_size:
+                    logger.debug(
+                        "NCCLUniqueID has been broadcasted. The "
+                        "NCCLUniqueIDStore will go out of context and be "
+                        "destroyed.")
+                    rendezvous.destroy_store()
+
+        comms = xe.nccl_CreateCommunicators(len(devices_ids), 
+                                            world_size, 
+                                            devices_global_rank, 
+                                            devices_ids, 
+                                            nccl_uid)
+        self._dev_comm_map[comm_key] = comms
+        return comms
+
+    def send(self, tensors, send_options=SendOptions()):
+        """Send a tensor to a destination gpu in the group.
+
+        Args:
+            tensors (List): the tensor to send.
+            send_options: send options.
+
+        Returns:
+            None
+        """
+
+        buffer = tensors[0]
+        my_gpu_idx = xe.get_buffer_device_id(buffer)
+        peer_rank, peer_gpu_idx = send_options.dst_rank, send_options.dst_gpu_index
+        comm_key = _get_comm_key_send_recv(self.rank, my_gpu_idx, peer_rank, peer_gpu_idx)
+        comms = self._get_nccl_p2p_communicator(comm_key, my_gpu_idx, peer_rank,
+                                                peer_gpu_idx)
+
+        peer_p2p_rank = 0 if self.rank > peer_rank else 1
+        xe.nccl_Send(comms, buffer, send_options.start_pos, send_options.n_elements, peer_p2p_rank)
+
+    def recv(self, tensors, recv_options=RecvOptions()):
+        """Receive a tensor from a source gpu in the group.
+
+        Args:
+            tensors (List): the received tensor.
+            recv_options: Receive options.
+
+        Returns:
+            None
+        """
+
+        buffer = tensors[0]
+        my_gpu_idx = xe.get_buffer_device_id(buffer)
+        peer_rank, peer_gpu_idx = recv_options.src_rank, recv_options.src_gpu_index
+        comm_key = _get_comm_key_send_recv(self.rank, my_gpu_idx, peer_rank, peer_gpu_idx)
+        comms = self._get_nccl_p2p_communicator(comm_key, my_gpu_idx, peer_rank,
+                                                peer_gpu_idx)
+
+        peer_p2p_rank = 0 if self.rank > peer_rank else 1
+        xe.nccl_Recv(comms, buffer, recv_options.start_pos, recv_options.n_elements, peer_p2p_rank)
+
+    def _get_nccl_p2p_communicator(self,
+                                   comm_key,
+                                   my_gpu_idx,
+                                   peer_rank,
+                                   peer_gpu_idx,
+                                   nccl_uid=None):
+        """Create or retrieve an NCCL communicator for p2p tasks.
+
+        Note(Hao): this function is not thread-safe now.
+
+        Args:
+            comm_key (str): communicator key.
+            my_gpu_idx (int): the gpu index on the current process.
+            peer_rank (int): the rank of the destination process.
+            peer_gpu_idx (int): the gpu index on the peer process.
+        Returns:
+            communicator
+        """
+        # pylint: disable=unused-argument
+        if not comm_key:
+            raise RuntimeError("Got empty communicator key.")
+
+        # TODO(Hao): lock the _dev_comm_map here.
+        if comm_key in self._dev_comm_map:
+            return self._dev_comm_map[comm_key]
+
+        # Note (Hao): This is a bit complex so I decide to take a note here.
+        # Here we need to consider three cases:
+        # Case 1: src_rank != dst_rank, hence the send and recv happen on
+        # different process (actors/tasks); each process makes independent
+        # collective calls and manages corresponding communicators.
+        # Case 2: src_rank == dst_rank, src_gpu_idx == dst_gpu_idx; for
+        # this case, we simply throw a RuntimeError;
+        # Case 3: src_rank == dst_rank, src_gpu_idx != dst_gpu_idx, which
+        # means the send and recv will be called on the same process. We
+        # DO NOT support this case for now. We need to properly scope:
+        # (1) communicators creation, and
+        # (2) send/recv calls
+        # using groupStart(（ and groupEnd() calls to avoid deadlocks.
+        if self.rank < peer_rank:
+            my_p2p_rank = 0
+        elif self.rank > peer_rank:
+            my_p2p_rank = 1
+        else:
+            raise RuntimeError(
+                "Send and recv happens on the same process! "
+                "alpa.collective does not support this case as of now. "
+                "Alternatively, consider doing GPU to GPU memcpy?")
+        group_key = self._generate_group_key(comm_key)
+        if my_p2p_rank == 0:
+            if nccl_uid is None:
+                nccl_uid = self._generate_nccl_uid(group_key)
+        else:
+            if nccl_uid is None:
+                rendezvous = Rendezvous(group_key)
+                rendezvous.meet(timeout_s=3000)
+                nccl_uid = rendezvous.get_nccl_id()
+                # Recycle the NCCLUniqueIDStore named actor *pro-activately* to
+                # avoid named actor leak.
+                if rendezvous.get_access_counter() == 2:
+                    logger.debug(
+                        "NCCLUniqueID has been broadcasted. The "
+                        "NCCLUniqueIDStore will go out of context and be "
+                        "destroyed.")
+                    rendezvous.destroy_store()
+
+        comms = xe.nccl_CreateCommunicators(1, 2, [my_p2p_rank], [my_gpu_idx], nccl_uid)
+        self._dev_comm_map[comm_key] = comms
+        return comms
+
+    def _generate_group_key(self, comm_key):
+        """Generate a unique key used to initialize the KV store.
+
+        The group key is a concatenation of the communicator key and
+        the group name, following: [comm_key]@[group_name].
+        """
+        return comm_key + "@" + self.group_name
+
+    @staticmethod
+    def _destroy_store(group_key):
+        """Destroy the KV store (Ray named actor).
+
+        Args:
+            group_key (str): the unique key to retrieve the KV store.
+
+        Returns:
+            None
+        """
+        store_name = get_store_name(group_key)
+        try:
+            store = ray.get_actor(store_name)
+            ray.kill(store)
+        except ValueError:
+            logger.info(f"The store with name {store_name} has been destroyed "
+                        f"somewhere else.")
+
+    @staticmethod
+    def generate_nccl_uid():
+        group_uid = xla_nccl_util.get_nccl_unique_id()
+        return group_uid
+
+    @staticmethod
+    def _generate_nccl_uid(key):
+        """Generate an NCCL unique ID for initializing communicators.
+
+        The method will also create a KV store using Ray named actor and store
+        the NCCLUniqueID in the store. The store needs to be garbage collected
+        when destroying the collective group.
+
+        Args:
+            key (str): the key of the .
+
+        Returns:
+            NCCLUniqueID (str): NCCL unique ID.
+        """
+        group_uid = xla_nccl_util.get_nccl_unique_id()
+        store_name = get_store_name(key)
+        # Avoid a potential circular dependency in ray/actor.py
+        from alpa.collective.util import NCCLUniqueIDStore  # pylint: disable=import-outside-toplevel
+        store = NCCLUniqueIDStore.options(
+            name=store_name, lifetime="detached").remote(store_name)
+        ray.get([store.set_id.remote(group_uid)])
+        return group_uid
+
+    def create_p2p_communicator(self,
+                                my_gpu_idx: int,
+                                peer_rank: int,
+                                peer_gpu_idx: int,
+                                nccl_uid: str = None):
+        """A public method to create p2p communicators
+
+        Args:
+            my_gpu_idx (int): the gpu index on self rank.
+            peer_rank (int): the rank of the peer process.
+            peer_gpu_idx (int): the index of the gpu on the peer process.
+            nccl_uid (str, optional): optionally to provide the NCCLUniqueID in
+                advance.
+
+        Returns:
+            None
+        """
+        comm_key = _get_comm_key_send_recv(self.rank, my_gpu_idx, peer_rank,
+                                           peer_gpu_idx)
+        self._get_nccl_p2p_communicator(comm_key, my_gpu_idx, peer_rank,
+                                        peer_gpu_idx, nccl_uid)
+
+def _get_comm_key_send_recv(my_rank, my_gpu_idx, peer_rank, peer_gpu_idx):
+    """Return a key given source and destination ranks for p2p tasks.
+
+    The p2p key is in the following form:
+                [min_rank]_[gpu_index]:[max_rank]_[gpu_index].
+
+    Args:
+        my_rank (int): the rank of the source process.
+        my_gpu_idx (int): the source gpu index on the process.
+        peer_rank (int): the rank of the destination process.
+        peer_gpu_idx (int): the destination gpu index on the process.
+
+    Returns:
+        comm_key (str): a string key to query the communication cache.
+    """
+    if my_rank < peer_rank:
+        lower_key = str(my_rank) + "_" + str(my_gpu_idx)
+        higher_key = str(peer_rank) + "_" + str(peer_gpu_idx)
+    elif my_rank > peer_rank:
+        lower_key = str(peer_rank) + "_" + str(peer_gpu_idx)
+        higher_key = str(my_rank) + "_" + str(my_gpu_idx)
+    else:
+        raise RuntimeError(
+            "Send and recv happens on the same process. alpa.collective "
+            "does not support this case as of now. Alternatively, consider "
+            "doing GPU to GPU memcpy?")
+    comm_key = lower_key + ":" + higher_key
+    return comm_key

--- a/alpa/collective/collective_group/xla_nccl_collective_group.py
+++ b/alpa/collective/collective_group/xla_nccl_collective_group.py
@@ -138,10 +138,9 @@ class XLANCCLGroup(BaseGroup):
                         "destroyed.")
                     rendezvous.destroy_store()
 
-        nccl_use_multistream = True if ENV.NCCL_USE_MULTISTREAM.val else False
         comms = xe.nccl_create_communicators(world_size, devices_global_rank,
                                              devices_ids, nccl_uid,
-                                             nccl_use_multistream)
+                                             ENV.NCCL_USE_MULTISTREAM.val)
         self._dev_comm_map[comm_key] = comms
         return comms
 
@@ -257,9 +256,9 @@ class XLANCCLGroup(BaseGroup):
                         "destroyed.")
                     rendezvous.destroy_store()
 
-        nccl_use_multistream = True if ENV.NCCL_USE_MULTISTREAM.val else False
         comms = xe.nccl_create_communicators(2, [my_p2p_rank], [my_gpu_idx],
-                                             nccl_uid, nccl_use_multistream)
+                                             nccl_uid,
+                                             ENV.NCCL_USE_MULTISTREAM.val)
         self._dev_comm_map[comm_key] = comms
         return comms
 

--- a/alpa/collective/collective_group/xla_nccl_util.py
+++ b/alpa/collective/collective_group/xla_nccl_util.py
@@ -1,4 +1,4 @@
-"""Code to wrap NCCL API calls from XLA."""
+"""Code to wrap NCCL API calls from XLA extension."""
 from jax._src.lib import xla_extension as xe
 
 

--- a/alpa/collective/collective_group/xla_nccl_util.py
+++ b/alpa/collective/collective_group/xla_nccl_util.py
@@ -3,23 +3,11 @@ from jax._src.lib import xla_extension as xe
 
 
 def get_nccl_runtime_version():
-    return xe.nccl_GetVersion()
+    return xe.nccl_get_version()
 
 
 def get_nccl_unique_id():
-    return xe.nccl_GetUniqueId()
+    return xe.nccl_get_unique_id()
 
 
-def create_nccl_communicator(world_size, nccl_unique_id, rank):
-    """Create an NCCL communicator using NCCL APIs.
-
-    Args:
-        world_size (int): the number of processes of this communicator group.
-        nccl_unique_id (str): the NCCLUniqueID for this group.
-        rank (int): the rank of this process.
-    Returns:
-        comm (nccl.ncclComm_t): an NCCL communicator.
-    """
-    comm = xe.nccl_NcclCommunicator(world_size, nccl_unique_id, rank)
-    return comm
 

--- a/alpa/collective/collective_group/xla_nccl_util.py
+++ b/alpa/collective/collective_group/xla_nccl_util.py
@@ -1,0 +1,25 @@
+"""Code to wrap NCCL API calls from XLA."""
+from jax._src.lib import xla_extension as xe
+
+
+def get_nccl_runtime_version():
+    return xe.nccl_GetVersion()
+
+
+def get_nccl_unique_id():
+    return xe.nccl_GetUniqueId()
+
+
+def create_nccl_communicator(world_size, nccl_unique_id, rank):
+    """Create an NCCL communicator using NCCL APIs.
+
+    Args:
+        world_size (int): the number of processes of this communicator group.
+        nccl_unique_id (str): the NCCLUniqueID for this group.
+        rank (int): the rank of this process.
+    Returns:
+        comm (nccl.ncclComm_t): an NCCL communicator.
+    """
+    comm = xe.nccl_NcclCommunicator(world_size, nccl_unique_id, rank)
+    return comm
+

--- a/alpa/collective/collective_group/xla_nccl_util.py
+++ b/alpa/collective/collective_group/xla_nccl_util.py
@@ -8,6 +8,3 @@ def get_nccl_runtime_version():
 
 def get_nccl_unique_id():
     return xe.nccl_get_unique_id()
-
-
-

--- a/alpa/collective/mesh_run_nccl_collective.py
+++ b/alpa/collective/mesh_run_nccl_collective.py
@@ -1,0 +1,388 @@
+from typing import Sequence
+import logging
+
+from jax import device_put
+from jax._src.lib import xla_extension as xe
+
+import jax.numpy as jnp
+import numpy as np
+import cupy
+
+import alpa.collective as col
+from alpa.collective.collective_group import nccl_util
+from alpa.util import (jax_tensor_to_cupy,
+                       cupy_to_jax_tensor, jax_tensor_set,
+                       xla_buffer_to_jax_tensor, jax_tensor_to_xla_buffer,
+                       xla_buffer_to_cupy, cupy_to_xla_buffer,
+                       is_continuous_subset, infer_offset_and_n_elements,
+                       jax_tensor_index, infer_start_pos_and_n_elements)
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+def xla_nccl_send_tile(mesh, uuid: int, offset: Sequence[slice],
+                       dst_rank: int, dst_gpu_idx: int, group_name: str):
+
+    tensor_shape = mesh.buffers[uuid].shape
+    if is_continuous_subset(offset, tensor_shape):
+        start_pos, n_elements = (
+            infer_start_pos_and_n_elements(tensor_shape, offset))
+        col.send_multigpu(mesh.buffers[uuid],
+                            dst_rank,
+                            dst_gpu_idx,
+                            group_name,
+                            start_pos=start_pos,
+                            n_elements=n_elements)
+    else:
+        # slower path, because of indexing.
+        logger.debug(
+            "Send goes along the slowest path. "
+            "If this is for transformers, please check the resharding "
+            "specs.")
+        start_indices = tuple(o.start for o in offset)
+        slice_sizes = tuple(o.stop - o.start for o in offset)
+        src_buffer = jax_tensor_index(
+            xla_buffer_to_jax_tensor(mesh.buffers[uuid]), start_indices,
+            slice_sizes)
+        to_send = jax_tensor_to_xla_buffer(src_buffer)
+        n_elements = np.prod(slice_sizes)
+        col.send_multigpu(to_send,
+                            dst_rank,
+                            dst_gpu_idx,
+                            group_name,
+                            start_pos=0,
+                            n_elements=n_elements)
+
+def xla_nccl_recv_tile(mesh, uuid: int, device_id: int,
+                       indices_in_dst_tile: Sequence[slice], src_rank: int,
+                       src_gpu_idx: int, group_name: str):
+    tensor_shape = mesh.buffers[uuid].shape
+    slice_shape = tuple(ind.stop - ind.start for ind in indices_in_dst_tile)
+    is_bool = mesh.buffers[uuid].dtype == np.bool_
+    if is_continuous_subset(indices_in_dst_tile, tensor_shape):
+        start_pos, n_elements = infer_start_pos_and_n_elements(tensor_shape,
+                                    indices_in_dst_tile)
+        col.recv_multigpu(mesh.buffers[uuid],
+                            src_rank,
+                            src_gpu_idx,
+                            group_name,
+                            start_pos=start_pos,
+                            n_elements=n_elements)
+    else:
+        tmp_buffer = device_put(
+            jnp.ones(slice_shape, dtype=mesh.buffers[uuid].dtype),
+            mesh.local_devices[device_id])
+        to_recv = jax_tensor_to_xla_buffer(tmp_buffer)
+        n_elements = np.prod(slice_shape)
+        col.recv_multigpu(to_recv,
+                            src_rank,
+                            src_gpu_idx,
+                            group_name,
+                            start_pos=0,
+                            n_elements=n_elements)
+        start_indices = tuple(
+            ind_in_dst.start for ind_in_dst in indices_in_dst_tile)
+        new_buffer = jax_tensor_set(
+            xla_buffer_to_jax_tensor(mesh.buffers[uuid]),
+            xla_buffer_to_jax_tensor(to_recv), start_indices)
+        mesh.buffers[uuid] = jax_tensor_to_xla_buffer(new_buffer)
+    if is_bool:
+        mesh.buffers[uuid] = _uint8_to_bool(mesh.buffers[uuid])
+
+def xla_nccl_allgather(mesh, uuids: Sequence[int],
+                        device_ids: Sequence[int],
+                        tensor_slices: Sequence[slice], output_slice):
+
+    if repr(sorted(device_ids)) not in mesh.allgather_communicators:
+        mesh.allgather_communicators[repr(sorted(device_ids))] = (
+            mesh.nccl_local_allgather_init_comms(list(device_ids)))
+
+    communicators = mesh.allgather_communicators[repr(sorted(device_ids))]
+    is_bool = mesh.buffers[uuids[device_ids[0]]].dtype == np.bool_
+    tensor_shape = mesh.buffers[uuids[device_ids[0]]].shape
+    global_start_pos, _ = infer_start_pos_and_n_elements(
+        tensor_shape, output_slice)
+
+    buffers = []
+    local_start_pos_list = []
+    for device_id, tensor_slice in zip(device_ids, tensor_slices):
+        uuid = uuids[device_id]
+        xla_buffer = mesh.buffers[uuid]
+        start_pos, _ = infer_start_pos_and_n_elements(
+            tensor_shape, tensor_slice)
+        buffers.append(xla_buffer)
+        local_start_pos_list.append(start_pos)
+
+    _, local_n_elements = infer_offset_and_n_elements(tensor_slices[0])
+    xe.nccl_local_all_gather(communicators, buffers, local_start_pos_list,
+                                global_start_pos, local_n_elements)
+
+    for device_id, buf in zip(device_ids, buffers):
+        uuid = uuids[device_id]
+        if is_bool:
+            buf = _uint8_to_bool(buf)
+        mesh.buffers[uuid] = buf
+
+def xla_nccl_broadcast(mesh, uuids, comm_key, world_size, devices_ids,
+                        devices_global_rank, tensor_slices, group_name):
+    buffers = []
+    local_start_pos_list = []
+    is_bool = mesh.buffers[uuids[devices_ids[0]]].dtype == np.bool_
+    _, n_elements = infer_offset_and_n_elements(tensor_slices[0])
+    for device_id, global_rank, tensor_slice in zip(devices_ids,
+                                                    devices_global_rank,
+                                                    tensor_slices):
+        uuid = uuids[device_id]
+        tensor_shape = mesh.buffers[uuid].shape
+        slice_shape = tuple(ind.stop - ind.start for ind in tensor_slice)
+        if is_continuous_subset(tensor_slice, tensor_shape):
+            # fast path, two cases: (1) same shape, (2) continuous subset.
+            start_pos, _ = infer_start_pos_and_n_elements(
+                tensor_shape, tensor_slice)
+            local_start_pos_list.append(start_pos)
+            buffers.append(mesh.buffers[uuid])
+        else:
+            tmp = None
+            if global_rank == 0:
+                start_indices = tuple(o.start for o in tensor_slice)
+                tmp = jax_tensor_index(
+                    xla_buffer_to_jax_tensor(mesh.buffers[uuid]),
+                    start_indices, slice_shape)
+            else:
+                tmp = device_put(
+                    jnp.ones(slice_shape, dtype=mesh.buffers[uuid].dtype),
+                    mesh.local_devices[device_id])
+            local_start_pos_list.append(0)
+            buffers.append(jax_tensor_to_xla_buffer(tmp))
+
+    col.broadcast_partialgpu(buffers, n_elements, comm_key, world_size,
+                                devices_ids, devices_global_rank, group_name,
+                                local_start_pos_list)
+
+    for xla_buffer, device_id, global_rank, tensor_slice in zip(
+            buffers, devices_ids, devices_global_rank, tensor_slices):
+        if global_rank == 0:
+            continue
+        uuid = uuids[device_id]
+        tensor_shape = mesh.buffers[uuid].shape
+        slice_shape = tuple(ind.stop - ind.start for ind in tensor_slice)
+        if is_continuous_subset(tensor_slice, tensor_shape):
+            mesh.buffers[uuid] = xla_buffer
+        else:
+            start_indices = tuple(
+                ind_in_dst.start for ind_in_dst in tensor_slice)
+            new_buffer = jax_tensor_set(
+                xla_buffer_to_jax_tensor(mesh.buffers[uuid]),
+                xla_buffer_to_jax_tensor(xla_buffer), start_indices)
+            mesh.buffers[uuid] = jax_tensor_to_xla_buffer(new_buffer)
+        if is_bool:
+            mesh.buffers[uuid] = _uint8_to_bool(mesh.buffers[uuid])
+
+# Note: in this device mesh code, we will use 3 types of tensors:
+# (1) JAX high-level _DeviceArray, which is index-able, has __cuda_array__
+#     interface
+# (2) XLA low-level PyLocalBuffer, which is not index-able
+# (3) cupy array, which is an intermediate format for ray collective
+def cupy_nccl_send_tile(mesh, uuid: int, offset: Sequence[slice],
+                        dst_rank: int, dst_gpu_idx: int, group_name: str):
+    """
+    Send a slice of a source buffer to a target GPU.
+
+    Args:
+        uuid: the uuid of the xla buffers.
+        offset: the slice to be sent in the buffer.
+        dst_rank: destination rank to send.
+        dst_gpu_idx: the gpu index on the destination rank.
+        group_name: collective group name
+    """
+    tensor_shape = mesh.buffers[uuid].shape
+    if is_continuous_subset(offset, tensor_shape):
+        # fast path, two cases: (1) same shape, (2) continuous subset.
+        slice_shape = tuple(ind.stop - ind.start for ind in offset)
+        to_send = xla_buffer_to_cupy(mesh.buffers[uuid])
+        if slice_shape == tensor_shape:
+            col.send_multigpu(to_send, dst_rank, dst_gpu_idx, group_name)
+        else:
+            ind, n_elements = infer_offset_and_n_elements(offset)
+            col.send_multigpu(to_send[ind],
+                                dst_rank,
+                                dst_gpu_idx,
+                                group_name,
+                                n_elements=n_elements)
+    else:
+        # slower path, because of indexing.
+        logger.debug(
+            "Send goes along the slowest path. "
+            "If this is for transformers, please check the resharding "
+            "specs.")
+        start_indices = tuple(o.start for o in offset)
+        slice_sizes = tuple(o.stop - o.start for o in offset)
+        src_buffer = jax_tensor_index(
+            xla_buffer_to_jax_tensor(mesh.buffers[uuid]), start_indices,
+            slice_sizes)
+        to_send = jax_tensor_to_cupy(src_buffer)
+        col.send_multigpu(to_send, dst_rank, dst_gpu_idx, group_name)
+        
+
+def cupy_nccl_recv_tile(mesh, uuid: int, device_id: int,
+                        indices_in_dst_tile: Sequence[slice], src_rank: int,
+                        src_gpu_idx: int, group_name: str):
+    """
+    Receive a slice from a source GPU and in-place write it on the target
+    buffer.
+
+    Args:
+        uuid: the uuid of the xla buffers.
+        device_id: the device where the buffer is received, used to allocate
+            tmp buffer.
+        indices_in_dst_tile: the slice index to be written on destination
+            buffer.
+        src_rank: source rank to receive from.
+        src_gpu_idx: the sender gpu index on the source rank.
+        group_name: collective group name.
+    """
+    
+    tensor_shape = mesh.buffers[uuid].shape
+    slice_shape = tuple(ind.stop - ind.start for ind in indices_in_dst_tile)
+    is_bool = mesh.buffers[uuid].dtype == np.bool_
+    if is_continuous_subset(indices_in_dst_tile, tensor_shape):
+        to_recv = xla_buffer_to_cupy(mesh.buffers[uuid],
+                                        take_ownership=True)
+        if slice_shape == tensor_shape:
+            col.recv_multigpu(to_recv, src_rank, src_gpu_idx, group_name)
+        else:
+            ind, n_elements = infer_offset_and_n_elements(
+                indices_in_dst_tile)
+            col.recv_multigpu(to_recv[ind],
+                                src_rank,
+                                src_gpu_idx,
+                                group_name,
+                                n_elements=n_elements)
+        mesh.buffers[uuid] = cupy_to_xla_buffer(to_recv)
+    else:
+        # The following call will allocate memory and cause a few H2D and
+        # D2D kernels.
+        # See: https://github.com/alpa-projects/alpa/issues/145
+        logger.debug(
+            "Recv goes along the slowest path. "
+            "If this is for transformers, please check the resharding "
+            "specs.")
+        tmp_buffer = device_put(
+            jnp.ones(slice_shape, dtype=mesh.buffers[uuid].dtype),
+            mesh.local_devices[device_id])
+        to_recv = jax_tensor_to_cupy(tmp_buffer, take_ownership=True)
+        col.recv_multigpu(to_recv, src_rank, src_gpu_idx, group_name)
+        recv_tensor = cupy_to_jax_tensor(to_recv)
+        start_indices = tuple(
+            ind_in_dst.start for ind_in_dst in indices_in_dst_tile)
+
+        # The following in-place write will cause a D2D copy kernel
+        # See: https://github.com/alpa-projects/alpa/issues/144
+        # It is unavoidable, but it is better than:
+        # new_buffer = dynamic_update_slice(src_buf, update, start_indices)
+        # which is not in-place and will cause extra allocation-related
+        # kernels.
+        new_buffer = jax_tensor_set(
+            xla_buffer_to_jax_tensor(mesh.buffers[uuid]), recv_tensor,
+            start_indices)
+        mesh.buffers[uuid] = jax_tensor_to_xla_buffer(new_buffer)
+    if is_bool:
+        mesh.buffers[uuid] = _uint8_to_bool(mesh.buffers[uuid])
+
+
+def cupy_nccl_allgather(mesh, uuids: Sequence[int],
+                        device_ids: Sequence[int],
+                        tensor_slices: Sequence[slice], output_slice):
+
+    cupy_buffers = []
+    communicators = mesh.allgather_communicators[repr(sorted(device_ids))]
+    relative_idx = dict(zip(sorted(device_ids), range(len(device_ids))))
+    output_idx, _ = infer_offset_and_n_elements(output_slice)
+    is_bool = mesh.buffers[uuids[0]].dtype == np.bool_
+    nccl_util.groupStart()
+    for device_id, tensor_slice in zip(device_ids, tensor_slices):
+        uuid = uuids[device_id]
+        xla_buffer = mesh.buffers[uuid]
+        cupy_buffer = xla_buffer_to_cupy(xla_buffer, take_ownership=True)
+        ind, n_elements = infer_offset_and_n_elements(tensor_slice)
+        cupy_slice = cupy_buffer[ind]
+        cupy_output_slice = cupy_buffer[output_idx]
+        communicators[relative_idx[device_id]].allGather(
+            nccl_util.get_tensor_ptr(cupy_slice),
+            nccl_util.get_tensor_ptr(cupy_output_slice), n_elements,
+            nccl_util.get_nccl_tensor_dtype(cupy_buffer),
+            cupy.cuda.Stream.null.ptr)
+        cupy_buffers.append(cupy_buffer)
+    nccl_util.groupEnd()
+    for device_id, cupy_buffer in zip(device_ids, cupy_buffers):
+        uuid = uuids[device_id]
+        buf = cupy_to_xla_buffer(cupy_buffer)
+        if is_bool:
+            buf = _uint8_to_bool(buf)
+        mesh.buffers[uuid] = buf
+
+def cupy_nccl_broadcast(mesh, uuids, comm_key, world_size, devices_ids,
+                        devices_global_rank, tensor_slices, group_name):
+    to_use = []
+    for_buffer = []
+    is_bool = mesh.buffers[uuids[devices_ids[0]]].dtype == np.bool_
+    for device_id, global_rank, tensor_slice in zip(devices_ids,
+                                                    devices_global_rank,
+                                                    tensor_slices):
+        uuid = uuids[device_id]
+        tensor_shape = mesh.buffers[uuid].shape
+        slice_shape = tuple(ind.stop - ind.start for ind in tensor_slice)
+        if is_continuous_subset(tensor_slice, tensor_shape):
+            # fast path, two cases: (1) same shape, (2) continuous subset.
+            tmp = xla_buffer_to_cupy(mesh.buffers[uuid])
+            if slice_shape != tensor_shape:
+                ind, _ = infer_offset_and_n_elements(tensor_slice)
+                to_use.append(tmp[ind])
+            else:
+                to_use.append(tmp)
+            for_buffer.append(tmp)
+        else:
+            tmp = None
+            if global_rank == 0:
+                start_indices = tuple(o.start for o in tensor_slice)
+                tmp = jax_tensor_index(
+                    xla_buffer_to_jax_tensor(mesh.buffers[uuid]),
+                    start_indices, slice_shape)
+                tmp = jax_tensor_to_cupy(tmp)
+            else:
+                tmp = device_put(
+                    jnp.ones(slice_shape, dtype=mesh.buffers[uuid].dtype),
+                    mesh.local_devices[device_id])
+                tmp = jax_tensor_to_cupy(tmp, take_ownership=True)
+            to_use.append(tmp)
+            for_buffer.append(tmp)
+
+    _, n_elements = infer_offset_and_n_elements(tensor_slices[0])
+    col.broadcast_partialgpu(to_use, n_elements, comm_key, world_size,
+                                devices_ids, devices_global_rank, group_name)
+
+    for for_buffer_tensor, device_id, global_rank, tensor_slice in zip(
+            for_buffer, devices_ids, devices_global_rank, tensor_slices):
+        if global_rank == 0:
+            continue
+        uuid = uuids[device_id]
+        tensor_shape = mesh.buffers[uuid].shape
+        slice_shape = tuple(ind.stop - ind.start for ind in tensor_slice)
+        if is_continuous_subset(tensor_slice, tensor_shape):
+            mesh.buffers[uuid] = cupy_to_xla_buffer(for_buffer_tensor)
+        else:
+            recv_tensor = cupy_to_jax_tensor(for_buffer_tensor)
+            start_indices = tuple(
+                ind_in_dst.start for ind_in_dst in tensor_slice)
+            new_buffer = jax_tensor_set(
+                xla_buffer_to_jax_tensor(mesh.buffers[uuid]), recv_tensor,
+                start_indices)
+            mesh.buffers[uuid] = jax_tensor_to_xla_buffer(new_buffer)
+        if is_bool:
+            mesh.buffers[uuid] = _uint8_to_bool(mesh.buffers[uuid])
+            
+# in XLA pred(bool) and uint8 are different, but xla->dlpack->xla
+# turns a bool into uint8. This implementation is slow.
+def _uint8_to_bool(xla_buffer):
+    buf = xla_buffer_to_jax_tensor(xla_buffer).astype(np.bool_)
+    return jax_tensor_to_xla_buffer(buf)

--- a/alpa/collective/types.py
+++ b/alpa/collective/types.py
@@ -87,6 +87,7 @@ class BroadcastOptions:
     devices_global_rank = []
     n_elements = 0
     timeout_ms = unset_timeout_ms
+    local_start_pos_list = []
 
 
 @dataclass
@@ -101,6 +102,7 @@ class SendOptions:
     dst_gpu_index = 0
     n_elements = 0
     timeout_ms = unset_timeout_ms
+    start_pos = 0
 
 
 @dataclass
@@ -109,3 +111,4 @@ class RecvOptions:
     src_gpu_index = 0
     n_elements = 0
     unset_timeout_ms = unset_timeout_ms
+    start_pos = 0

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -60,7 +60,7 @@ from alpa.util import (benchmark_func, list_gpu_info, jax_tensor_to_cupy,
                        xla_buffer_to_cupy, cupy_to_xla_buffer,
                        is_continuous_subset, infer_offset_and_n_elements,
                        jax_tensor_index, OrderedSet, update_jax_platform, 
-                       infer_slice_size, infer_start_position)
+                       infer_slice_size, infer_start_pos_and_n_elements)
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -150,7 +150,7 @@ class MeshHostWorker:
                 jax_tensor = device_put(jnp.ones((1,), dtype=jnp.int8), d)
                 self.signal_tensors.append(
                     jax_tensor_to_xla_buffer(jax_tensor)
-                    if global_config.nccl_mode == "from_xla" else
+                    if global_config.nccl_mode == "from_xla_extension" else
                     jax_tensor_to_cupy(jax_tensor, take_ownership=True)
                 )
 
@@ -376,8 +376,7 @@ class MeshHostWorker:
 
         tensor_shape = self.buffers[uuid].shape
         if is_continuous_subset(offset, tensor_shape):
-            ind, n_elements = infer_offset_and_n_elements(offset)
-            start_pos = infer_start_position(tensor_shape, ind, n_elements)
+            start_pos, n_elements = infer_start_pos_and_n_elements(tensor_shape, offset)
             col.send_multigpu(self.buffers[uuid],
                               dst_rank,
                               dst_gpu_idx,
@@ -467,8 +466,7 @@ class MeshHostWorker:
         slice_shape = tuple(ind.stop - ind.start for ind in indices_in_dst_tile)
         is_bool = self.buffers[uuid].dtype == np.bool_
         if is_continuous_subset(indices_in_dst_tile, tensor_shape):
-            ind, n_elements = infer_offset_and_n_elements(indices_in_dst_tile)
-            start_pos = infer_start_position(tensor_shape, ind, n_elements)
+            start_pos, n_elements = infer_start_pos_and_n_elements(tensor_shape, indices_in_dst_tile)
             col.recv_multigpu(self.buffers[uuid],
                               src_rank,
                               src_gpu_idx,
@@ -596,7 +594,7 @@ class MeshHostWorker:
         task: ReshardingSendTask = self.send_tasks[uuid]
         for send_tile_spec, buf_uuid in zip(task.tile_specs, buf_uuids):
             send_tile_spec: ReshardingTileSpec
-            if global_config.nccl_mode == "xla_nccl":
+            if global_config.nccl_mode == "from_xla_extension":
                 send_tile_func = self.xla_nccl_send_tile
             else:
                 send_tile_func = self.send_tile
@@ -612,7 +610,7 @@ class MeshHostWorker:
                                          recv_spec.shape, recv_spec.dtype)
             for recv_tile_spec in recv_spec.tile_specs:
                 recv_tile_spec: ReshardingTileSpec
-                if global_config.nccl_mode == "xla_nccl":
+                if global_config.nccl_mode == "from_xla_extension":
                     recv_tile_func = self.xla_nccl_recv_tile
                 else:
                     recv_tile_func = self.recv_tile
@@ -626,7 +624,7 @@ class MeshHostWorker:
         for allgather_spec in allgather_specs:
             device_ids = sorted(allgather_spec.device_ids)
             if repr(device_ids) not in self.allgather_communicators:
-                if global_config.nccl_mode == "xla_nccl":
+                if global_config.nccl_mode == "from_xla_extension":
                     communicators = xe.nccl_InitCommunicator(len(device_ids), list(device_ids))
                 else:
                     communicators = nccl.NcclCommunicator.initAll(list(device_ids))
@@ -637,7 +635,7 @@ class MeshHostWorker:
         task: ReshardingAllGatherTask = self.allgather_tasks[uuid]
         allgather_specs = task.allgather_specs
         for allgather_spec in allgather_specs:
-            if global_config.nccl_mode == "xla_nccl":
+            if global_config.nccl_mode == "from_xla_extension":
                 allgather_func = self.xla_nccl_allgather
             else:
                 allgather_func = self.allgather
@@ -655,16 +653,14 @@ class MeshHostWorker:
         communicators = self.allgather_communicators[repr(sorted(device_ids))]
         is_bool = self.buffers[uuids[device_ids[0]]].dtype == np.bool_
         tensor_shape = self.buffers[uuids[device_ids[0]]].shape
-        output_ids, n_elements = infer_offset_and_n_elements(output_slice)
-        global_start_pos = infer_start_position(tensor_shape, output_ids, n_elements)
+        global_start_pos, _ = infer_start_pos_and_n_elements(tensor_shape, output_slice)
 
         buffers = []
         local_start_pos_list = []
         for device_id, tensor_slice in zip(device_ids, tensor_slices):
             uuid = uuids[device_id]
             xla_buffer = self.buffers[uuid]
-            ind, n_elements = infer_offset_and_n_elements(tensor_slice)
-            start_pos = infer_start_position(tensor_shape, ind, n_elements)
+            start_pos, _ = infer_start_pos_and_n_elements(tensor_shape, tensor_slice)
             buffers.append(xla_buffer)
             local_start_pos_list.append(start_pos)
         
@@ -712,16 +708,6 @@ class MeshHostWorker:
                 buf = _uint8_to_bool(buf)
             self.buffers[uuid] = buf
 
-    def test_initcommunicator(self, device_ids):
-        communicators = xe.InitCommunicator(len(device_ids), list(device_ids))
-        self.allgather_communicators[repr(device_ids)] = communicators
-
-    def test_allgather(self, uuids, device_ids, tensor_slices, output_slice):
-        buffers = [self.buffers[uuid] for uuid in uuids]
-        communicators = self.allgather_communicators[repr(device_ids)]
-        ind, n_elements = infer_offset_and_n_elements(tensor_slices[0])
-        xe.LocalAllGather(len(device_ids), communicators, buffers, device_ids, n_elements)
-
     def put_resharding_broadcast_task(self, uuid, tasks, group_name):
         self.broadcast_tasks[uuid] = ReshardingBroadcastTask(
             broadcast_specs=tasks, group_name=group_name)
@@ -747,7 +733,7 @@ class MeshHostWorker:
                                                  broadcast_spec.dtype)
 
             broadcast_func = None
-            if global_config.nccl_mode == "xla_nccl":
+            if global_config.nccl_mode == "from_xla_extension":
                 broadcast_func = self.xla_nccl_broadcast
             else:
                 broadcast_func = self.broadcast
@@ -769,15 +755,10 @@ class MeshHostWorker:
             uuid = uuids[device_id]
             tensor_shape = self.buffers[uuid].shape
             slice_shape = tuple(ind.stop - ind.start for ind in tensor_slice)
-            n_elements = infer_slice_size(slice_shape)
             if is_continuous_subset(tensor_slice, tensor_shape):
                 # fast path, two cases: (1) same shape, (2) continuous subset.
-                ind, _ = infer_offset_and_n_elements(tensor_slice)
-                start_pos = infer_start_position(slice_shape, ind, n_elements)
-                if slice_shape != tensor_shape:
-                    local_start_pos_list.append(start_pos)
-                else:
-                    local_start_pos_list.append(0)
+                start_pos, _ = infer_start_pos_and_n_elements(tensor_shape, tensor_slice)
+                local_start_pos_list.append(start_pos)
                 buffers.append(self.buffers[uuid])
             else:
                 tmp = None

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -162,7 +162,6 @@ class MeshHostWorker:
             self.recv_tile_func = self.xla_nccl_recv_tile
             self.allgather_func = self.xla_nccl_allgather
             self.broadcast_func = self.xla_nccl_broadcast
-            self.nccl_use_multistream = True if ENV.NCCL_USE_MULTISTREAM.val else False
             self.nccl_local_allgather_init_comms = xe.nccl_init_communicator
         else:
             self.send_tile_func = self.cupy_nccl_send_tile
@@ -429,8 +428,8 @@ class MeshHostWorker:
     #     interface
     # (2) XLA low-level PyLocalBuffer, which is not index-able
     # (3) cupy array, which is an intermediate format for ray collective
-    def cupy_nccl_send_tile(self, uuid: int, offset: Sequence[slice], dst_rank: int,
-                            dst_gpu_idx: int, group_name: str):
+    def cupy_nccl_send_tile(self, uuid: int, offset: Sequence[slice],
+                            dst_rank: int, dst_gpu_idx: int, group_name: str):
         """
         Send a slice of a source buffer to a target GPU.
 
@@ -648,7 +647,7 @@ class MeshHostWorker:
                 if global_config.nccl_mode == "from_xla_extension":
                     self.allgather_communicators[repr(device_ids)] = \
                         self.nccl_local_allgather_init_comms(list(device_ids), 
-                            self.nccl_use_multistream)
+                            ENV.NCCL_USE_MULTISTREAM.val)
                 else:
                     self.allgather_communicators[repr(device_ids)] = \
                         self.nccl_local_allgather_init_comms(list(device_ids))
@@ -670,7 +669,7 @@ class MeshHostWorker:
             if global_config.nccl_mode == "from_xla_extension":
                 communicators = \
                     self.nccl_local_allgather_init_comms(list(device_ids), 
-                        self.nccl_use_multistream)
+                        ENV.NCCL_USE_MULTISTREAM.val)
             else:
                 communicators = \
                     self.nccl_local_allgather_init_comms(list(device_ids))

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -646,8 +646,8 @@ class MeshHostWorker:
             if repr(device_ids) not in self.allgather_communicators:
                 if global_config.nccl_mode == "xla_extension":
                     self.allgather_communicators[repr(device_ids)] = (
-                        self.nccl_local_allgather_init_comms(list(device_ids), 
-                            ENV.NCCL_USE_MULTISTREAM.val))
+                        self.nccl_local_allgather_init_comms(
+                            list(device_ids), ENV.NCCL_USE_MULTISTREAM.val))
                 else:
                     self.allgather_communicators[repr(device_ids)] = (
                         self.nccl_local_allgather_init_comms(list(device_ids)))
@@ -667,14 +667,13 @@ class MeshHostWorker:
 
         if repr(sorted(device_ids)) not in self.allgather_communicators:
             if global_config.nccl_mode == "xla_extension":
-                communicators = (
-                    self.nccl_local_allgather_init_comms(list(device_ids),
-                        ENV.NCCL_USE_MULTISTREAM.val))
+                communicators = (self.nccl_local_allgather_init_comms(
+                    list(device_ids), ENV.NCCL_USE_MULTISTREAM.val))
             else:
-                communicators = (
-                    self.nccl_local_allgather_init_comms(list(device_ids)))
-            self.allgather_communicators[repr(sorted(device_ids))] = (
-                communicators)
+                communicators = (self.nccl_local_allgather_init_comms(
+                    list(device_ids)))
+            self.allgather_communicators[repr(
+                sorted(device_ids))] = (communicators)
 
         communicators = self.allgather_communicators[repr(sorted(device_ids))]
         is_bool = self.buffers[uuids[device_ids[0]]].dtype == np.bool_
@@ -702,7 +701,8 @@ class MeshHostWorker:
                 buf = _uint8_to_bool(buf)
             self.buffers[uuid] = buf
 
-    def cupy_nccl_allgather(self, uuids: Sequence[int], device_ids: Sequence[int],
+    def cupy_nccl_allgather(self, uuids: Sequence[int],
+                            device_ids: Sequence[int],
                             tensor_slices: Sequence[slice], output_slice):
         cupy_buffers = []
         communicators = self.allgather_communicators[repr(sorted(device_ids))]

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -61,7 +61,8 @@ from alpa.util import (benchmark_func, list_gpu_info, jax_tensor_to_cupy,
                        xla_buffer_to_cupy, cupy_to_xla_buffer,
                        is_continuous_subset, infer_offset_and_n_elements,
                        jax_tensor_index, OrderedSet, update_jax_platform,
-                       infer_slice_size, infer_start_pos_and_n_elements)
+                       infer_slice_size, infer_start_pos_and_n_elements,
+                       is_ray_node_resource)
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -57,9 +57,6 @@ from alpa.util import (benchmark_func, list_gpu_info, jax_tensor_to_cupy,
                        jax_tensor_to_xla_buffer, OrderedSet,
                        update_jax_platform, is_ray_node_resource)
 
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
-
 if global_config.nccl_mode == "cupy":
     from alpa.collective.mesh_run_nccl_collective import (
         cupy_nccl_send_tile as mesh_run_send_tile, cupy_nccl_recv_tile as
@@ -71,6 +68,9 @@ else:
         xla_nccl_send_tile as mesh_run_send_tile, xla_nccl_recv_tile as
         mesh_run_recv_tile, xla_nccl_allgather as mesh_run_allgather,
         xla_nccl_broadcast as mesh_run_broadcast)
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 ReshardingTileSpec = namedtuple("ReshardingSendSpec",
                                 ["offset", "rank", "gpu_idx"])

--- a/alpa/global_env.py
+++ b/alpa/global_env.py
@@ -53,6 +53,9 @@ class GlobalConfig:
         # Cross mesh resharding mode. Possible choices: {"send_recv",
         # "broadcast"}
         self.resharding_mode = "send_recv"
+        # Which nccl to use. Possible choices: {"from_cupy",
+        # "from_xla"}
+        self.nccl_mode = "from_xla" # "from_cupy" 
 
         ########## Options of XLA compilation ##########
         # Whether to use xla while instruction for preventing CSE in

--- a/alpa/global_env.py
+++ b/alpa/global_env.py
@@ -55,7 +55,7 @@ class GlobalConfig:
         self.resharding_mode = "send_recv"
         # Which nccl to use. Possible choices: {"from_cupy",
         # "from_xla_extension"}
-        self.nccl_mode = "from_xla_extension" # "from_cupy" 
+        self.nccl_mode = "from_xla_extension" # "from_cupy"
 
         ########## Options of XLA compilation ##########
         # Whether to use xla while instruction for preventing CSE in

--- a/alpa/global_env.py
+++ b/alpa/global_env.py
@@ -55,7 +55,7 @@ class GlobalConfig:
         self.resharding_mode = "send_recv"
         # Which nccl to use. Possible choices: {"from_cupy",
         # "from_xla_extension"}
-        self.nccl_mode = "from_xla_extension" # "from_cupy"
+        self.nccl_mode = "from_xla_extension"  # "from_cupy"
 
         ########## Options of XLA compilation ##########
         # Whether to use xla while instruction for preventing CSE in

--- a/alpa/global_env.py
+++ b/alpa/global_env.py
@@ -53,9 +53,9 @@ class GlobalConfig:
         # Cross mesh resharding mode. Possible choices: {"send_recv",
         # "broadcast"}
         self.resharding_mode = "send_recv"
-        # Which nccl to use. Possible choices: {"from_cupy",
-        # "from_xla_extension"}
-        self.nccl_mode = "from_xla_extension"  # "from_cupy"
+        # Which nccl to use. Possible choices: {"cupy",
+        # "xla_extension"}
+        self.nccl_mode = "xla_extension"
 
         ########## Options of XLA compilation ##########
         # Whether to use xla while instruction for preventing CSE in

--- a/alpa/global_env.py
+++ b/alpa/global_env.py
@@ -54,8 +54,8 @@ class GlobalConfig:
         # "broadcast"}
         self.resharding_mode = "send_recv"
         # Which nccl to use. Possible choices: {"from_cupy",
-        # "from_xla"}
-        self.nccl_mode = "from_xla" # "from_cupy" 
+        # "from_xla_extension"}
+        self.nccl_mode = "from_xla_extension" # "from_cupy" 
 
         ########## Options of XLA compilation ##########
         # Whether to use xla while instruction for preventing CSE in

--- a/alpa/util.py
+++ b/alpa/util.py
@@ -863,7 +863,6 @@ def is_continuous_subset(tensor_slice, tensor_shape, row_major=True):
         return slice_shape[dim + 1:] == tensor_shape[dim + 1:]
 
 
-
 def infer_start_pos_and_n_elements(tensor_shape, tensor_slice):
     start_pos = 0
     n_elements = 1

--- a/alpa/util.py
+++ b/alpa/util.py
@@ -866,6 +866,7 @@ def is_continuous_subset(tensor_slice, tensor_shape, row_major=True):
 def infer_slice_size(slice_shape):
     return np.prod(slice_shape)
 
+
 def infer_start_pos_and_n_elements(tensor_shape, tensor_slice):
     start_pos = 0
     n_elements = 1
@@ -873,6 +874,7 @@ def infer_start_pos_and_n_elements(tensor_shape, tensor_slice):
         start_pos = start_pos * dim_len + dim_slice.start
         n_elements = n_elements * (dim_slice.stop - dim_slice.start)
     return start_pos, n_elements
+
 
 def infer_offset_and_n_elements(tensor_slice):
     """Calculate the offset and #elements before making NCCL calls.

--- a/alpa/util.py
+++ b/alpa/util.py
@@ -863,9 +863,6 @@ def is_continuous_subset(tensor_slice, tensor_shape, row_major=True):
         return slice_shape[dim + 1:] == tensor_shape[dim + 1:]
 
 
-def infer_slice_size(slice_shape):
-    return np.prod(slice_shape)
-
 
 def infer_start_pos_and_n_elements(tensor_shape, tensor_slice):
     start_pos = 0

--- a/alpa/util.py
+++ b/alpa/util.py
@@ -864,18 +864,15 @@ def is_continuous_subset(tensor_slice, tensor_shape, row_major=True):
 
 
 def infer_slice_size(slice_shape):
-    size = 1
-    for i in slice_shape:
-        size = size * i
-    return size
-    
-def infer_start_position(tensor_shape, offset, n_elements):
-    block = 0
-    for i, pos in enumerate(offset):
-        dim_len = tensor_shape[i]
-        block = block * dim_len + pos
-    position = block * n_elements
-    return position
+    return np.prod(slice_shape)
+
+def infer_start_pos_and_n_elements(tensor_shape, tensor_slice):
+    start_pos = 0
+    n_elements = 1
+    for dim_len, dim_slice in zip(tensor_shape, tensor_slice):
+        start_pos = start_pos * dim_len + dim_slice.start
+        n_elements = n_elements * (dim_slice.stop - dim_slice.start)
+    return start_pos, n_elements
 
 def infer_offset_and_n_elements(tensor_slice):
     """Calculate the offset and #elements before making NCCL calls.

--- a/alpa/util.py
+++ b/alpa/util.py
@@ -863,6 +863,20 @@ def is_continuous_subset(tensor_slice, tensor_shape, row_major=True):
         return slice_shape[dim + 1:] == tensor_shape[dim + 1:]
 
 
+def infer_slice_size(slice_shape):
+    size = 1
+    for i in slice_shape:
+        size = size * i
+    return size
+    
+def infer_start_position(tensor_shape, offset, n_elements):
+    block = 0
+    for i, pos in enumerate(offset):
+        dim_len = tensor_shape[i]
+        block = block * dim_len + pos
+    position = block * n_elements
+    return position
+
 def infer_offset_and_n_elements(tensor_slice):
     """Calculate the offset and #elements before making NCCL calls.
 

--- a/docs/gallery/tutorials/alpa_vs_pmap.py
+++ b/docs/gallery/tutorials/alpa_vs_pmap.py
@@ -37,11 +37,11 @@ is also attached at the end of the article.
 # Comparing ``alpa.parallelize``, ``pmap``, ``xmap``, and ``pjit``
 # -----------------------------------------------------------------
 # Besides ``pmap``, jax also provides
-# `xmap <https://jax.readthedocs.io/en/latest/notebooks/xmap_tutorial.html>`_ and 
+# `xmap <https://jax.readthedocs.io/en/latest/notebooks/xmap_tutorial.html>`_ and
 # `pjit <https://jax.readthedocs.io/en/latest/jax-101/08-pjit.html>`_
 # for more advanced parallelization.
-# The table below compares the features of ``alpa.parallelize``, ``pmap``, ``xmap`` 
-# and ``pjit``. In summary, ``alpa.parallelize`` supports more parallelism 
+# The table below compares the features of ``alpa.parallelize``, ``pmap``, ``xmap``
+# and ``pjit``. In summary, ``alpa.parallelize`` supports more parallelism
 # techniques in a more automatic way.
 #
 # ================  ================ ==================== ==================== =========

--- a/examples/opt_serving/benchmark/benchmark_text_gen.py
+++ b/examples/opt_serving/benchmark/benchmark_text_gen.py
@@ -240,4 +240,3 @@ if __name__ == "__main__":
         f"{latency_32_tokens:.2f}"
     ]
     write_tsv(heads, values, "results.tsv")
-

--- a/examples/opt_serving/generator.py
+++ b/examples/opt_serving/generator.py
@@ -118,8 +118,7 @@ class GeneratorInterface:
     def load_model(self):
         """Load model and return the model wrapper."""
         tic = time.time()
-        self.model_wrapper = get_model(self.model_name, "cuda", self.path,
-                                       True)
+        self.model_wrapper = get_model(self.model_name, "cuda", self.path, True)
         load_time = time.time() - tic
 
         # Init tokenizer

--- a/examples/opt_serving/textgen_demo.py
+++ b/examples/opt_serving/textgen_demo.py
@@ -20,4 +20,3 @@ output = model.generate(input_ids=input_ids, max_length=256, do_sample=True)
 generated_string = tokenizer.batch_decode(output, skip_special_tokens=True)
 
 print(generated_string)
-

--- a/tests/runtime/test_xla_nccl.py
+++ b/tests/runtime/test_xla_nccl.py
@@ -42,8 +42,8 @@ class XLANCCLTest(unittest.TestCase):
                 slice(0, size[1], None)
             ])
         ray.get(
-            worker.xla_nccl_allgather.remote(uuids, device_ids, tensor_slices,
-                                             output_slice))
+            worker.allgather.remote(uuids, device_ids, tensor_slices,
+                                    output_slice))
         ray.get(worker.block_until_ready_buffers.remote(uuids))
         refs = ray.get(worker.get_buffers.remote(uuids))
         for i in range(4):

--- a/tests/runtime/test_xla_nccl.py
+++ b/tests/runtime/test_xla_nccl.py
@@ -8,12 +8,15 @@ from alpa.mesh_executable import next_remote_buffer_uuid
 from alpa.global_env import global_config
 
 
-class PybindNCCLTest(unittest.TestCase):
+class XLANCCLTest(unittest.TestCase):
 
     def setUp(self):
         init(cluster="ray")
 
-    def test_pybind_nccl_allgather(self):
+    def test_xla_nccl_allgather(self):
+        backup_nccl_mode = global_config.nccl_mode
+        global_config.nccl_mode = "xla_extension"
+        
         data_shape = (1, 4)
         size = (4, 4)
         virtual_mesh = get_global_virtual_physical_mesh()
@@ -46,11 +49,13 @@ class PybindNCCLTest(unittest.TestCase):
         for i in range(4):
             for j in range(4):
                 assert refs[i][j * shard_len, 0] == j
+        
+        global_config.nccl_mode = backup_nccl_mode
 
 
 def suite():
     suite = unittest.TestSuite()
-    suite.addTest(PybindNCCLTest("test_pybind_nccl_allgather"))
+    suite.addTest(XLANCCLTest("test_xla_nccl_allgather"))
     return suite
 
 

--- a/tests/runtime/test_xla_nccl.py
+++ b/tests/runtime/test_xla_nccl.py
@@ -16,7 +16,7 @@ class XLANCCLTest(unittest.TestCase):
     def test_xla_nccl_allgather(self):
         backup_nccl_mode = global_config.nccl_mode
         global_config.nccl_mode = "xla_extension"
-        
+
         data_shape = (1, 4)
         size = (4, 4)
         virtual_mesh = get_global_virtual_physical_mesh()
@@ -49,7 +49,7 @@ class XLANCCLTest(unittest.TestCase):
         for i in range(4):
             for j in range(4):
                 assert refs[i][j * shard_len, 0] == j
-        
+
         global_config.nccl_mode = backup_nccl_mode
 
 

--- a/tests/test_pybind_nccl.py
+++ b/tests/test_pybind_nccl.py
@@ -1,0 +1,54 @@
+"""Test cross-mesh resharding."""
+import unittest
+import numpy as np
+import ray
+from alpa import init
+from alpa.device_mesh import get_global_virtual_physical_mesh
+from alpa.mesh_executable import next_remote_buffer_uuid
+from alpa.global_env import global_config
+
+class PybindNCCLTest(unittest.TestCase):
+
+    def setUp(self):
+        init(cluster="ray")
+
+    def test_pybind_nccl_allgather(self):
+        data_shape = (1, 4)
+        size = (4, 4)
+        virtual_mesh = get_global_virtual_physical_mesh()
+        mesh = virtual_mesh.slice_2d(range(data_shape[0]),
+                                    [range(data_shape[1])] *
+                                    data_shape[0]).get_physical_mesh()
+        worker = mesh.workers[0]
+        device_ids = np.arange(mesh.num_devices_per_host)
+        uuids = next_remote_buffer_uuid(data_shape[1])
+        shard_len = size[0]//mesh.num_devices_per_host
+        shards = []
+        for i in range(mesh.num_devices_per_host):
+            data = np.zeros(size, dtype=int)
+            data[i*shard_len:(i+1)*shard_len, :] = i
+            shards.append(data)
+        
+        ray.get(worker.put_buffers.remote(uuids, device_ids, shards, 1, 0))
+        output_slice = [slice(0, size[0], None), slice(0, size[1], None)]
+        tensor_slices = []
+        for i in range(mesh.num_devices_per_host):
+            tensor_slices.append([slice(i*shard_len, (i+1)*shard_len, None), slice(0, size[1], None)])
+        ray.get(worker.xla_nccl_allgather.remote(uuids, device_ids, tensor_slices, output_slice))
+        ray.get(worker.block_until_ready_buffers.remote(uuids))
+        refs = ray.get(worker.get_buffers.remote(uuids))
+        for i in range(4):
+            for j in range(4):
+                assert refs[i][j*shard_len,0] == j
+                    
+
+def suite():
+    suite = unittest.TestSuite()
+    suite.addTest(PybindNCCLTest("test_pybind_nccl_allgather"))
+    return suite
+
+
+if __name__ == '__main__':
+    runner = unittest.TextTestRunner()
+    runner.run(suite())
+#python3 run_all.py --filter test_pybind_nccl.py

--- a/tests/test_pybind_nccl.py
+++ b/tests/test_pybind_nccl.py
@@ -7,6 +7,7 @@ from alpa.device_mesh import get_global_virtual_physical_mesh
 from alpa.mesh_executable import next_remote_buffer_uuid
 from alpa.global_env import global_config
 
+
 class PybindNCCLTest(unittest.TestCase):
 
     def setUp(self):
@@ -17,30 +18,35 @@ class PybindNCCLTest(unittest.TestCase):
         size = (4, 4)
         virtual_mesh = get_global_virtual_physical_mesh()
         mesh = virtual_mesh.slice_2d(range(data_shape[0]),
-                                    [range(data_shape[1])] *
-                                    data_shape[0]).get_physical_mesh()
+                                     [range(data_shape[1])] *
+                                     data_shape[0]).get_physical_mesh()
         worker = mesh.workers[0]
         device_ids = np.arange(mesh.num_devices_per_host)
         uuids = next_remote_buffer_uuid(data_shape[1])
-        shard_len = size[0]//mesh.num_devices_per_host
+        shard_len = size[0] // mesh.num_devices_per_host
         shards = []
         for i in range(mesh.num_devices_per_host):
             data = np.zeros(size, dtype=int)
-            data[i*shard_len:(i+1)*shard_len, :] = i
+            data[i * shard_len:(i + 1) * shard_len, :] = i
             shards.append(data)
-        
+
         ray.get(worker.put_buffers.remote(uuids, device_ids, shards, 1, 0))
         output_slice = [slice(0, size[0], None), slice(0, size[1], None)]
         tensor_slices = []
         for i in range(mesh.num_devices_per_host):
-            tensor_slices.append([slice(i*shard_len, (i+1)*shard_len, None), slice(0, size[1], None)])
-        ray.get(worker.xla_nccl_allgather.remote(uuids, device_ids, tensor_slices, output_slice))
+            tensor_slices.append([
+                slice(i * shard_len, (i + 1) * shard_len, None),
+                slice(0, size[1], None)
+            ])
+        ray.get(
+            worker.xla_nccl_allgather.remote(uuids, device_ids, tensor_slices,
+                                             output_slice))
         ray.get(worker.block_until_ready_buffers.remote(uuids))
         refs = ray.get(worker.get_buffers.remote(uuids))
         for i in range(4):
             for j in range(4):
-                assert refs[i][j*shard_len,0] == j
-                    
+                assert refs[i][j * shard_len, 0] == j
+
 
 def suite():
     suite = unittest.TestSuite()

--- a/tests/test_pybind_nccl.py
+++ b/tests/test_pybind_nccl.py
@@ -51,4 +51,3 @@ def suite():
 if __name__ == '__main__':
     runner = unittest.TextTestRunner()
     runner.run(suite())
-#python3 run_all.py --filter test_pybind_nccl.py


### PR DESCRIPTION
### General

This PR for [#issue432](https://github.com/alpa-projects/alpa/issues/432). It replaces the independent cupy nccl api with nccl api used in tensorflow-alpa. tensorflow-alpa repo is also changed correspondingly [#PR116](https://github.com/alpa-projects/tensorflow-alpa/pull/116). They should be merged togather so as to run successfully. 

To use the new api, we need to set `global_config.nccl_mode = "from_xla_extension"` To use cupy nccl apis, set it to `"from_cupy"`. In this PR, I have already set it to "from_xla_extension" by default. If the new api keeps running successfully after being tested by all of you. We could then finally deprecate cupy nccl api.  

### Experiments

I tested Alpa with the new api on 

1. gpt-8gpu, gpt-16gpu, gpt-32gpu, gpt-64gpu, moe-8gpu, moe-16gpu, wresnet-8gpu and wresnet-16gpu in benchmark folder. 
2. test_cross_mesh_resharding.py and test_pybind_nccl.py in tests folder. test_pybind_nccl.py is newly added in this PR. It could be used to test whether pybind for nccl from tensorflow-alpa works well or not. 

The above cases could run successfully. The speed is almost the same as using cupy nccl api(less than 2% difference). 

### Implementation description

To add nccl apis from tensorflow-alpa, I create `XLANCCLGroup` to replace `NCCLGroup`. The `XLANCCLGroup` contains all the same functionalities as NCCLgroup does, but with the new apis used. Here, in order to keep the number of apis and pybind python-C++ types conversion as few as possible, I implement functionalities of XLANCCLGroup inside tensorflow-alpa with C++. Because pybind11 python-c++ types conversion through pybind is tricky, when it comes to NCCL types and Classes with complicated inheritance. The implementation of these functionalities are in `alpa_nccl_wrapper.cc`.