### PR TITLE
[FIX] Fix a bug in next_remote_buffer_uuid

### DIFF
--- a/alpa/mesh_executable.py
+++ b/alpa/mesh_executable.py
@@ -132,7 +132,8 @@ class RemoteBufferRef:
         self.device_mesh = device_mesh
         self.host_id = host_id
         self.device_id = device_id
-        self.uuid = (uuid if uuid is not None else next_remote_buffer_uuid().item())
+        self.uuid = (uuid
+                     if uuid is not None else next_remote_buffer_uuid().item())
         self.is_deleted_on_workers = False
         logger.debug(f"RemoteBufferRef uuid: {self.uuid} created on mesh "
                      f"with devices {self.device_mesh.device_strs}.")

--- a/alpa/mesh_executable.py
+++ b/alpa/mesh_executable.py
@@ -132,7 +132,7 @@ class RemoteBufferRef:
         self.device_mesh = device_mesh
         self.host_id = host_id
         self.device_id = device_id
-        self.uuid = uuid if uuid is not None else next_remote_buffer_uuid()
+        self.uuid = (uuid if uuid is not None else next_remote_buffer_uuid().item())
         self.is_deleted_on_workers = False
         logger.debug(f"RemoteBufferRef uuid: {self.uuid} created on mesh "
                      f"with devices {self.device_mesh.device_strs}.")
@@ -166,10 +166,7 @@ def next_mesh_executable_uuid():
 def next_remote_buffer_uuid(number=1):
     """Return the next uuid of a remote buffer."""
     global remote_buffer_counter
-    if number == 1:
-        ret = remote_buffer_counter
-    else:
-        ret = np.arange(remote_buffer_counter, remote_buffer_counter + number)
+    ret = np.arange(remote_buffer_counter, remote_buffer_counter + number)
     remote_buffer_counter = (remote_buffer_counter + number) % (1 << 60)
     return ret
 
@@ -186,8 +183,6 @@ def create_remote_buffer_refs(device_mesh,
         device_indices = range(device_mesh.num_devices_per_host)
     size = len(host_indices) * len(device_indices) * num_batches
     uuids = next_remote_buffer_uuid(size)
-    if size == 1:
-        uuids = (uuids,)
     uuid_iter = iter(uuids)
     refs = []
     for host_id in host_indices:

--- a/alpa/model/gpt_model.py
+++ b/alpa/model/gpt_model.py
@@ -23,7 +23,7 @@ class FlaxGPTForLMModule(nn.Module):
     bias_init: Callable[..., np.ndarray] = jax.nn.initializers.zeros
 
     def setup(self):
-        self.transformers = FlaxBertModule(config=self.config,  
+        self.transformers = FlaxBertModule(config=self.config,
                                            add_pooling_layer=False,
                                            dtype=self.dtype)
 

--- a/alpa/model/gpt_model.py
+++ b/alpa/model/gpt_model.py
@@ -23,7 +23,7 @@ class FlaxGPTForLMModule(nn.Module):
     bias_init: Callable[..., np.ndarray] = jax.nn.initializers.zeros
 
     def setup(self):
-        self.transformers = FlaxBertModule(config=self.config,
+        self.transformers = FlaxBertModule(config=self.config,  
                                            add_pooling_layer=False,
                                            dtype=self.dtype)
 

--- a/format.sh
+++ b/format.sh
@@ -22,7 +22,6 @@ builtin cd "$ROOT" || exit 1
 
 YAPF_VERSION=$(yapf --version | awk '{print $2}')
 PYLINT_VERSION=$(pylint --version | head -n 1 | awk '{print $2}')
-PYLINT_QUOTES_VERSION=$(pip3 list | grep pylint | awk '{print $2}')
 
 # params: tool name, tool version, required version
 tool_version_check() {


### PR DESCRIPTION
Sometimes we need to request a size 1 array from `next_remote_buffer_uuid`, and the previous implementation will directly return a number instead of a numpy array. Also fix an error in `format.sh` that requires `pylint-quote` that is no longer needed.