### PR TITLE
[Docs] Quote ".[dev]" in installation guide 

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -91,7 +91,7 @@ Install from Source
 1.  Clone repos
 
   .. code:: bash
-  
+
     git clone --recursive git@github.com:alpa-projects/alpa.git
 
 2. Install Alpa
@@ -99,12 +99,12 @@ Install from Source
   .. code:: bash
 
     cd alpa
-    pip3 install -e .[dev]  # Note that the suffix `[dev]` is required to build custom modules.
+    pip3 install -e ".[dev]"  # Note that the suffix `[dev]` is required to build custom modules.
 
 3. Build and install jaxlib
 
   .. code:: bash
-  
+
     cd alpa/build_jaxlib
     python3 build/build.py --enable_cuda --dev_install --tf_path=$(pwd)/../third_party/tensorflow-alpa
     cd dist

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -91,6 +91,7 @@ Install from Source
 1.  Clone repos
 
   .. code:: bash
+
     git clone --recursive git@github.com:alpa-projects/alpa.git
 
 2. Install Alpa
@@ -103,6 +104,7 @@ Install from Source
 3. Build and install jaxlib
 
   .. code:: bash
+
     cd alpa/build_jaxlib
     python3 build/build.py --enable_cuda --dev_install --tf_path=$(pwd)/../third_party/tensorflow-alpa
     cd dist

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -91,7 +91,6 @@ Install from Source
 1.  Clone repos
 
   .. code:: bash
-
     git clone --recursive git@github.com:alpa-projects/alpa.git
 
 2. Install Alpa
@@ -104,7 +103,6 @@ Install from Source
 3. Build and install jaxlib
 
   .. code:: bash
-
     cd alpa/build_jaxlib
     python3 build/build.py --enable_cuda --dev_install --tf_path=$(pwd)/../third_party/tensorflow-alpa
     cd dist


### PR DESCRIPTION
I'm following build from source guide in the docs:https://alpa-projects.github.io/install.html#install-from-source on zsh and it will complain `zsh: no matches found: .[dev]` 

Adding this quote helps to make installation successful.
