### PR TITLE
[Fix] Fix OPT example after UUID refactor

### DIFF
--- a/alpa/global_env.py
+++ b/alpa/global_env.py
@@ -12,7 +12,7 @@ class GlobalConfig:
             os.environ.get("XLA_PYTHON_CLIENT_MEM_FRACTION", 0.9))
         self.xla_gpu_autotune_level = 4
         # The threshold to tigger a batched deletion on workers.
-        self.delete_remote_buffers_threshold = 200
+        self.delete_remote_arrays_threshold = 50
         # Whether to use AWS EFA network interface
         self.use_aws_efa = os.environ.get("ALPA_USE_AWS_EFA",
                                           "").lower() in ["true", "1"]

--- a/alpa/mesh_executable.py
+++ b/alpa/mesh_executable.py
@@ -247,10 +247,7 @@ class NormalMeshDriverExecutable(MeshDriverExecutable):
         timers(self.shard_args_timer_name).stop()
 
         if isinstance(physical_mesh, DistributedPhysicalDeviceMesh):
-            # Shape: (num_args,)
             input_uuids = np.array([ref.uuid for ref in input_bufs])
-
-            # Shape: (num_outs,)
             output_uuids = next_array_uuids(num_outs)
 
             if "sync_before" not in kwargs:
@@ -263,7 +260,6 @@ class NormalMeshDriverExecutable(MeshDriverExecutable):
                     self.exec_uuid, input_uuids, output_uuids, **kwargs)
 
             # Gather output buffers
-            # Shape: (num_outs, num_devices)
             output_bufs = np.array(
                 [RemoteArrayRef(physical_mesh, uuid) for uuid in output_uuids])
 
@@ -630,7 +626,6 @@ class GradAccMeshDriverExecutable(MeshDriverExecutable):
         timers(self.shard_args_timer_name).stop()
 
         if isinstance(physical_mesh, DistributedPhysicalDeviceMesh):
-            # Shape: (num_args,)
             first_batch_uuids = np.array([ref.uuid for ref in first_batch_bufs])
 
             if next_batches_bufs:
@@ -639,7 +634,6 @@ class GradAccMeshDriverExecutable(MeshDriverExecutable):
             else:
                 next_batches_uuids = (None,) * num_hosts
 
-            # Shape: (num_outs,)
             output_uuids = next_array_uuids(num_outs)
 
             # Execute SPMD binary
@@ -650,7 +644,6 @@ class GradAccMeshDriverExecutable(MeshDriverExecutable):
                     global_config.shard_parallel_sync_for_timer)
 
             # Gather output buffers
-            # Shape: (num_outs, num_devices)
             output_bufs = np.array(
                 [RemoteArrayRef(physical_mesh, uuid) for uuid in output_uuids])
 

--- a/examples/opt_serving/benchmark/benchmark_step_func.py
+++ b/examples/opt_serving/benchmark/benchmark_step_func.py
@@ -26,7 +26,7 @@ def run_benchmark(args):
 
     alpa.global_config.shard_parallel_sync_for_timer = True
     alpa.global_config.pipeline_parallel_sync_for_timer = True
-    alpa.global_config.delete_remote_buffers_threshold = 700
+    alpa.global_config.delete_remote_arrays_threshold = 100
 
     batch_size = 1
     seq_len = 16

--- a/examples/opt_serving/benchmark/benchmark_text_gen.py
+++ b/examples/opt_serving/benchmark/benchmark_text_gen.py
@@ -77,7 +77,7 @@ if __name__ == "__main__":
 
     if not autoregressive:
         # Increase the frequency of deleting buffers to avoid OOM.
-        global_config.delete_remote_buffers_threshold = 4
+        global_config.delete_remote_arrays_threshold = 1
 
         # forward mode
         tic = time.time()

--- a/tests/runtime/test_memory_leak.py
+++ b/tests/runtime/test_memory_leak.py
@@ -16,7 +16,7 @@ class MemoryLeakTest(unittest.TestCase):
 
     def setUp(self):
         init()
-        global_config.delete_remote_buffers_threshold = 0
+        global_config.delete_remote_arrays_threshold = 0
 
     def tearDown(self):
         shutdown()


### PR DESCRIPTION
Fix several bugs after #556 
I can confirm the speed of opt-2.7b on p3.16 goes from 44 token/s to 50 token/s after the refactor 