### PR TITLE
[Feature] Support multiple executables in OPT serving

### DIFF
--- a/examples/opt_serving/model/opt_model.py
+++ b/examples/opt_serving/model/opt_model.py
@@ -540,7 +540,7 @@ def init_cache_aval(config, batch_size):
     head_dim = config.decoder_embed_dim // config.decoder_attention_heads
 
     all_cache = []
-    for i in range(config.decoder_layers):
+    for _ in range(config.decoder_layers):
         layer_cache = (
             jax.core.ShapedArray((batch_size, config.max_target_positions,
                                   config.decoder_attention_heads, head_dim),
@@ -688,6 +688,9 @@ def get_pipeshard_executable(config,
                              support_output_attentions=False,
                              support_output_hidden_states=False,
                              autoregressive=True):
+    if not autoregressive:
+        assert not isinstance(decoding_length_per_step, list), \
+            "we only support multiple executables for autoregressive!"
 
     # Init model
     model, params = init_model_aval(config)
@@ -708,7 +711,6 @@ def get_pipeshard_executable(config,
 
     if autoregressive:
 
-        @alpa.parallelize(batch_argnums=(1,), method=method)
         def inference_step_with_cache(params, batch):
             output = model.apply(
                 params,
@@ -720,15 +722,72 @@ def get_pipeshard_executable(config,
             return output
 
         alpa.global_config.always_donate_micro_batch_vars = False
-        executable = inference_step_with_cache.get_executable(
-            params, {
-                "input_ids":
-                    jax.core.ShapedArray((batch_size, 1), jnp.int32),
-                "position_ids":
-                    jax.core.ShapedArray((batch_size, 1), jnp.int32),
-                "cache":
-                    init_cache_aval(config, batch_size),
-            })
+
+        cache = init_cache_aval(config, batch_size)
+
+        if not isinstance(decoding_length_per_step, list):
+            decoding_length_per_step = [decoding_length_per_step]
+
+        if 1 not in decoding_length_per_step:
+            print("WARNING: missing step=1 in multiple decoding steps. Added")
+            decoding_length_per_step.append(1)
+
+        print("Compiling %d executable(s) for decoding length %s" %
+              (len(decoding_length_per_step), str(decoding_length_per_step)))
+        executables = {}
+
+        # Compile an executable with sequence length 1
+        executable = alpa.parallelize(
+            inference_step_with_cache, batch_argnums=(1,),
+            method=method).get_executable(
+                params, {
+                    "input_ids":
+                        jax.core.ShapedArray((batch_size, 1), jnp.int32),
+                    "position_ids":
+                        jax.core.ShapedArray((batch_size, 1), jnp.int32),
+                    "cache":
+                        cache,
+                })
+        executable.dump_debug_info("tmp_executable_1")
+        executables[1] = executable
+
+        # Create another parallel method with assigned input sharding specs
+        method_with_input_sharding = alpa.PipeshardParallel(
+            num_micro_batches=num_micro_batches,
+            pipeline_schedule="inference",
+            layer_option="manual",
+            default_auto_sharding_option=alpa.AutoShardingOption(
+                # Force operator model parallel
+                force_batch_dim_to_mesh_dim=None if batch_size == 1 else 0,
+                # Disabling all-to-all and all-gather generates better intra-op strategies.
+                allow_all_to_all=False,
+                allow_all_gather=False,
+            ),
+            stage_input_shardings=executable.stage_input_shard_specs)
+
+        # Compile other executables
+        for decoding_length in decoding_length_per_step:
+            if decoding_length == 1:
+                # Step=1 has been compiled above
+                continue
+            executable = alpa.parallelize(
+                inference_step_with_cache,
+                batch_argnums=(1,),
+                method=method_with_input_sharding).get_executable(
+                    params, {
+                        "input_ids":
+                            jax.core.ShapedArray(
+                                (batch_size, decoding_length), jnp.int32),
+                        "position_ids":
+                            jax.core.ShapedArray(
+                                (batch_size, decoding_length), jnp.int32),
+                        "cache":
+                            cache,
+                    })
+            executable.dump_debug_info("tmp_executable_%d" % decoding_length)
+            executables[decoding_length] = executable
+        return executables, params
+
     else:
 
         @alpa.parallelize(batch_argnums=(1,), method=method)
@@ -755,7 +814,7 @@ def get_pipeshard_executable(config,
             })
 
     executable.dump_debug_info("tmp")
-    return executable, params
+    return {decoding_length_per_step: executable}, params
 
 
 def load_opt_params_worker_func(self, path, prefix_to_idx, config, shapes,
@@ -928,6 +987,46 @@ def load_params_dis_array(path, executable, params_aval, config, dummy=False):
                                                  flat_mesh_ids)
 
     return flat_arrays
+
+
+def load_multi_executable_params_dis_array(path,
+                                           executables,
+                                           params_aval,
+                                           config,
+                                           dummy=False):
+    """Load parameters to workers that will be used by all executables. Accordingly,
+    we need to make sure the parameter sharding specs are identical for all executables.
+    """
+    shared_input_shard_specs = None
+    for executable in executables.values():
+        stage_input_shard_specs = executable.stage_input_shard_specs
+        if shared_input_shard_specs is not None:
+            assert shared_input_shard_specs == stage_input_shard_specs, \
+                "All executables must have the same input sharding specs."
+        else:
+            shared_input_shard_specs = stage_input_shard_specs
+    return load_params_dis_array(path,
+                                 list(executables.values())[0], params_aval,
+                                 config, dummy)
+
+
+def init_multi_executable_cache_dis_array(executables,
+                                          config,
+                                          batch_size,
+                                          dummy=False):
+    """Initialize cache to workers that will be used by all executables. Accordingly,
+    we need to make sure all executables are using the same cache.
+    """
+    cache_info = None
+    for executable in executables.values():
+        _, batch_info = executable.get_input_placement_specs()
+        if cache_info is not None:
+            assert cache_info == batch_info["cache"], \
+                "All executables must share the same cache"
+        else:
+            cache_info = batch_info["cache"]
+    return init_cache_dis_array(
+        list(executables.values())[0], config, batch_size, dummy)
 
 
 def init_cache_dis_array(executable, config, batch_size, dummy=False):


### PR DESCRIPTION
The initial support of multiple executables to cover various input prompt lengths.

Usage (note that this is only applicable to autoregressive mode):
```
python benchmark_text_gen.py --model alpa/opt-2.7b --path ... --multi-executable
```

Since this is only for benchmarking, currently we check all prompts we are going to run and make a list of decoder lengths accordingly.

Next steps:
- Enable parameter sharing between executables (#550). Now we encounter the following error, which should be caused by different input shardings.
```
  File "/home/ubuntu/alpa/alpa/pipeline_parallel/pipeshard_executable.py", line 221, in __call__
    out = self.launch_on_driver(*args_flat)
  File "/home/ubuntu/alpa/alpa/pipeline_parallel/pipeshard_executable.py", line 150, in launch_on_driver
    self.num_batch, mesh_args)
  File "/home/ubuntu/alpa/alpa/device_mesh.py", line 1117, in shard_args_to_bufs
    assert replica.indices == indices
AssertionError
```
- Fix the bug of crashing with non-power-of-2 prompt (#561). The current error is:
```
  File "/home/ubuntu/alpa/alpa/pipeline_parallel/cross_mesh_resharding.py", line 1067, in dst_tile_to_src_tiles_map
    self._dst_tile_to_src_tiles_map = self.generate_src_dst_map()
  File "/home/ubuntu/alpa/alpa/pipeline_parallel/cross_mesh_resharding.py", line 1085, in generate_src_dst_map
    self._look_up_dst_tile_from_src(tile))
  File "/home/ubuntu/alpa/alpa/pipeline_parallel/cross_mesh_resharding.py", line 1113, in _look_up_dst_tile_from_src
    assert not ragged
AssertionError
```
- Support input padding. Currently we compile one executable for a prompt. However, ideally we should limit the executable number and pad the input prompt to fit the pre-compiled executable with the nearest decoding length.
- Improve performance. Now multiple executables will introduce some overheads at the certain iteration (e.g., 50) during text generation, so that its end-to-end latency is longer than the single executable. I'm still investigating the root cause.

cc @zhisbug @zhuohan123 @merrymercy 