### PR TITLE
[API Change] Move layer constrution decorators to ParallelMethod

### DIFF
--- a/alpa/__init__.py
+++ b/alpa/__init__.py
@@ -15,10 +15,13 @@ from alpa.parallel_method import (ShardParallel, PipeshardParallel,
                                   DataParallel, Zero2Parallel, Zero3Parallel,
                                   CreateStateParallel)
 from alpa.pipeline_parallel.primitive_def import mark_pipeline_boundary
-from alpa.pipeline_parallel.layer_construction import (
-    manual_remat, automatic_remat, ManualLayerOption, AutoLayerOption)
-from alpa.pipeline_parallel.stage_construction import (
-    ManualStageOption, AutoStageOption, UniformStageOption)
+from alpa.pipeline_parallel.layer_construction import (manual_remat,
+                                                       automatic_remat,
+                                                       ManualLayerOption,
+                                                       AutoLayerOption)
+from alpa.pipeline_parallel.stage_construction import (ManualStageOption,
+                                                       AutoStageOption,
+                                                       UniformStageOption)
 from alpa.shard_parallel.auto_sharding import AutoShardingOption
 from alpa.serialization import save_checkpoint, restore_checkpoint
 from alpa.timer import timers

--- a/alpa/__init__.py
+++ b/alpa/__init__.py
@@ -12,13 +12,13 @@ from alpa.device_mesh import (DeviceCluster, PhysicalDeviceMesh,
 from alpa.global_env import global_config
 from alpa.mesh_profiling import ProfilingResultDatabase
 from alpa.parallel_method import (ShardParallel, PipeshardParallel,
-                                  ManualPipeshardParallel, CreateStateParallel,
-                                  DataParallel, Zero2Parallel, Zero3Parallel)
+                                  DataParallel, Zero2Parallel, Zero3Parallel,
+                                  CreateStateParallel)
 from alpa.pipeline_parallel.primitive_def import mark_pipeline_boundary
-from alpa.pipeline_parallel.layer_construction import (manual_remat,
-                                                       automatic_remat,
-                                                       AutoLayerOption,
-                                                       ManualLayerOption)
+from alpa.pipeline_parallel.layer_construction import (
+    manual_remat, automatic_remat, ManualLayerOption, AutoLayerOption)
+from alpa.pipeline_parallel.stage_construction import (
+    ManualStageOption, AutoStageOption, UniformStageOption)
 from alpa.shard_parallel.auto_sharding import AutoShardingOption
 from alpa.serialization import save_checkpoint, restore_checkpoint
 from alpa.timer import timers

--- a/alpa/__init__.py
+++ b/alpa/__init__.py
@@ -15,9 +15,10 @@ from alpa.parallel_method import (ShardParallel, PipeshardParallel,
                                   ManualPipeshardParallel, CreateStateParallel,
                                   DataParallel, Zero2Parallel, Zero3Parallel)
 from alpa.pipeline_parallel.primitive_def import mark_pipeline_boundary
-from alpa.pipeline_parallel.layer_construction import (
-    manual_remat, automatic_remat, automatic_layer_construction,
-    manual_layer_construction)
+from alpa.pipeline_parallel.layer_construction import (manual_remat,
+                                                       automatic_remat,
+                                                       AutoLayerOption,
+                                                       ManualLayerOption)
 from alpa.shard_parallel.auto_sharding import AutoShardingOption
 from alpa.serialization import save_checkpoint, restore_checkpoint
 from alpa.timer import timers

--- a/alpa/api.py
+++ b/alpa/api.py
@@ -15,7 +15,7 @@ from alpa.device_mesh import init_global_cluster, shutdown_global_cluster
 from alpa.parallel_method import ParallelMethod, ShardParallel
 from alpa.pipeline_parallel.primitive_def import mark_gradient
 from alpa.util import (auto_donate_argnums, auto_static_argnums,
-                       abstractify_with_aval)
+                       abstractify_with_aval, GradFuncTransformContext)
 
 is_initialized = False
 
@@ -219,8 +219,15 @@ def grad(*args, **kwargs):
     """
 
     def ret(*call_args, **call_kwargs):
-        func = api.grad(*args, **kwargs)
-        return mark_gradient(func(*call_args, **call_kwargs))
+        # Apply transformations (e.g., layer construction, auto rematerialization)
+        # to the forward func
+        arg_list = list(args)
+        for transform in GradFuncTransformContext.transforms:
+            arg_list[0] = transform(arg_list[0])
+        grad_func = api.grad(*arg_list, **kwargs)
+
+        grads = grad_func(*call_args, **call_kwargs)
+        return mark_gradient(grads)
 
     return ret
 
@@ -236,8 +243,14 @@ def value_and_grad(*args, **kwargs):
     """
 
     def ret(*call_args, **call_kwargs):
-        func = api.value_and_grad(*args, **kwargs)
-        val, grads = func(*call_args, **call_kwargs)
+        # Apply transformations (e.g., layer construction, auto rematerialization)
+        # to the forward func
+        arg_list = list(args)
+        for transform in GradFuncTransformContext.transforms:
+            arg_list[0] = transform(arg_list[0])
+        grad_func = api.value_and_grad(*arg_list, **kwargs)
+
+        val, grads = grad_func(*call_args, **call_kwargs)
         return mark_gradient((val, grads))
 
     return ret

--- a/alpa/api.py
+++ b/alpa/api.py
@@ -219,7 +219,7 @@ def grad(*args, **kwargs):
     """
 
     def ret(*call_args, **call_kwargs):
-        # Apply transformations (e.g., layer construction, auto rematerialization)
+        # Apply transformations (e.g., layer construction, rematerialization)
         # to the forward func
         arg_list = list(args)
         for transform in GradFuncTransformContext.transforms:
@@ -243,7 +243,7 @@ def value_and_grad(*args, **kwargs):
     """
 
     def ret(*call_args, **call_kwargs):
-        # Apply transformations (e.g., layer construction, auto rematerialization)
+        # Apply transformations (e.g., layer construction, rematerialization)
         # to the forward func
         arg_list = list(args)
         for transform in GradFuncTransformContext.transforms:

--- a/alpa/parallel_method.py
+++ b/alpa/parallel_method.py
@@ -179,7 +179,7 @@ class PipeshardParallel(ParallelMethod):
         self.pipeline_schedule = pipeline_schedule
         if layer_option == "manual":
             layer_option = ManualLayerOption()
-        self.layer_option = layer_option or AutoLayerOption(layer_num=8)
+        self.layer_option = layer_option or AutoLayerOption(layer_num=2)
         if stage_option == "auto":
             stage_option = AutoStageOption(
                 submesh_physical_shape_space="power_of_two",

--- a/alpa/parallel_method.py
+++ b/alpa/parallel_method.py
@@ -161,7 +161,11 @@ class PipeshardParallel(ParallelMethod):
         pipeline_schedule: The pipieline schedules.
           Possible choices: {"1f1b", "gpipe", "inference"}
         layer_option: Options of grouping basic operators to layers.
+          Possible choices are {"manual", alpa.AutoLayerOption,
+                                 alpa.ManualLayerOption}
         stage_option: Options of grouping layers into pipeline stages.
+          Possible choices are {"uniform", "auto", alpa.AutoStageOption,,
+                                 alpa.ManualStageOption}
     """
 
     def __init__(

--- a/alpa/parallel_method.py
+++ b/alpa/parallel_method.py
@@ -31,7 +31,6 @@ from alpa.pipeline_parallel.layer_construction import (LayerOption,
                                                        ManualLayerOption)
 from alpa.pipeline_parallel.stage_construction import (StageOption,
                                                        AutoStageOption,
-                                                       ManualStageOption,
                                                        UniformStageOption)
 from alpa.shard_parallel.auto_sharding import AutoShardingOption, LogicalDeviceMesh
 from alpa.shard_parallel.compile_executable import compile_shard_executable

--- a/alpa/parallel_method.py
+++ b/alpa/parallel_method.py
@@ -18,7 +18,6 @@ from typing import Callable, Optional, Sequence, Union, Any
 from jax import linear_util as lu
 from jax.core import AbstractValue
 from jax.tree_util import PyTreeDef
-import numpy as np
 
 from alpa.create_state_parallel import compile_create_state_executable
 from alpa.device_mesh import (PhysicalDeviceMesh, VirtualPhysicalMesh,
@@ -26,10 +25,10 @@ from alpa.device_mesh import (PhysicalDeviceMesh, VirtualPhysicalMesh,
                               get_global_virtual_physical_mesh)
 from alpa.pipeline_parallel.compile_executable import compile_pipeshard_executable
 from alpa.pipeline_parallel.local_pipeline import compile_local_pipeline_executable
-from alpa.pipeline_parallel.layer_construction import (
-    LayerOption, AutoLayerOption, ManualLayerOption)
+from alpa.pipeline_parallel.layer_construction import (LayerOption,
+                                                       AutoLayerOption,
+                                                       ManualLayerOption)
 from alpa.pipeline_parallel.stage_construction import (StageOption,
-                                                       AutoStageOption,
                                                        ManualStageOption,
                                                        UniformStageOption)
 from alpa.shard_parallel.auto_sharding import AutoShardingOption, LogicalDeviceMesh

--- a/alpa/parallel_method.py
+++ b/alpa/parallel_method.py
@@ -26,7 +26,10 @@ from alpa.device_mesh import (PhysicalDeviceMesh, VirtualPhysicalMesh,
                               get_global_virtual_physical_mesh)
 from alpa.pipeline_parallel.compile_executable import compile_pipeshard_executable
 from alpa.pipeline_parallel.local_pipeline import compile_local_pipeline_executable
-from alpa.pipeline_parallel.stage_construction import (AutoStageOption,
+from alpa.pipeline_parallel.layer_construction import (
+    LayerOption, AutoLayerOption, ManualLayerOption)
+from alpa.pipeline_parallel.stage_construction import (StageOption,
+                                                       AutoStageOption,
                                                        ManualStageOption,
                                                        UniformStageOption)
 from alpa.shard_parallel.auto_sharding import AutoShardingOption, LogicalDeviceMesh
@@ -157,20 +160,8 @@ class PipeshardParallel(ParallelMethod):
           solver.
         pipeline_schedule: The pipieline schedules.
           Possible choices: {"1f1b", "gpipe", "inference"}
-        stage_mode: How to construct stages.
-          Possible choices: {"uniform", "auto"}
-        submesh_physical_shape_space: The search space of the physical submesh
-          shapes.
-          Possible choices: {"power_of_two", "small_power_of_two", "all"}.
-        submesh_logical_shape_space: The search space of the logical mesh
-          shapes.
-          Possible choices: {"default", "single_node_model_parallel", "all"}.
-        auto_stage_imbalance_tolerance: The tolerance of imbalance
-          in the auto-stage construction.
-        use_hlo_cost_model: Whether to use the Hlo instruction cost model for
-          pipeline profiling.
-        profiling_database_filename: The filename of profiling result database.
-        cached_compute_cost: The file name of the cached compute cost.
+        layer_option: Options of grouping basic operators to layers.
+        stage_option: Options of grouping layers into pipeline stages.
     """
 
     def __init__(
@@ -179,28 +170,16 @@ class PipeshardParallel(ParallelMethod):
             num_micro_batches: int = 1,
             default_auto_sharding_option: Optional[AutoShardingOption] = None,
             pipeline_schedule: str = "1f1b",
-            stage_mode: str = "uniform",
-            submesh_physical_shape_space: str = "power_of_two",
-            submesh_logical_shape_space: str = "single_node_model_parallel",
-            auto_stage_imbalance_tolerance: float = np.inf,
-            use_hlo_cost_model: bool = False,
-            profiling_database_filename: Optional[str] = None,
-            cached_compute_cost: Optional[str] = None):
+            layer_option: Optional[Union[LayerOption, str]] = None,
+            stage_option: Optional[StageOption] = None):
         self.devices = devices
         self.num_micro_batches = num_micro_batches
         self.as_option = default_auto_sharding_option or AutoShardingOption()
         self.pipeline_schedule = pipeline_schedule
-        if stage_mode == "auto":
-            self.stage_option = AutoStageOption(submesh_physical_shape_space,
-                                                submesh_logical_shape_space,
-                                                auto_stage_imbalance_tolerance,
-                                                use_hlo_cost_model,
-                                                profiling_database_filename,
-                                                cached_compute_cost)
-        elif stage_mode == "uniform":
-            self.stage_option = UniformStageOption()
-        else:
-            raise ValueError(f"Invalid stage mode: {stage_mode}")
+        if layer_option == "manual":
+            layer_option = ManualLayerOption()
+        self.layer_option = layer_option or AutoLayerOption(layer_num=8)
+        self.stage_option = stage_option or UniformStageOption()
 
     def compile_executable(
         self,
@@ -225,7 +204,7 @@ class PipeshardParallel(ParallelMethod):
         return compile_pipeshard_executable(
             fun, in_tree, out_tree_thunk, static_argnums, donated_invars,
             batch_invars, mesh, self.num_micro_batches, self.pipeline_schedule,
-            self.as_option, self.stage_option, *avals)
+            self.as_option, self.layer_option, self.stage_option, *avals)
 
 
 class ManualPipeshardParallel(PipeshardParallel):

--- a/alpa/parallel_method.py
+++ b/alpa/parallel_method.py
@@ -219,51 +219,6 @@ class PipeshardParallel(ParallelMethod):
             self.as_option, self.layer_option, self.stage_option, *avals)
 
 
-class ManualPipeshardParallel(PipeshardParallel):
-    """Use pipeshard parallelism with manual assignment.
-
-    This method can be used to load the solution found by auto
-    PipeshardParallel.
-
-    Args:
-        forward_stage_layer_ids: Layer IDs of each forward stage.
-        submesh_physical_shapes: The physical shapes of submeshes of each stage.
-        submesh_logical_shapes: The logical shapes of submeshes of each stage.
-        submesh_autosharding_option_dicts: The auto-sharding options of each
-          stage.
-        devices: Specify the devices to use. If it is None, use all the devices
-          in the cluster.
-        num_micro_batches: The number of micro batches for gradient
-          accumulation.
-        default_auto_sharding_option: The default options of the auto-sharding
-          solver.
-        pipeline_schedule: The pipieline schedules.
-          Possible choices: {"1f1b", "gpipe", "inference"}
-    """
-
-    def __init__(
-            self,
-            forward_stage_layer_ids: Sequence[Sequence[int]],
-            submesh_physical_shapes: Sequence[Sequence[int]],
-            submesh_logical_shapes: Sequence[Sequence[int]],
-            submesh_autosharding_option_dicts: Sequence[dict],
-            devices: Optional[VirtualPhysicalMesh] = None,
-            num_micro_batches: int = 1,
-            default_auto_sharding_option: Optional[AutoShardingOption] = None,
-            pipeline_schedule: str = "1f1b"):
-        # pylint: disable=super-init-not-called
-        self.devices = devices
-        self.num_micro_batches = num_micro_batches
-        self.as_option = default_auto_sharding_option or AutoShardingOption()
-        self.pipeline_schedule = pipeline_schedule
-        self.stage_option = ManualStageOption(
-            forward_stage_layer_ids,
-            submesh_physical_shapes,
-            submesh_logical_shapes,
-            submesh_autosharding_option_dicts,
-        )
-
-
 class LocalPipelineParallel(ParallelMethod):
     """
     Run pipeline parallel on a single device.

--- a/alpa/pipeline_parallel/compile_executable.py
+++ b/alpa/pipeline_parallel/compile_executable.py
@@ -27,11 +27,15 @@ from alpa.pipeline_parallel.apply_grad import (compute_grad_to_accumulate_grad,
                                                process_apply_gradient,
                                                split_compute_grad_and_apply_grad
                                               )
+from alpa.pipeline_parallel.layer_construction import (
+    LayerOption, AutoLayerOption, ManualLayerOption)
 from alpa.pipeline_parallel.stage_construction import (
     cluster_layers_and_slice_mesh, StageOption)
 from alpa.pipeline_parallel.stage_profiling import CompileWorkerPool
 from alpa.shard_parallel.auto_sharding import AutoShardingOption
-from alpa.util import get_var_mapping, trace_jaxpr_with_micro_batch, OrderedSet
+from alpa.util import (get_var_mapping, trace_jaxpr_with_micro_batch, OrderedSet,
+                       GradFuncTransformContext)
+
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -43,7 +47,8 @@ def compile_pipeshard_executable(
         donated_invars: Sequence[bool], batch_invars: Sequence[bool],
         virtual_mesh: VirtualPhysicalMesh, num_microbatch: int,
         pipeline_schedule: str, default_as_option: AutoShardingOption,
-        stage_option: StageOption, *avals: Sequence[AbstractValue]):
+        layer_option: LayerOption, stage_option: StageOption,
+        *avals: Sequence[AbstractValue]):
     """
     Compile a callable for pipeshard parallel which combines
     pipeline parallelism and 2d shard parallelsim.
@@ -51,19 +56,23 @@ def compile_pipeshard_executable(
     debug_compilation_time(None)
     name_base = f"{fun.__name__}_pipeshard_parallel"
 
-    # Trace the function wit a micro batch to get the jaxpr
-    closed_jaxpr, micro_batch_size = trace_jaxpr_with_micro_batch(
-        fun, batch_invars, num_microbatch, avals)
+    if pipeline_schedule == "inference":
+        fun.f = layer_option.transform(fun.f)
 
-    if num_microbatch > 1:
-        # Trace again with a full batch
-        for store in fun.stores:
-            if store:
-                store.reset()
-        full_batch_closed_jaxpr, _ = trace_jaxpr_with_micro_batch(
-            fun, batch_invars, 1, avals)
-    else:
-        full_batch_closed_jaxpr = None
+    with GradFuncTransformContext(layer_option.transform):
+        # Trace the function wit a micro batch to get the jaxpr
+        closed_jaxpr, micro_batch_size = trace_jaxpr_with_micro_batch(
+            fun, batch_invars, num_microbatch, avals)
+
+        if num_microbatch > 1:
+            # Trace again with a full batch
+            for store in fun.stores:
+                if store:
+                    store.reset()
+            full_batch_closed_jaxpr, _ = trace_jaxpr_with_micro_batch(
+                fun, batch_invars, 1, avals)
+        else:
+            full_batch_closed_jaxpr = None
     debug_compilation_time("trace")
 
     pipeshard_config = compile_pipeshard_executable_internal(

--- a/alpa/pipeline_parallel/compile_executable.py
+++ b/alpa/pipeline_parallel/compile_executable.py
@@ -227,6 +227,7 @@ def compile_pipeshard_executable_internal(
         flop_count=total_flops,
         in_tree=in_tree).compile()
 
+    debug_compilation_time("runtime emitter")
     return pipeshard_config
 
 

--- a/alpa/pipeline_parallel/compile_executable.py
+++ b/alpa/pipeline_parallel/compile_executable.py
@@ -27,15 +27,13 @@ from alpa.pipeline_parallel.apply_grad import (compute_grad_to_accumulate_grad,
                                                process_apply_gradient,
                                                split_compute_grad_and_apply_grad
                                               )
-from alpa.pipeline_parallel.layer_construction import (
-    LayerOption, AutoLayerOption, ManualLayerOption)
+from alpa.pipeline_parallel.layer_construction import LayerOption
 from alpa.pipeline_parallel.stage_construction import (
     cluster_layers_and_slice_mesh, StageOption)
 from alpa.pipeline_parallel.stage_profiling import CompileWorkerPool
 from alpa.shard_parallel.auto_sharding import AutoShardingOption
-from alpa.util import (get_var_mapping, trace_jaxpr_with_micro_batch, OrderedSet,
-                       GradFuncTransformContext)
-
+from alpa.util import (get_var_mapping, trace_jaxpr_with_micro_batch,
+                       OrderedSet, GradFuncTransformContext)
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)

--- a/alpa/pipeline_parallel/layer_construction.py
+++ b/alpa/pipeline_parallel/layer_construction.py
@@ -1,4 +1,6 @@
-"""Cluster small ops into layers and rematerialize at layer boundary."""
+"""Group small ops into layers and rematerialize at layer boundary."""
+from abc import ABC, abstractmethod
+from collections import namedtuple
 import logging
 from functools import partial, wraps
 from typing import Callable, Union, Sequence
@@ -22,6 +24,37 @@ from alpa.util import (clone_jaxpr, slices_to_jaxpr, OrderedSet,
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
+
+
+class LayerOption(ABC):
+    def __init__(self):
+        pass
+
+    @abstractmethod
+    def transform(self, func):
+        raise NotImplementedError()
+
+
+class ManualLayerOption(LayerOption):
+    def __init__(self, remat_layer=False):
+        self.remat_layer = remat_layer
+        super().__init__()
+
+    def transform(self, func):
+        return manual_layer_construction(func, remat_layer=self.remat_layer)
+
+
+class AutoLayerOption(LayerOption):
+    def __init__(self, layer_num: int, remat_layer=False):
+        super().__init__()
+        self.layer_num = layer_num
+        self.remat_layer = remat_layer
+
+    def transform(self, func):
+        return automatic_layer_construction(func,
+                                            layer_num=self.layer_num,
+                                            remat_layer=self.remat_layer)
+
 
 LAYER_HEAVY_OP_LOWER_BOUND = 3
 DEFAULT_EPS = 0.6
@@ -533,8 +566,8 @@ def manual_layer_construction(fun: Callable = None,
 def automatic_layer_construction(fun: Callable = None,
                                  *,
                                  static_argnums: Sequence[int] = (),
-                                 remat_layer: bool = False,
                                  layer_num: int = None,
+                                 remat_layer: bool = False,
                                  eps: float = DEFAULT_EPS,
                                  cost_criteria: str = DEFAULT_COST_CRITERIA,
                                  layer_eps: float = 0.0):
@@ -546,10 +579,10 @@ def automatic_layer_construction(fun: Callable = None,
         static_argnums: An optional int or collection of ints that specify
           which positional arguments to treat as static (compile-time constant).
           Same as in jax.jit
-        remat_layer: Whether to rematerialize each layer at layer boundaries.
         layer_num: the number of layers to rematerialize. If set to "auto", the
           number of layers will be automatically determined by a binary search.
           The binary search might not work for complex input functions.
+        remat_layer: Whether to rematerialize each layer at layer boundaries.
         eps: the tolerance of inbalance of the costs of different layers.
         cost_criteria: the cost criteria to use for deciding the layers.
         layer_eps: a parameter for layer_num binary search.

--- a/alpa/pipeline_parallel/layer_construction.py
+++ b/alpa/pipeline_parallel/layer_construction.py
@@ -26,6 +26,7 @@ logger.setLevel(logging.DEBUG)
 
 
 class LayerOption(ABC):
+    """Options of grouping operators into layers."""
 
     def __init__(self):
         pass
@@ -36,6 +37,10 @@ class LayerOption(ABC):
 
 
 class ManualLayerOption(LayerOption):
+    """
+    Manually specifying the boundaries of layers by using
+    alpa.mark_pipeline_boundary()
+    """
 
     def __init__(self, remat_layer=False):
         self.remat_layer = remat_layer
@@ -46,6 +51,13 @@ class ManualLayerOption(LayerOption):
 
 
 class AutoLayerOption(LayerOption):
+    """
+    Use an algorithm to automatically group operators into
+    layers. The parameter `layer_num` specifies the number of
+    resulting layers. You can try a few values for this parameters.
+    The best choice of this value depends on the number of nodes in your
+    cluster and the number of repetitive blocks in your model.
+    """
 
     def __init__(self, layer_num: int, remat_layer=False):
         super().__init__()

--- a/alpa/pipeline_parallel/layer_construction.py
+++ b/alpa/pipeline_parallel/layer_construction.py
@@ -1,6 +1,5 @@
 """Group small ops into layers and rematerialize at layer boundary."""
 from abc import ABC, abstractmethod
-from collections import namedtuple
 import logging
 from functools import partial, wraps
 from typing import Callable, Union, Sequence
@@ -27,6 +26,7 @@ logger.setLevel(logging.DEBUG)
 
 
 class LayerOption(ABC):
+
     def __init__(self):
         pass
 
@@ -36,6 +36,7 @@ class LayerOption(ABC):
 
 
 class ManualLayerOption(LayerOption):
+
     def __init__(self, remat_layer=False):
         self.remat_layer = remat_layer
         super().__init__()
@@ -45,6 +46,7 @@ class ManualLayerOption(LayerOption):
 
 
 class AutoLayerOption(LayerOption):
+
     def __init__(self, layer_num: int, remat_layer=False):
         super().__init__()
         self.layer_num = layer_num

--- a/alpa/pipeline_parallel/layer_construction.py
+++ b/alpa/pipeline_parallel/layer_construction.py
@@ -363,8 +363,7 @@ def cluster_jaxpr_by_cost(jaxpr: Jaxpr, layer_num: int, eps: float, costs,
         k = a_argmin[r, q]
         reversed_sliced_eqns.append(jaxpr.eqns[k:r])
         r = k
-    assert r == 0, ("no solution for layer clustering"
-                    if r == -1 else "unknown error")
+    assert r == 0, "No solution for layer construction."
     solution = list(reversed(reversed_sliced_eqns))
 
     # print("dp solution")

--- a/alpa/pipeline_parallel/stage_construction.py
+++ b/alpa/pipeline_parallel/stage_construction.py
@@ -3,10 +3,11 @@ Core implementations for stage construction algorithms.
 The algorithm groups layers into pipeline stages.
 """
 from collections import namedtuple
+from dataclasses import dataclass
 from datetime import datetime
 import logging
 from time import time
-from typing import Sequence, List, Tuple, Dict, Union
+from typing import Sequence, List, Tuple, Dict, Union, Optional
 
 from jax.core import Var
 import numpy as np
@@ -28,16 +29,39 @@ from alpa.util import OrderedSet, maybe_numba_jit
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
-# Options for stage construction
-AutoStageOption = namedtuple("AutoStageOption", [
-    "submesh_physical_shape_space", "submesh_logical_shape_space",
-    "stage_imbalance_tolerance", "use_hlo_cost_model",
-    "profiling_database_filename", "cached_compute_cost"
-])
-ManualStageOption = namedtuple("ManualStageOption", [
-    "forward_stage_layer_ids", "submesh_physical_shapes",
-    "submesh_logical_shapes", "submesh_autosharding_option_dicts"
-])
+
+@dataclass
+class AutoStageOption:
+    """Options of auto stage construction algorithm."""
+    # The search space of the physical submesh shapes.
+    # Possible choices: {"power_of_two", "small_power_of_two", "all"}.
+    submesh_physical_shape_space: str = "power_of_two"
+    # The search space of the logical mesh shapes.
+    # Possible choices: {"default", "single_node_model_parallel", "all"}.
+    submesh_logical_shape_space: str = "single_node_model_parallel"
+    # The tolerance of imbalance in the auto-stage construction.
+    stage_imbalance_tolerance: float = np.inf
+    # The tolerance of imbalance in the auto-stage construction.
+    use_hlo_cost_model: bool = False
+    # The filename of profiling result database.
+    profiling_database_filename: Optional[str] = None
+    # The file name of the cached compute cost.
+    cached_compute_cost: Optional[str] = None
+
+
+@dataclass
+class ManualStageOption:
+    """Options of manual stage assignment."""
+    # Layer IDs of each forward stage.
+    forward_stage_layer_ids: Sequence[Sequence[int]]
+    # The physical shapes of submeshes of each stage.
+    submesh_physical_shapes: Sequence[Sequence[int]]
+    # The logical shapes of submeshes of each stage.
+    submesh_logical_shapes: Sequence[Sequence[int]]
+    # The auto-sharding options of each stage.
+    submesh_autosharding_option_dicts: Sequence[dict]
+
+
 UniformStageOption = namedtuple("UniformStageOption", [])
 
 StageOption = Union[AutoStageOption, ManualStageOption, UniformStageOption]

--- a/alpa/pipeline_parallel/stage_construction.py
+++ b/alpa/pipeline_parallel/stage_construction.py
@@ -1,4 +1,7 @@
-"""Core implementations for stage construction algorithms."""
+"""
+Core implementations for stage construction algorithms.
+The algorithm groups layers into pipeline stages.
+"""
 from collections import namedtuple
 from datetime import datetime
 import logging

--- a/alpa/testing.py
+++ b/alpa/testing.py
@@ -16,7 +16,8 @@ from alpa.model.bert_model import BertConfig, FlaxBertLayer
 from alpa.model.model_util import FlaxBaseModelOutput, TrainState
 from alpa.parallel_method import PipeshardParallel
 from alpa.pipeline_parallel.layer_construction import (
-    automatic_layer_construction, manual_layer_construction)
+    automatic_layer_construction, manual_layer_construction,
+    AutoLayerOption, ManualLayerOption)
 from alpa.pipeline_parallel.primitive_def import mark_pipeline_boundary
 from alpa.pipeline_parallel.stage_construction import (UniformStageOption,
                                                        StageOption)
@@ -110,16 +111,7 @@ def create_dummy_train_state(rngkey, model, inputs, dtype=jnp.float16):
     return state
 
 
-def decorate_loss_fn(fn, manual_pipeline, use_remat, layer_num):
-    if manual_pipeline:
-        return manual_layer_construction(fn, remat_layer=use_remat)
-    return automatic_layer_construction(fn,
-                                        remat_layer=use_remat,
-                                        layer_num=layer_num)
-
-
-def get_mlp_train_step(parallel_method, manual_pipeline_layer, use_remat,
-                       use_value_and_grad):
+def get_mlp_train_step(parallel_method, use_value_and_grad):
 
     def train_step(state, batch):
 
@@ -129,8 +121,6 @@ def get_mlp_train_step(parallel_method, manual_pipeline_layer, use_remat,
             return loss
 
         if parallel_method:
-            loss_func = decorate_loss_fn(loss_func, manual_pipeline_layer,
-                                         use_remat, 2)
             if use_value_and_grad:
                 val, grads = value_and_grad(loss_func)(state.params)
             else:
@@ -152,7 +142,7 @@ def get_mlp_train_step(parallel_method, manual_pipeline_layer, use_remat,
         return train_step
 
 
-def get_mlp_inference_step(parallel_method, manual_pipeline_layer):
+def get_mlp_inference_step(parallel_method):
 
     def inference_step(state, batch):
         out = state.apply_fn(state.params, batch["x"])
@@ -160,8 +150,6 @@ def get_mlp_inference_step(parallel_method, manual_pipeline_layer):
         return out, loss
 
     if parallel_method:
-        inference_step = decorate_loss_fn(inference_step, manual_pipeline_layer,
-                                          False, 2)
         return parallelize(inference_step,
                            donate_argnums=(),
                            method=parallel_method)
@@ -169,8 +157,7 @@ def get_mlp_inference_step(parallel_method, manual_pipeline_layer):
         return inference_step
 
 
-def get_bert_layer_collection_inference_step(parallel_method,
-                                             manual_pipeline_layer, num_layers):
+def get_bert_layer_collection_inference_step(parallel_method):
 
     def inference_step(state, batch):
         out = state.apply_fn(state.params,
@@ -188,8 +175,6 @@ def get_bert_layer_collection_inference_step(parallel_method,
         return out, loss
 
     if parallel_method:
-        inference_step = decorate_loss_fn(inference_step, manual_pipeline_layer,
-                                          False, num_layers)
         return parallelize(inference_step,
                            donate_argnums=(),
                            method=parallel_method)
@@ -198,14 +183,7 @@ def get_bert_layer_collection_inference_step(parallel_method,
 
 
 def get_bert_layer_train_step(parallel_method,
-                              manual_pipeline_layer,
-                              use_remat,
-                              num_layers,
-                              use_value_and_grad,
-                              decorate_loss=None):
-    if decorate_loss is None:
-        decorate_loss = parallel_method is not None
-
+                  use_value_and_grad):
     def train_step(state, batch):
 
         def loss_func(params):
@@ -213,9 +191,7 @@ def get_bert_layer_train_step(parallel_method,
             loss = jnp.mean((out - batch["y"])**2)
             return loss
 
-        if decorate_loss:
-            loss_func = decorate_loss_fn(loss_func, manual_pipeline_layer,
-                                         use_remat, num_layers)
+        if parallel_method:
             if use_value_and_grad:
                 val, grads = value_and_grad(loss_func)(state.params)
             else:
@@ -252,9 +228,12 @@ class PipelineBasicTest(unittest.TestCase):
                 stage_option: Optional[StageOption] = None,
                 as_option: Optional[AutoShardingOption] = None,
                 do_numerical_test: bool = True):
-        method = PipeshardParallel(num_micro_batches=4)
-        method.stage_option = stage_option or UniformStageOption()
-        method.as_option = as_option or AutoShardingOption()
+        method = PipeshardParallel(
+            num_micro_batches=4,
+            default_auto_sharding_option=as_option or AutoShardingOption(),
+            layer_option=ManualLayerOption(remat_layer=use_remat) if manual_pipeline_layer else
+	                 AutoLayerOption(layer_num=2, remat_layer=use_remat),
+            stage_option=stage_option or UniformStageOption())
 
         # Init model and optimizer
         batch_size = 64
@@ -271,10 +250,8 @@ class PipelineBasicTest(unittest.TestCase):
         state = create_train_state(rngkey, model, [x])
 
         # Compile
-        serial_train_step = get_mlp_train_step(None, None, None,
-                                               use_value_and_grad)
-        parallel_train_step = get_mlp_train_step(method, manual_pipeline_layer,
-                                                 use_remat, use_value_and_grad)
+        serial_train_step = get_mlp_train_step(None, use_value_and_grad)
+        parallel_train_step = get_mlp_train_step(method, use_value_and_grad)
         executable = parallel_train_step.get_executable(state, batch)
 
         # Run correctnesss test
@@ -310,9 +287,12 @@ class PipelineBasicTest(unittest.TestCase):
                          stage_option: Optional[StageOption] = None,
                          as_option: Optional[AutoShardingOption] = None,
                          do_numerical_test: bool = True):
-        method = PipeshardParallel(num_micro_batches=2)
-        method.stage_option = stage_option or UniformStageOption()
-        method.as_option = as_option or AutoShardingOption()
+        method = PipeshardParallel(
+            num_micro_batches=4,
+            default_auto_sharding_option=as_option or AutoShardingOption(),
+            layer_option=ManualLayerOption(remat_layer=use_remat) if manual_pipeline_layer else
+	                 AutoLayerOption(layer_num=n_layers, remat_layer=use_remat),
+            stage_option=stage_option or UniformStageOption())
 
         # Init model and optimizer
         rngkey = jax.random.PRNGKey(0)
@@ -331,13 +311,8 @@ class PipelineBasicTest(unittest.TestCase):
         state = create_train_state(rngkey, model, [x, attention_mask])
 
         # Compile
-        serial_train_step = get_bert_layer_train_step(None, None, None,
-                                                      n_layers,
-                                                      use_value_and_grad)
-        parallel_train_step = get_bert_layer_train_step(method,
-                                                        manual_pipeline_layer,
-                                                        use_remat, n_layers,
-                                                        use_value_and_grad)
+        serial_train_step = get_bert_layer_train_step(None, use_value_and_grad)
+        parallel_train_step = get_bert_layer_train_step(method, use_value_and_grad)
         executable = parallel_train_step.get_executable(state, batch)
 
         # Run correctnesss test

--- a/alpa/testing.py
+++ b/alpa/testing.py
@@ -15,9 +15,8 @@ from alpa.api import init, shutdown, parallelize, grad, value_and_grad
 from alpa.model.bert_model import BertConfig, FlaxBertLayer
 from alpa.model.model_util import FlaxBaseModelOutput, TrainState
 from alpa.parallel_method import PipeshardParallel
-from alpa.pipeline_parallel.layer_construction import (
-    automatic_layer_construction, manual_layer_construction,
-    AutoLayerOption, ManualLayerOption)
+from alpa.pipeline_parallel.layer_construction import (AutoLayerOption,
+                                                       ManualLayerOption)
 from alpa.pipeline_parallel.primitive_def import mark_pipeline_boundary
 from alpa.pipeline_parallel.stage_construction import (UniformStageOption,
                                                        StageOption)
@@ -182,8 +181,8 @@ def get_bert_layer_collection_inference_step(parallel_method):
         return inference_step
 
 
-def get_bert_layer_train_step(parallel_method,
-                  use_value_and_grad):
+def get_bert_layer_train_step(parallel_method, use_value_and_grad):
+
     def train_step(state, batch):
 
         def loss_func(params):
@@ -231,8 +230,9 @@ class PipelineBasicTest(unittest.TestCase):
         method = PipeshardParallel(
             num_micro_batches=4,
             default_auto_sharding_option=as_option or AutoShardingOption(),
-            layer_option=ManualLayerOption(remat_layer=use_remat) if manual_pipeline_layer else
-	                 AutoLayerOption(layer_num=2, remat_layer=use_remat),
+            layer_option=ManualLayerOption(
+                remat_layer=use_remat) if manual_pipeline_layer else
+            AutoLayerOption(layer_num=2, remat_layer=use_remat),
             stage_option=stage_option or UniformStageOption())
 
         # Init model and optimizer
@@ -290,8 +290,9 @@ class PipelineBasicTest(unittest.TestCase):
         method = PipeshardParallel(
             num_micro_batches=4,
             default_auto_sharding_option=as_option or AutoShardingOption(),
-            layer_option=ManualLayerOption(remat_layer=use_remat) if manual_pipeline_layer else
-	                 AutoLayerOption(layer_num=n_layers, remat_layer=use_remat),
+            layer_option=ManualLayerOption(
+                remat_layer=use_remat) if manual_pipeline_layer else
+            AutoLayerOption(layer_num=n_layers, remat_layer=use_remat),
             stage_option=stage_option or UniformStageOption())
 
         # Init model and optimizer
@@ -312,7 +313,8 @@ class PipelineBasicTest(unittest.TestCase):
 
         # Compile
         serial_train_step = get_bert_layer_train_step(None, use_value_and_grad)
-        parallel_train_step = get_bert_layer_train_step(method, use_value_and_grad)
+        parallel_train_step = get_bert_layer_train_step(method,
+                                                        use_value_and_grad)
         executable = parallel_train_step.get_executable(state, batch)
 
         # Run correctnesss test

--- a/alpa/testing.py
+++ b/alpa/testing.py
@@ -181,7 +181,12 @@ def get_bert_layer_collection_inference_step(parallel_method):
         return inference_step
 
 
-def get_bert_layer_train_step(parallel_method, use_value_and_grad):
+def get_bert_layer_train_step(parallel_method,
+                              use_value_and_grad,
+                              use_alpa_grad=None):
+
+    if use_alpa_grad is None:
+        use_alpa_grad = parallel_method is not None
 
     def train_step(state, batch):
 
@@ -190,7 +195,7 @@ def get_bert_layer_train_step(parallel_method, use_value_and_grad):
             loss = jnp.mean((out - batch["y"])**2)
             return loss
 
-        if parallel_method:
+        if use_alpa_grad:
             if use_value_and_grad:
                 val, grads = value_and_grad(loss_func)(state.params)
             else:

--- a/alpa/torch/trainer.py
+++ b/alpa/torch/trainer.py
@@ -19,13 +19,8 @@ related to dist dataloading.
 TrainState = namedtuple("TrainState", ["params", "bufs", "optim_state"])
 
 
-def train_torch_module(pt_module_gen,
-                       weight_init_func,
-                       dataloader,
-                       loss_func,
-                       optim_gen,
-                       parallel_method,
-                       layer_num=2):
+def train_torch_module(pt_module_gen, weight_init_func, dataloader, loss_func,
+                       optim_gen, parallel_method):
     for mode in ["local", "dist"]:
         # "local": pure PT eager mode on a single GPU,
         #     allows print in middle of graph, no dist training
@@ -59,11 +54,6 @@ def train_torch_module(pt_module_gen,
                 # do loss computation
                 loss_value = loss_func(out, targets)
                 return loss_value, bufs
-
-            if atorch.mode() == "dist" and isinstance(parallel_method,
-                                                      alpa.PipeshardParallel):
-                compute_loss = alpa.automatic_layer_construction(
-                    layer_num=layer_num)(compute_loss)
 
             # do model forward + backward pass
             (loss_value, bufs), params_grad = atorch.value_and_grad(

--- a/alpa/util.py
+++ b/alpa/util.py
@@ -611,8 +611,7 @@ class XlaPassContext:
         self.value_dict = value_dict
 
     def __enter__(self):
-        assert XlaPassContext.current is None, (
-            "Do not support nested context")
+        assert XlaPassContext.current is None, ("Do not support nested context")
         XlaPassContext.current = self
         xe.set_pass_context(self.value_dict)
 

--- a/alpa/util.py
+++ b/alpa/util.py
@@ -115,6 +115,23 @@ def update_jax_platform(platform):
     xb.get_backend.cache_clear()
 
 
+class GradFuncTransformContext:
+    """
+    A context to hold transformations applied to the forward function
+    before calling alpa.grad or alpa.value_and_grad.
+    """
+    transforms = []
+
+    def __init__(self, transform):
+        self.transform = transform
+
+    def __enter__(self):
+        GradFuncTransformContext.transforms.append(self.transform)
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        GradFuncTransformContext.transforms.pop()
+
+
 ########################################
 ##### Data Structure Utilities
 ########################################
@@ -595,7 +612,7 @@ class XlaPassContext:
 
     def __enter__(self):
         assert XlaPassContext.current is None, (
-            "Do not support recurrent context")
+            "Do not support nested context")
         XlaPassContext.current = self
         xe.set_pass_context(self.value_dict)
 

--- a/benchmark/alpa/benchmark_3d_infer_one_case_gpt_bert.py
+++ b/benchmark/alpa/benchmark_3d_infer_one_case_gpt_bert.py
@@ -75,7 +75,6 @@ def benchmark_gpt_bert_internal(model_type,
     (_, no_embedding, batch_size, seq_len, hidden_size, num_layers, num_heads,
      vocab_size, num_micro_batches, parallel_mode,
      parallel_args) = benchmark_case
-    no_embedding = True
     dtype = jnp.float16
     tie_word_embeddings = False
 

--- a/benchmark/alpa/benchmark_3d_infer_one_case_gpt_bert.py
+++ b/benchmark/alpa/benchmark_3d_infer_one_case_gpt_bert.py
@@ -7,9 +7,8 @@ import optax
 import time
 
 from alpa import (parallelize, global_config, get_global_cluster,
-                  set_global_virtual_physical_mesh, PipeshardParallel,
-                  ManualPipeshardParallel, AutoShardingOption,
-                  manual_layer_construction)
+                  set_global_virtual_physical_mesh, AutoShardingOption,
+                  PipeshardParallel, ManualStageOption)
 from alpa.model.bert_model import BertConfig, FlaxBertLayerCollection
 from alpa.model.model_util import TrainState
 from alpa.model.gpt_model import FlaxGPTForLMModule
@@ -58,9 +57,9 @@ def get_infer_step(parallel_method, model, no_embedding):
         return loss
 
     if no_embedding:
-        infer_step = manual_layer_construction(infer_step_without_embedding)
+        infer_step = infer_step_without_embedding
     else:
-        infer_step = manual_layer_construction(infer_step_with_embedding)
+        infer_step = infer_step_with_embedding
     return parallelize(infer_step, method=parallel_method, donate_argnums=())
 
 
@@ -76,6 +75,7 @@ def benchmark_gpt_bert_internal(model_type,
     (_, no_embedding, batch_size, seq_len, hidden_size, num_layers, num_heads,
      vocab_size, num_micro_batches, parallel_mode,
      parallel_args) = benchmark_case
+    no_embedding = True
     dtype = jnp.float16
     tie_word_embeddings = False
 
@@ -91,12 +91,13 @@ def benchmark_gpt_bert_internal(model_type,
         add_manual_remat = False
         num_manual_pipeline_stages = num_auto_layers
         add_manual_layer_marker = True
-        method = ManualPipeshardParallel(
-            *manual_stage_option,
+        method = PipeshardParallel(
             num_micro_batches=num_micro_batches,
             default_auto_sharding_option=AutoShardingOption(
                 prefer_reduce_scatter=prefer_reduce_scatter),
-            pipeline_schedule="inference")
+            pipeline_schedule="inference",
+            layer_option="manual",
+            stage_option=ManualStageOption(*manual_stage_option))
     else:
         raise ValueError(f"Invalid mode: {parallel_mode}")
 
@@ -206,7 +207,7 @@ def benchmark_gpt_bert_internal(model_type,
         executable.sync()
     e2e_latency = (time.time() - tic) / niter
 
-    overall_latency = np.mean(executable.get_execution_time_costs(warmup=1))
+    overall_latency = np.mean(executable.get_execution_time_costs())
 
     max_mem_allocated = executable.mesh_group.get_max_memory_allocated()
 

--- a/benchmark/alpa/benchmark_3d_one_case_moe.py
+++ b/benchmark/alpa/benchmark_3d_one_case_moe.py
@@ -72,6 +72,7 @@ def benchmark_moe_internal(benchmark_case, niter, num_hosts,
         prefer_reduce_scatter, use_remat, num_auto_layers, auto_stage_option = parallel_args
         add_manual_layer_marker = num_manual_pipeline_stages = add_manual_remat = None
         use_fine_grained_remat = fine_grained_remat_num_layers = None
+        auto_stage_option["cached_compute_cost"] = None
         method = PipeshardParallel(
             num_micro_batches=num_micro_batches,
             default_auto_sharding_option=AutoShardingOption(
@@ -80,7 +81,7 @@ def benchmark_moe_internal(benchmark_case, niter, num_hosts,
             ),
             layer_option=AutoLayerOption(layer_num=num_auto_layers,
                                          remat_layer=use_remat),
-            stage_option=AutoStageOption(*auto_stage_option))
+            stage_option=AutoStageOption(**auto_stage_option))
     elif parallel_mode == "load_solution":
         prefer_reduce_scatter, use_remat, num_auto_layers, manual_stage_option = parallel_args
         add_manual_layer_marker = num_manual_pipeline_stages = add_manual_remat = None

--- a/benchmark/alpa/benchmark_3d_one_case_moe.py
+++ b/benchmark/alpa/benchmark_3d_one_case_moe.py
@@ -8,7 +8,8 @@ import ray
 import alpa
 from alpa import (parallelize, global_config, get_global_cluster,
                   set_global_virtual_physical_mesh, AutoShardingOption,
-                  PipeshardParallel, ManualPipeshardParallel)
+                  PipeshardParallel, ManualStageOption, AutoStageOption,
+                  AutoLayerOption)
 from alpa.model.model_util import optax_adafactor
 from alpa.model.moe import FlaxMoEForLMModule, MoEConfig, TrainState
 from alpa.pipeline_parallel.stage_construction import get_last_dp_result
@@ -69,42 +70,41 @@ def benchmark_moe_internal(benchmark_case, niter, num_hosts,
     # Parallel configs
     if parallel_mode == "search":
         prefer_reduce_scatter, use_remat, num_auto_layers, auto_stage_option = parallel_args
-        auto_layer = True
-        auto_remat_mode = "fine_grained" if use_remat else None
-        num_auto_remat_layers = num_layers
-        add_manual_layer_marker = add_manual_remat = num_manual_pipeline_stages = False
+        add_manual_layer_marker = num_manual_pipeline_stages = add_manual_remat = None
+        use_fine_grained_remat = fine_grained_remat_num_layers = None
         method = PipeshardParallel(
-            stage_mode="auto",
             num_micro_batches=num_micro_batches,
             default_auto_sharding_option=AutoShardingOption(
                 prefer_reduce_scatter=prefer_reduce_scatter,
                 allow_mixed_mesh_shape=True,
             ),
-            **auto_stage_option)
+            layer_option=AutoLayerOption(layer_num=num_auto_layers,
+                                         remat_layer=use_remat),
+            stage_option=AutoStageOption(*auto_stage_option))
     elif parallel_mode == "load_solution":
         prefer_reduce_scatter, use_remat, num_auto_layers, manual_stage_option = parallel_args
-        auto_layer = True
-        auto_remat_mode = "fine_grained" if use_remat else None
-        num_auto_remat_layers = num_layers
-        add_manual_layer_marker = add_manual_remat = num_manual_pipeline_stages = False
-        method = ManualPipeshardParallel(
-            *manual_stage_option,
+        add_manual_layer_marker = num_manual_pipeline_stages = add_manual_remat = None
+        use_fine_grained_remat = use_remat
+        fine_grained_remat_num_layers = num_layers
+        method = PipeshardParallel(
             num_micro_batches=num_micro_batches,
             default_auto_sharding_option=AutoShardingOption(
                 prefer_reduce_scatter=prefer_reduce_scatter,
                 allow_mixed_mesh_shape=True,
-            ))
+            ),
+            layer_option=AutoLayerOption(layer_num=num_auto_layers),
+            stage_option=ManualStageOption(*manual_stage_option))
     elif parallel_mode == "manual":
         (prefer_reduce_scatter, use_remat, (dp, op, pp),
          force_batch_dim_mapping) = parallel_args
         as_option = AutoShardingOption(
-            prefer_reduce_scatter=prefer_reduce_scatter)
+            prefer_reduce_scatter=prefer_reduce_scatter,
+            allow_mixed_mesh_shape=True)
         if force_batch_dim_mapping:
             as_option.force_batch_dim_to_mesh_dim = 0
-        auto_layer = False
-        num_auto_layers = auto_remat_mode = num_auto_remat_layers = None
         add_manual_layer_marker = True
         add_manual_remat = use_remat
+        use_fine_grained_remat = fine_grained_remat_num_layers = None
 
         logical_mesh_shape = (dp, op)
         num_manual_pipeline_stages = pp
@@ -117,13 +117,15 @@ def benchmark_moe_internal(benchmark_case, niter, num_hosts,
             physical_mesh_shape = (num_mesh_devices // num_devices_per_host,
                                    num_devices_per_host)
 
-        method = ManualPipeshardParallel(
+        method = PipeshardParallel(
             num_micro_batches=num_micro_batches,
-            forward_stage_layer_ids=[[i] for i in range(pp)],
-            submesh_physical_shapes=[physical_mesh_shape] * pp,
-            submesh_logical_shapes=[logical_mesh_shape] * pp,
-            submesh_autosharding_option_dicts=[{}] * pp,
-            default_auto_sharding_option=as_option)
+            default_auto_sharding_option=as_option,
+            layer_option="manual",
+            stage_option=ManualStageOption(
+                forward_stage_layer_ids=[[i] for i in range(pp)],
+                submesh_physical_shapes=[physical_mesh_shape] * pp,
+                submesh_logical_shapes=[logical_mesh_shape] * pp,
+                submesh_autosharding_option_dicts=[{}] * pp))
     else:
         raise ValueError(f"Invalid model: {parallel_mode}")
 
@@ -160,9 +162,8 @@ def benchmark_moe_internal(benchmark_case, niter, num_hosts,
     print_used_time("Create train state")
 
     # Compile executable
-    train_step = get_train_step(method, auto_layer, num_manual_pipeline_stages,
-                                num_auto_layers, auto_remat_mode,
-                                num_auto_remat_layers)
+    train_step = get_train_step(method, use_fine_grained_remat,
+                                fine_grained_remat_num_layers)
     executable = train_step.get_executable(state, batch, rngkey)
     print_used_time("Compile (driver)")
 

--- a/benchmark/alpa/suite_auto_gpt.py
+++ b/benchmark/alpa/suite_auto_gpt.py
@@ -6,89 +6,91 @@ max_global_batch_size = 1024
 auto_stage_option = {
     "submesh_physical_shape_space": "small_power_of_two",
     "submesh_logical_shape_space": "all",
-    "auto_stage_imbalance_tolerance": 1.0,
+    "stage_imbalance_tolerance": 1.0,
     "use_hlo_cost_model": True,
     "profiling_database_filename": "prof_database.pkl",
 }
-
 
 prefer_reduce_scatter = True
 use_remat = True
 
 
 def get_search_cases(model_name, num_micro_batches_list, num_auto_layers_list):
-    return [(max_global_batch_size, *gpt_specs[model_name],
-             num_micro_batches, "search",
-             (prefer_reduce_scatter, use_remat,
-              num_auto_layers, auto_stage_option))
+    return [(max_global_batch_size, *gpt_specs[model_name], num_micro_batches,
+             "search", (prefer_reduce_scatter, use_remat, num_auto_layers,
+                        auto_stage_option))
             for num_micro_batches in num_micro_batches_list
             for num_auto_layers in num_auto_layers_list]
 
+
 def get_solution_case(model_name, num_micro_batches, num_auto_layers,
-                      forward_stage_layer_ids,
-                      submesh_physical_shapes, submesh_logical_shapes,
+                      forward_stage_layer_ids, submesh_physical_shapes,
+                      submesh_logical_shapes,
                       submesh_autosharding_option_dicts):
-    return [(max_global_batch_size, *gpt_specs[model_name],
-             num_micro_batches, "load_solution",
+    return [(max_global_batch_size, *gpt_specs[model_name], num_micro_batches,
+             "load_solution",
              (prefer_reduce_scatter, use_remat, num_auto_layers,
-              (forward_stage_layer_ids,
-               submesh_physical_shapes, submesh_logical_shapes,
-               submesh_autosharding_option_dicts)))]
+              (forward_stage_layer_ids, submesh_physical_shapes,
+               submesh_logical_shapes, submesh_autosharding_option_dicts)))]
 
 
 # Temporary debug suite
-tmp_suite = {
-}
-
+tmp_suite = {}
 
 # Performance test with search solutions found for p3.16xlarge
 perf_test_suite = {
-1: get_solution_case("350M", 512,
-                     1, [[0]],
-                     [(1, 1)], [(1, 1)],
-                     [{}]),
-2: get_solution_case("760M", 128,
-                     6, [[0, 1, 2], [3, 4, 5]],
-                     [(1, 1)] * 2, [(1, 1)] * 2,
-                     [{'force_batch_dim_to_mesh_dim': 0}] * 2),
-4: get_solution_case("1.3B", 128,
-                     6, [[0, 1, 2], [3, 4, 5]],
-                     [(1, 2)] * 2, [(2, 1)] * 2,
-                     [{'force_batch_dim_to_mesh_dim': 0}] * 2),
-8: get_solution_case("2.6B", 128,
-                     8, [[0, 1], [2, 3], [4, 5, 6, 7]],
-                     [(1, 2), (1, 2), (1, 4)], [(2, 1), (2, 1), (4, 1)],
-                     [{'force_batch_dim_to_mesh_dim': 0}, {}, {}]),
-16: get_solution_case("6.7B", 64,
-                      8, [[0, 1, 2, 3], [4, 5, 6, 7]],
-                      [(1, 8)] * 2, [(2, 4)] * 2,
-                      [{'force_batch_dim_to_mesh_dim': 0}] * 2),
-32: get_solution_case("15B", 128,
-                      16, [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11], [12, 13, 14, 15]],
-                      [(1, 8)] * 4, [(2, 4)] * 4,
-                      [{'force_batch_dim_to_mesh_dim': 0}] * 4),
-64: get_solution_case("39B", 1024,
-                      16, [[0], [1], [2], [3], [4], [5], [6], [7], [8], [9], [10], [11], [12], [13], [14], [15]],
-                      [(1, 4)] * 16, [(1, 4)] * 16,
-                      [{'force_batch_dim_to_mesh_dim': 0}] * 16),
+    1:
+        get_solution_case("350M", 512, 1, [[0]], [(1, 1)], [(1, 1)], [{}]),
+    2:
+        get_solution_case("760M", 128, 6, [[0, 1, 2], [3, 4, 5]], [(1, 1)] * 2,
+                          [(1, 1)] * 2, [{
+                              'force_batch_dim_to_mesh_dim': 0
+                          }] * 2),
+    4:
+        get_solution_case("1.3B", 128, 6, [[0, 1, 2], [3, 4, 5]], [(1, 2)] * 2,
+                          [(2, 1)] * 2, [{
+                              'force_batch_dim_to_mesh_dim': 0
+                          }] * 2),
+    8:
+        get_solution_case("2.6B", 128, 8, [[0, 1], [2, 3], [4, 5, 6, 7]],
+                          [(1, 2), (1, 2), (1, 4)], [(2, 1), (2, 1), (4, 1)], [{
+                              'force_batch_dim_to_mesh_dim': 0
+                          }, {}, {}]),
+    16:
+        get_solution_case("6.7B", 64, 8, [[0, 1, 2, 3], [4, 5, 6, 7]],
+                          [(1, 8)] * 2, [(2, 4)] * 2, [{
+                              'force_batch_dim_to_mesh_dim': 0
+                          }] * 2),
+    32:
+        get_solution_case(
+            "15B", 128, 16,
+            [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11], [12, 13, 14, 15]],
+            [(1, 8)] * 4, [(2, 4)] * 4, [{
+                'force_batch_dim_to_mesh_dim': 0
+            }] * 4),
+    64:
+        get_solution_case("39B", 1024,
+                          16, [[0], [1], [2], [3], [4], [5], [6], [7], [8], [9],
+                               [10], [11], [12], [13], [14], [15]],
+                          [(1, 4)] * 16, [(1, 4)] * 16, [{
+                              'force_batch_dim_to_mesh_dim': 0
+                          }] * 16),
 }
-
 
 # Grid search on hyperparameters
 grid_search_suite = {
-2: (get_search_cases("760M", [32, 64, 128, 256], [6]) +
-    get_search_cases("760M", [32, 64], [12])),
-4: (get_search_cases("1.3B", [32, 64, 128], [6]) +
-    get_search_cases("1.3B", [32, 64], [12])),
-8: (get_search_cases("2.6B", [64, 128, 256], [8]) +
-    get_search_cases("2.6B", [64, 128], [16])),
-16: get_search_cases("6.7B", [32, 64, 128, 256], [8]),
-32: get_search_cases("15B", [64, 128, 256, 512], [16]),
-64: get_search_cases("39B", [128, 256, 512, 1024], [8]),
+    2: (get_search_cases("760M", [32, 64, 128, 256], [6]) +
+        get_search_cases("760M", [32, 64], [12])),
+    4: (get_search_cases("1.3B", [32, 64, 128], [6]) +
+        get_search_cases("1.3B", [32, 64], [12])),
+    8: (get_search_cases("2.6B", [64, 128, 256], [8]) +
+        get_search_cases("2.6B", [64, 128], [16])),
+    16: get_search_cases("6.7B", [32, 64, 128, 256], [8]),
+    32: get_search_cases("15B", [64, 128, 256, 512], [16]),
+    64: get_search_cases("39B", [128, 256, 512, 1024], [8]),
 }
-
 
 # Small test cases for correctness test
 correctness_test_suite = {
-8: get_search_cases("2.6B", [128], [8]),
+    8: get_search_cases("2.6B", [128], [8]),
 }

--- a/benchmark/alpa/suite_auto_moe.py
+++ b/benchmark/alpa/suite_auto_moe.py
@@ -7,7 +7,7 @@ expert_group_size = 2048
 auto_stage_option = {
     "submesh_physical_shape_space": "small_power_of_two",
     "submesh_logical_shape_space": "all",
-    "auto_stage_imbalance_tolerance": 1.0,
+    "stage_imbalance_tolerance": 1.0,
     "use_hlo_cost_model": True,
     "profiling_database_filename": "prof_database.pkl",
 }
@@ -18,67 +18,65 @@ use_remat = True
 
 def get_search_cases(model_name, num_micro_batches_list, num_auto_layers_list):
     return [(max_global_batch_size, *moe_specs[model_name], expert_group_size,
-             num_micro_batches, "search",
-             (prefer_reduce_scatter, use_remat,
-              num_auto_layers, auto_stage_option))
+             num_micro_batches, "search", (prefer_reduce_scatter, use_remat,
+                                           num_auto_layers, auto_stage_option))
             for num_micro_batches in num_micro_batches_list
             for num_auto_layers in num_auto_layers_list]
 
 
 def get_solution_case(model_name, num_micro_batches, num_auto_layers,
-                      forward_stage_layer_ids,
-                      submesh_physical_shapes, submesh_logical_shapes,
+                      forward_stage_layer_ids, submesh_physical_shapes,
+                      submesh_logical_shapes,
                       submesh_autosharding_option_dicts):
     return [(max_global_batch_size, *moe_specs[model_name], expert_group_size,
              num_micro_batches, "load_solution",
              (prefer_reduce_scatter, use_remat, num_auto_layers,
-              (forward_stage_layer_ids,
-               submesh_physical_shapes, submesh_logical_shapes,
-               submesh_autosharding_option_dicts)))]
+              (forward_stage_layer_ids, submesh_physical_shapes,
+               submesh_logical_shapes, submesh_autosharding_option_dicts)))]
+
 
 # Temporary debug suite
-tmp_suite = {
-}
-
+tmp_suite = {}
 
 # Performance test with search solutions found for p3.16xlarge
 perf_test_suite = {
-1: get_solution_case("380M", 512,
-    1, [[0]],
-    [(1, 1)], [(1, 1)],
-    [{}]),
-2: get_solution_case("690M", 32,
-    8, [[0, 1, 2, 3, 4, 5, 6, 7]],
-    [(1, 2)], [(2, 1)],
-    [{'force_batch_dim_to_mesh_dim': 0}]),
-4: get_solution_case("1.3B", 32,
-    8, [[0, 1, 2, 3], [4, 5, 6, 7]],
-    [(1, 2)] * 2, [(2, 1)] * 2,
-    [{'force_batch_dim_to_mesh_dim': 0}] * 2),
-8: get_solution_case("2.4B", 32,
-    8, [[0, 1, 2, 3], [4, 5, 6, 7]],
-    [(1, 4)] * 2, [(4, 1)] * 2,
-    [{'force_batch_dim_to_mesh_dim': 0}] * 2),
-16: get_solution_case("10B", 16,
-    8, [[0, 1, 2, 3], [4, 5, 6, 7]],
-    [(1, 8)] * 2, [(8, 1)] * 2,
-    [{}] * 2),
-32: get_solution_case("27B", 128,
-    8, [[0], [1], [2], [3], [4], [5], [6], [7]],
-    [(1, 4)] * 8, [(4, 1)] * 8,
-    [{}] * 8),
-64: get_solution_case("70B", 64,
-    8, [[0], [1], [2], [3], [4], [5], [6], [7]],
-    [(1, 8)] * 8, [(8, 1)] * 8,
-    [{}] * 8),
+    1:
+        get_solution_case("380M", 512, 1, [[0]], [(1, 1)], [(1, 1)], [{}]),
+    2:
+        get_solution_case("690M", 32, 8, [[0, 1, 2, 3, 4, 5, 6, 7]], [(1, 2)],
+                          [(2, 1)], [{
+                              'force_batch_dim_to_mesh_dim': 0
+                          }]),
+    4:
+        get_solution_case("1.3B", 32, 8, [[0, 1, 2, 3], [4, 5, 6, 7]],
+                          [(1, 2)] * 2, [(2, 1)] * 2, [{
+                              'force_batch_dim_to_mesh_dim': 0
+                          }] * 2),
+    8:
+        get_solution_case("2.4B", 32, 8, [[0, 1, 2, 3], [4, 5, 6, 7]],
+                          [(1, 4)] * 2, [(4, 1)] * 2, [{
+                              'force_batch_dim_to_mesh_dim': 0
+                          }] * 2),
+    16:
+        get_solution_case("10B", 16, 8, [[0, 1, 2, 3], [4, 5, 6, 7]],
+                          [(1, 8)] * 2, [(8, 1)] * 2, [{}] * 2),
+    32:
+        get_solution_case("27B", 128, 8,
+                          [[0], [1], [2], [3], [4], [5], [6], [7]],
+                          [(1, 4)] * 8, [(4, 1)] * 8, [{}] * 8),
+    64:
+        get_solution_case("70B", 64, 8,
+                          [[0], [1], [2], [3], [4], [5], [6], [7]],
+                          [(1, 8)] * 8, [(8, 1)] * 8, [{}] * 8),
 }
 
 # Grid search on hyperparameters
 grid_search_suite = {
-2: (get_search_cases("690M", [16, 32, 64], [8])),
-4: (get_search_cases("1.3B", [16, 32, 64], [8])),
-8: (get_search_cases("2.4B", [16, 32, 64], [8])),
-16: (get_search_cases("10B", [16, 32, 64], [8])),
-32: (get_search_cases("27B", [32, 64, 128], [4, 8, 16])),
-64: (get_search_cases("70B", [64], [8, 16, 32])),   # submesh_choices_mode: "small_power_of_two", max num_cpus = 20
+    2: (get_search_cases("690M", [16, 32, 64], [8])),
+    4: (get_search_cases("1.3B", [16, 32, 64], [8])),
+    8: (get_search_cases("2.4B", [16, 32, 64], [8])),
+    16: (get_search_cases("10B", [16, 32, 64], [8])),
+    32: (get_search_cases("27B", [32, 64, 128], [4, 8, 16])),
+    64: (get_search_cases("70B", [64], [8, 16, 32])
+        ),  # submesh_choices_mode: "small_power_of_two", max num_cpus = 20
 }

--- a/benchmark/alpa/suite_wresnet.py
+++ b/benchmark/alpa/suite_wresnet.py
@@ -10,113 +10,135 @@ _ = None
 
 wresnet_specs = {
     #    I,   L,   C,   W,  dtype,
-"250M": (224, 50,  160, 2,  "fp32"),
-"500M": (224, 50,  224, 2,  "fp32"),
-"1B":   (224, 50,  320, 2,  "fp32"),
-"2B":   (224, 50,  448, 2,  "fp32"),
-"4B":   (224, 50,  640, 2,  "fp32"),
-"6.8B": (224, 50,  320, 16, "fp32"),
-"13B":  (224, 101, 320, 16, "fp32"),
+    "250M": (224, 50, 160, 2, "fp32"),
+    "500M": (224, 50, 224, 2, "fp32"),
+    "1B": (224, 50, 320, 2, "fp32"),
+    "2B": (224, 50, 448, 2, "fp32"),
+    "4B": (224, 50, 640, 2, "fp32"),
+    "6.8B": (224, 50, 320, 16, "fp32"),
+    "13B": (224, 101, 320, 16, "fp32"),
 }
-
 
 prefer_reduce_scatter = True
 use_remat = True
 
 auto_stage_option = {
-    "auto_stage_imbalance_tolerance": 0.25,
     "submesh_physical_shape_space": "small_power_of_two",
     "submesh_logical_shape_space": "single_node_model_parallel",
+    "stage_imbalance_tolerance": 0.25,
+    "use_hlo_cost_model": False,
+    "profiling_database_filename": None,
 }
 
 
-def get_search_cases(model_name, max_global_batch_size,
-                     num_micro_batches_list):
+def get_search_cases(model_name, max_global_batch_size, num_micro_batches_list):
     return [(max_global_batch_size, *wresnet_specs[model_name],
-             num_micro_batches, "search",
-             (prefer_reduce_scatter, use_remat, auto_stage_option))
+             num_micro_batches, "search", (prefer_reduce_scatter, use_remat,
+                                           auto_stage_option))
             for num_micro_batches in num_micro_batches_list]
 
 
-def get_solution_case(model_name, max_global_batch_size,
-                      num_micro_batches,
-                      forward_stage_layer_ids,
-                      submesh_physical_shapes, submesh_logical_shapes,
+def get_solution_case(model_name, max_global_batch_size, num_micro_batches,
+                      forward_stage_layer_ids, submesh_physical_shapes,
+                      submesh_logical_shapes,
                       submesh_autosharding_option_dicts):
     return [(max_global_batch_size, *wresnet_specs[model_name],
              num_micro_batches, "load_solution",
              (prefer_reduce_scatter, use_remat,
-              (forward_stage_layer_ids,
-              submesh_physical_shapes, submesh_logical_shapes,
-              submesh_autosharding_option_dicts)))]
+              (forward_stage_layer_ids, submesh_physical_shapes,
+               submesh_logical_shapes, submesh_autosharding_option_dicts)))]
+
 
 # Performance test with shard parallel
-tmp_suite = { # key = the number of gpus, value = a list of cases
+tmp_suite = {  # key = the number of gpus, value = a list of cases
 }
 
 # Performance test with shard parallel
 perf_test_2d_suite = { # key = the number of gpus, value = a list of cases
-1: [
+    1: [
     #B,    I,   L,   C,   W, dtype,  NB, PM,          RS,    Remat, L_shape, FM
     (32,   224, 50,  160, 2, "fp32", 1,  "2d_shard", (False, False, (1, 1),  False)),
     (1536, 224, 50,  160, 2, "fp32", 48, "2d_shard", (False, False, (1, 1),  False)),
-],
+    ],
 
-4 : [
+    4 : [
     (32,   224, 50,  320, 2, "fp32", 1,  "2d_shard", (False, False, (4, 1),  False)),
     (1536, 224, 50,  320, 2, "fp32", 48, "2d_shard", (False, False, (4, 1),  False)),
     (64,   224, 50,  320, 2, "fp32", 1,  "2d_shard", (False, False, (4, 1),  False)),
     (1536, 224, 50,  320, 2, "fp32", 24, "2d_shard", (False, False, (4, 1),  False)),
-],
+    ],
 
-8: [
+    8: [
     (64,   224, 50,  320, 2, "fp32", 1,  "2d_shard", (False, False, (8, 1),  False)),
-],
+    ],
 }
-
 
 # Performance test with search solutions found for p3.16xlarge
 perf_test_auto_suite = {
-1: get_solution_case("250M", 1536, 24,
-                     [list(range(16))],
-                     [(1, 1)], [(1, 1)],
-                     [{}]),
-2: get_solution_case("500M", 1536, 24,
-                     [list(range(16))],
-                     [(1, 2)], [(1, 2)],
-                     [{}]),
-4: get_solution_case("1B", 1536, 24,
-                      [list(range(16))],
-                      [(1, 4)], [(1, 4)],
-                      [{}]),
-8: get_solution_case("2B",  1536, 24,
-                     [[0, 1, 2, 3, 4, 5, 6, 7], [8, 9, 10, 11, 12, 13, 14, 15]],
-                     [(1, 4), (1, 4)], [(4, 1), (1, 4)],
-                     [{}, {'force_batch_dim_to_mesh_dim': 0}]),
-16: get_solution_case("4B", 1536, 32,
-                      [[0, 1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12, 13, 14, 15]],
-                      [(1, 4), (1, 4), (1, 8)], [(4, 1), (4, 1), (8, 1)],
-                      [{'force_batch_dim_to_mesh_dim': 0}, {'force_batch_dim_to_mesh_dim': 0}, {}]),
-32: get_solution_case("6.8B", 1536, 32,
-                      [[0, 1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15]],
-                      [(1, 8), (1, 8), (1, 8), (1, 8)], [(8, 1), (8, 1), (8, 1), (8, 1)],
-                      [{'force_batch_dim_to_mesh_dim': 0}, {}, {}, {}]),
-64: get_solution_case("13B", 1520, 38,
-                      [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11], [12, 13, 14, 15], [16, 17, 18, 19], [20, 21, 22, 23], [24, 25, 26, 27, 28], [29, 30, 31, 32]],
-                      [(1, 8), (1, 8), (1, 8), (1, 8), (1, 8), (1, 8), (1, 8), (1, 8)],
-                      [(8, 1), (1, 8), (8, 1), (1, 8), (8, 1), (8, 1), (1, 8), (8, 1)],
-                      [{}, {'force_batch_dim_to_mesh_dim': 0}, {}, {'force_batch_dim_to_mesh_dim': 0}, {}, {}, {'force_batch_dim_to_mesh_dim': 0}, {}]),
+    1:
+        get_solution_case("250M", 1536, 24, [list(range(16))], [(1, 1)],
+                          [(1, 1)], [{}]),
+    2:
+        get_solution_case("500M", 1536, 24, [list(range(16))], [(1, 2)],
+                          [(1, 2)], [{}]),
+    4:
+        get_solution_case("1B", 1536, 24, [list(range(16))], [(1, 4)], [(1, 4)],
+                          [{}]),
+    8:
+        get_solution_case(
+            "2B", 1536, 24,
+            [[0, 1, 2, 3, 4, 5, 6, 7], [8, 9, 10, 11, 12, 13, 14, 15]],
+            [(1, 4), (1, 4)], [(4, 1), (1, 4)], [{}, {
+                'force_batch_dim_to_mesh_dim': 0
+            }]),
+    16:
+        get_solution_case(
+            "4B", 1536, 32,
+            [[0, 1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12, 13, 14, 15]],
+            [(1, 4), (1, 4), (1, 8)], [(4, 1), (4, 1), (8, 1)], [{
+                'force_batch_dim_to_mesh_dim': 0
+            }, {
+                'force_batch_dim_to_mesh_dim': 0
+            }, {}]),
+    32:
+        get_solution_case(
+            "6.8B", 1536,
+            32, [[0, 1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15]],
+            [(1, 8), (1, 8), (1, 8),
+             (1, 8)], [(8, 1), (8, 1), (8, 1),
+                       (8, 1)], [{
+                           'force_batch_dim_to_mesh_dim': 0
+                       }, {}, {}, {}]),
+    64:
+        get_solution_case("13B", 1520, 38,
+                          [[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11],
+                           [12, 13, 14, 15], [16, 17, 18, 19], [20, 21, 22, 23],
+                           [24, 25, 26, 27, 28], [29, 30, 31, 32]], [(1, 8),
+                                                                     (1, 8),
+                                                                     (1, 8),
+                                                                     (1, 8),
+                                                                     (1, 8),
+                                                                     (1, 8),
+                                                                     (1, 8),
+                                                                     (1, 8)],
+                          [(8, 1), (1, 8), (8, 1), (1, 8), (8, 1), (8, 1),
+                           (1, 8), (8, 1)], [{}, {
+                               'force_batch_dim_to_mesh_dim': 0
+                           }, {}, {
+                               'force_batch_dim_to_mesh_dim': 0
+                           }, {}, {}, {
+                               'force_batch_dim_to_mesh_dim': 0
+                           }, {}]),
 }
-
 
 # Grid search on hyperparameters
 grid_search_auto_suite = {  # key = the number of gpus, value = a list of cases
-1: get_search_cases("250M", 1536, [24, 32]),
-2: get_search_cases("500M", 1536, [24, 32]),
-4: get_search_cases("1B", 1536, [24, 32]),
-8: get_search_cases("2B", 1536, [24, 32]),
-16: get_search_cases("4B", 1536, [24, 32]),
-32: (get_search_cases("6.8B", 1520, [38]) +
+    1: get_search_cases("250M", 1536, [24, 32]),
+    2: get_search_cases("500M", 1536, [24, 32]),
+    4: get_search_cases("1B", 1536, [24, 32]),
+    8: get_search_cases("2B", 1536, [24, 32]),
+    16: get_search_cases("4B", 1536, [24, 32]),
+    32: (get_search_cases("6.8B", 1520, [38]) +
      get_search_cases("6.8B", 1512, [42])),
-64: get_search_cases("13B", 1520, [38]),
+    64: get_search_cases("13B", 1520, [38]),
 }

--- a/docs/gallery/tutorials/pipeshard_parallelism.py
+++ b/docs/gallery/tutorials/pipeshard_parallelism.py
@@ -16,7 +16,7 @@ Then we show how to use Alpa to automate this process.
 ################################################################################
 # Import Libraries and Initialize Environment
 # -------------------------------------------
-# We first import the required libraries.
+# First, import the required libraries.
 
 import alpa
 from alpa.testing import assert_allclose
@@ -89,7 +89,7 @@ tx = optax.adam(learning_rate=1e-3)
 state = TrainState.create(apply_fn=model.apply, params=params, tx=tx)
 
 
-# Define training step
+# Define the training step
 def train_step(state, batch):
 
     def loss_func(params):
@@ -108,14 +108,14 @@ expected_state = train_step(state, batch)
 ################################################################################
 # Pipeline Parallelism with Manual Assignment
 # -------------------------------------------
-# To manually assign stages for pipeline parallelism, we can use the
-# ``alpa.mark_pipeline_boundary`` function to mark the boundary of each pipeline
-# stage, and use the ``@alpa.manual_layer_construction`` decorator to indicate
-# that we are manually assigning stages. Note that each the pipeline stage is
-# also automatically parallelized by the shard parallel pass.
+# Pipeline paralleism requires partitioning the model into several pipeline
+# stages. To manually assign stages, we can use ``alpa.mark_pipeline_boundary``
+# to mark the boundary of each pipeline stage in the forward function.
+# Note that each pipeline stage is also automatically parallelized by the
+# shard parallel pass.
 
 
-# Define the manually parallelized model with pipeline markers.
+# Define a MLP model with manual stage boundaries.
 class ManualPipelineMLPModel(nn.Module):
     hidden_dim: int
 
@@ -125,7 +125,7 @@ class ManualPipelineMLPModel(nn.Module):
         x = nn.relu(x)
         x = nn.Dense(features=self.hidden_dim)(x)
         x = nn.relu(x)
-        # Use this boundary marker to separate the network into two stages.
+        # Use this boundary marker to separate the model into two stages.
         alpa.mark_pipeline_boundary()
         x = nn.Dense(features=self.hidden_dim * 4)(x)
         x = nn.relu(x)
@@ -142,13 +142,15 @@ manual_pipeline_state = TrainState.create(apply_fn=manual_pipeline_model.apply,
                                           tx=tx)
 
 
-# Define the training step with manually parallelized pipeline stages.
+# Define the training step.
 # We use the "alpa.PipeshardParallel" option to let alpa use both
-# pipeline parallelism and shard parallelism.
-@alpa.parallelize(method=alpa.PipeshardParallel(num_micro_batches=16))
+# pipeline parallelism and shard parallelism. To make pipeline parallelism
+# efficient, we need to fill the pipeline with many micro batches,
+# so a `num_micro_batches` should be specified.
+@alpa.parallelize(method=alpa.PipeshardParallel(num_micro_batches=16,
+                                                layer_option="manual"))
 def manual_pipeline_train_step(state, batch):
-    # Indicate that we are manually assigning pipeline stages.
-    @alpa.manual_layer_construction
+
     def loss_func(params):
         out = state.apply_fn(params, batch["x"])
         loss = jnp.mean((out - batch["y"])**2)
@@ -170,6 +172,16 @@ assert_allclose(expected_state.params,
 
 alpa.shutdown()
 
+####################
+#
+# .. note::
+#
+#   In addition, Alpa supports more flexible manual assignments of pipeline
+#   parallelism strategies. In the above example, each partitioned stages will
+#   be assigned an equal number of devices to run. If you want to control the
+#   device assignment of each stage, you can use the more advanced
+#   ``alpa.ManualPipeshardParallel``.
+
 ################################################################################
 # Pipeline Parallelism with Automatic Assignment
 # ----------------------------------------------
@@ -189,19 +201,19 @@ alpa.shutdown()
 
 alpa.init(cluster="ray")
 
-# Define training step with automatic pipeline-operator parallelism. Note that
-# we reuse the same model and state as the single device case. The only
-# modification required is the two decorators. The stage construction and
-# mesh slicing are performed within the `parallelize` decorator.
+# Define the parallel method.
+# `alpa.AutoLayerOption(layer_num=2)` means we use the auto layer construcion
+# algorithm to cluster primitive operators into two layers.
+# `stage_option="auto"` means we enable the auto stage construction algorithm.
+method = alpa.PipeshardParallel(num_micro_batches=16,
+                                layer_option=alpa.AutoLayerOption(layer_num=2),
+                                stage_option="auto")
 
 
-@alpa.parallelize(method=alpa.PipeshardParallel(num_micro_batches=16,
-                                                stage_mode="auto"))
+# Define the training step. The function body is the same as the above one.
+@alpa.parallelize(method=method)
 def auto_pipeline_train_step(state, batch):
-    # Indicate that we use automatic layer construction. The `layer_num` here
-    # is a hyperparameter to control how many layers we get from the
-    # layer construction algorithm.
-    @alpa.automatic_layer_construction(layer_num=2)
+
     def loss_func(params):
         out = state.apply_fn(params, batch["x"])
         loss = jnp.mean((out - batch["y"])**2)

--- a/docs/gallery/tutorials/pipeshard_parallelism.py
+++ b/docs/gallery/tutorials/pipeshard_parallelism.py
@@ -180,7 +180,7 @@ alpa.shutdown()
 #   parallelism strategies. In the above example, each partitioned stages will
 #   be assigned an equal number of devices to run. If you want to control the
 #   device assignment of each stage, you can use the more advanced
-#   ``alpa.ManualPipeshardParallel``.
+#   ``stage_option=alpa.ManualStageOption``.
 
 ################################################################################
 # Pipeline Parallelism with Automatic Assignment

--- a/docs/tutorials/perf_tuning_guide.rst
+++ b/docs/tutorials/perf_tuning_guide.rst
@@ -33,9 +33,9 @@ To make sure Alpa can perform auto-parallelization correctly, we can start with 
 
    Try to combine pipeline parallelism and shard parallelism. 
 
-   1. Layer construction. You can use the automatic layer construction by using ``@automatic_layer_construction``.
+   1. Layer construction. You can use the automatic layer construction by using ``layer_option=AutoLayerOption(layer_num=...)``.
       You can try a few choices of the ``layer_num`` argument and see the performance. The best choice of this value depends on the number of nodes in your cluster and the number of repetitive blocks in your model.
-      You can also do layer construction manually by using ``@manual_layer_construction`` and ``mark_pipeline_boundary``
+      You can also do layer construction manually by using ``layer_option="manual"`` and ``mark_pipeline_boundary``
    2. Number of micro batches. The ``num_micro_batches`` also affects the performance a lot. You can fix a large global batch size and try a few choices of ``num_micro_batches``.
 
 Reducing Runtime Overhead

--- a/examples/opt_serving/model/opt_model.py
+++ b/examples/opt_serving/model/opt_model.py
@@ -688,8 +688,8 @@ def get_pipeshard_executable(config,
 
     # Parallelize
     method = alpa.PipeshardParallel(num_micro_batches=num_micro_batches,
-                                    pipeline_schedule="inference")
-
+                                    pipeline_schedule="inference",
+                                    layer_option="manual")
     #method = alpa.ShardParallel()
 
     if autoregressive:

--- a/examples/opt_serving/model/opt_model.py
+++ b/examples/opt_serving/model/opt_model.py
@@ -689,15 +689,12 @@ def get_pipeshard_executable(config,
     # Parallelize
     method = alpa.PipeshardParallel(num_micro_batches=num_micro_batches,
                                     pipeline_schedule="inference")
-    layer_construction = alpa.manual_layer_construction
 
     #method = alpa.ShardParallel()
-    #layer_construction = lambda x: x
 
     if autoregressive:
 
         @alpa.parallelize(batch_argnums=(1,), method=method)
-        @layer_construction
         def inference_step_with_cache(params, batch):
             output = model.apply(
                 params,
@@ -718,7 +715,6 @@ def get_pipeshard_executable(config,
     else:
 
         @alpa.parallelize(batch_argnums=(1,), method=method)
-        @layer_construction
         def inference_step(params, batch):
             output = model.apply(
                 params,

--- a/tests/pipeline_parallel/test_bert.py
+++ b/tests/pipeline_parallel/test_bert.py
@@ -7,10 +7,10 @@ import optax
 import ray
 
 from alpa import init, parallelize, PipeshardParallel
-from alpa.layer_construction import manual_layer_construction
-from alpa.parallel_method import LocalPipelineParallel
 from alpa.model.model_util import TrainState
 from alpa.model.bert_model import BertConfig
+from alpa.parallel_method import LocalPipelineParallel
+from alpa.pipeline_parallel.layer_construction import manual_layer_construction
 from alpa.testing import BertLayerModel, assert_allclose
 
 

--- a/tests/pipeline_parallel/test_bert.py
+++ b/tests/pipeline_parallel/test_bert.py
@@ -6,8 +6,8 @@ import jax.numpy as jnp
 import optax
 import ray
 
-from alpa import (init, parallelize, manual_layer_construction,
-                  PipeshardParallel)
+from alpa import init, parallelize, PipeshardParallel
+from alpa.layer_construction import manual_layer_construction
 from alpa.parallel_method import LocalPipelineParallel
 from alpa.model.model_util import TrainState
 from alpa.model.bert_model import BertConfig

--- a/tests/pipeline_parallel/test_inference_only.py
+++ b/tests/pipeline_parallel/test_inference_only.py
@@ -5,7 +5,7 @@ import jax.numpy as jnp
 import numpy as np
 
 from alpa import (init, shutdown, PipeshardParallel, parallelize,
-                  mark_pipeline_boundary, manual_layer_construction)
+                  mark_pipeline_boundary)
 from alpa.model.bert_model import BertConfig, FlaxBertLayerCollection
 from alpa.testing import (MLPModel, create_train_state,
                           get_bert_layer_collection_inference_step,

--- a/tests/pipeline_parallel/test_inference_only.py
+++ b/tests/pipeline_parallel/test_inference_only.py
@@ -23,7 +23,8 @@ class PipelineInferenceTest(unittest.TestCase):
 
     def run_mlp_inference(self, manual_pipeline_layer):
         method = PipeshardParallel(num_micro_batches=4,
-                                   pipeline_schedule="inference")
+                                   pipeline_schedule="inference",
+                                   layer_option="manual")
 
         # Init model and optimizer
         batch_size = 64
@@ -40,9 +41,8 @@ class PipelineInferenceTest(unittest.TestCase):
         state = create_train_state(rngkey, model, [x])
 
         # Compile
-        serial_inference_step = get_mlp_inference_step(None, None)
-        parallel_inference_step = get_mlp_inference_step(
-            method, manual_pipeline_layer)
+        serial_inference_step = get_mlp_inference_step(None)
+        parallel_inference_step = get_mlp_inference_step(method)
         executable = parallel_inference_step.get_executable(state, batch)
 
         # Run correctnesss test
@@ -55,7 +55,8 @@ class PipelineInferenceTest(unittest.TestCase):
 
     def run_bert_layer_collection_inference(self, manual_pipeline_layer):
         method = PipeshardParallel(num_micro_batches=4,
-                                   pipeline_schedule="inference")
+                                   pipeline_schedule="inference",
+                                   layer_option="manual")
 
         # Init model and optimizer
         batch_size = 16
@@ -81,10 +82,8 @@ class PipelineInferenceTest(unittest.TestCase):
         state = create_train_state(rngkey, model, [x, attention_mask])
 
         # Compile
-        serial_inference_step = get_bert_layer_collection_inference_step(
-            None, None, n_layers)
-        parallel_inference_step = get_bert_layer_collection_inference_step(
-            method, manual_pipeline_layer, n_layers)
+        serial_inference_step = get_bert_layer_collection_inference_step(None)
+        parallel_inference_step = get_bert_layer_collection_inference_step(method)
         executable = parallel_inference_step.get_executable(state, batch)
 
         # Run correctnesss test
@@ -103,10 +102,10 @@ class PipelineInferenceTest(unittest.TestCase):
 
     def test_output(self):
         method = PipeshardParallel(num_micro_batches=1,
-                                   pipeline_schedule="inference")
+                                   pipeline_schedule="inference",
+                                   layer_option="manual")
 
         @parallelize(method=method)
-        @manual_layer_construction
         def func():
             a = jnp.ones(32)
             mark_pipeline_boundary()

--- a/tests/pipeline_parallel/test_inference_only.py
+++ b/tests/pipeline_parallel/test_inference_only.py
@@ -83,7 +83,8 @@ class PipelineInferenceTest(unittest.TestCase):
 
         # Compile
         serial_inference_step = get_bert_layer_collection_inference_step(None)
-        parallel_inference_step = get_bert_layer_collection_inference_step(method)
+        parallel_inference_step = get_bert_layer_collection_inference_step(
+            method)
         executable = parallel_inference_step.get_executable(state, batch)
 
         # Run correctnesss test

--- a/tests/pipeline_parallel/test_mlp.py
+++ b/tests/pipeline_parallel/test_mlp.py
@@ -29,6 +29,8 @@ class PipelineMLPTest(unittest.TestCase):
                 loss = jnp.mean((out - y)**2)
                 return loss
 
+            # Note, we can only use jax.grad in this testcase.
+            # TODO: Fix https://github.com/alpa-projects/alpa/issues/560
             grads = jax.grad(loss_func)(state.params, batch["x"], batch["y"])
             return grads
 

--- a/tests/pipeline_parallel/test_mlp.py
+++ b/tests/pipeline_parallel/test_mlp.py
@@ -6,8 +6,8 @@ import jax.numpy as jnp
 import optax
 import ray
 
-from alpa import (init, parallelize, manual_layer_construction,
-                  PipeshardParallel)
+from alpa import init, parallelize, PipeshardParallel
+from alpa.layer_construction import manual_layer_construction
 from alpa.parallel_method import LocalPipelineParallel
 from alpa.model.model_util import TrainState
 from alpa.testing import MLPModel, assert_allclose

--- a/tests/pipeline_parallel/test_mlp.py
+++ b/tests/pipeline_parallel/test_mlp.py
@@ -7,9 +7,9 @@ import optax
 import ray
 
 from alpa import init, parallelize, PipeshardParallel
-from alpa.layer_construction import manual_layer_construction
-from alpa.parallel_method import LocalPipelineParallel
 from alpa.model.model_util import TrainState
+from alpa.parallel_method import LocalPipelineParallel
+from alpa.pipeline_parallel.layer_construction import manual_layer_construction
 from alpa.testing import MLPModel, assert_allclose
 
 

--- a/tests/pipeline_parallel/test_tied_embedding.py
+++ b/tests/pipeline_parallel/test_tied_embedding.py
@@ -7,7 +7,7 @@ import jax.numpy as jnp
 import optax
 
 from alpa import (init, parallelize, mark_pipeline_boundary,
-                  manual_layer_construction, grad, PipeshardParallel)
+                  grad, PipeshardParallel)
 from alpa.model.model_util import TrainState
 from alpa.testing import assert_allclose
 
@@ -45,7 +45,6 @@ class PipelineTiedEmbeddingTest(unittest.TestCase):
                                 axis=-1).sum()
                 return loss
 
-            loss_func = manual_layer_construction(loss_func)
             grads = grad(loss_func)(state.params)
             return state.apply_gradients(grads=grads)
 
@@ -70,7 +69,7 @@ class PipelineTiedEmbeddingTest(unittest.TestCase):
         assert_allclose(actual_new_state.params, expected_new_state.params)
 
     def test_tied_embedding_pipeshard_parallel(self):
-        method = PipeshardParallel(num_micro_batches=2)
+        method = PipeshardParallel(num_micro_batches=2, layer_option="manual")
         self.train_tied_embedding(method)
 
 

--- a/tests/pipeline_parallel/test_tied_embedding.py
+++ b/tests/pipeline_parallel/test_tied_embedding.py
@@ -6,8 +6,8 @@ import jax
 import jax.numpy as jnp
 import optax
 
-from alpa import (init, parallelize, mark_pipeline_boundary,
-                  grad, PipeshardParallel)
+from alpa import (init, parallelize, mark_pipeline_boundary, grad,
+                  PipeshardParallel)
 from alpa.model.model_util import TrainState
 from alpa.testing import assert_allclose
 

--- a/tests/runtime/test_create_state.py
+++ b/tests/runtime/test_create_state.py
@@ -10,7 +10,7 @@ import optax
 
 import alpa
 from alpa import (init, shutdown, parallelize, ShardParallel, PipeshardParallel,
-                  CreateStateParallel, manual_layer_construction, fetch)
+                  CreateStateParallel)
 
 
 class CreateStateTest(unittest.TestCase):
@@ -43,9 +43,6 @@ class CreateStateTest(unittest.TestCase):
             def loss_func(params):
                 out = state.apply_fn(params, batch["x"])
                 return jnp.mean((out - batch["y"])**2)
-
-            if isinstance(method, PipeshardParallel):
-                loss_func = manual_layer_construction(loss_func)
 
             grads = alpa.grad(loss_func)(state.params)
             new_state = state.apply_gradients(grads=grads)
@@ -94,7 +91,7 @@ class CreateStateTest(unittest.TestCase):
         self.run_test(method)
 
     def test_pipeshard_parallel(self):
-        method = PipeshardParallel(num_micro_batches=2)
+        method = PipeshardParallel(num_micro_batches=2, layer_option="manual")
         self.run_test(method)
 
 

--- a/tests/runtime/test_dist_save_load.py
+++ b/tests/runtime/test_dist_save_load.py
@@ -146,9 +146,10 @@ class DistSaveLoadTest(unittest.TestCase):
             save_checkpoint(ckpt_dir, jax_state, 1)
 
             # Compile
-            method = PipeshardParallel(num_micro_batches=2)
-            serial_train_step = get_mlp_train_step(None, None, None, False)
-            parallel_train_step = get_mlp_train_step(method, True, False, False)
+            method = PipeshardParallel(num_micro_batches=2,
+                                       layer_option="manual")
+            serial_train_step = get_mlp_train_step(None, False)
+            parallel_train_step = get_mlp_train_step(method, False)
             executable = parallel_train_step.get_executable(jax_state, batch)
 
             # Restore checkpoint
@@ -181,9 +182,9 @@ class DistSaveLoadTest(unittest.TestCase):
         state = create_train_state(rngkey, model, [x])
 
         # Compile
-        method = PipeshardParallel(num_micro_batches=2)
-        serial_train_step = get_mlp_train_step(None, None, None, False)
-        parallel_train_step = get_mlp_train_step(method, True, False, False)
+        method = PipeshardParallel(num_micro_batches=2, layer_option="manual")
+        serial_train_step = get_mlp_train_step(None, False)
+        parallel_train_step = get_mlp_train_step(method, False)
         executable = parallel_train_step.get_executable(state, batch)
 
         # Run before save
@@ -233,7 +234,8 @@ class DistSaveLoadTest(unittest.TestCase):
                                                  intermediate_size=hidden_size *
                                                  4,
                                                  num_attention_heads=num_heads,
-                                                 num_hidden_layers=n_layers))
+                                                 num_hidden_layers=n_layers),
+                               manual_pipeline_layer=True)
         rngkey = jax.random.PRNGKey(0)
         params = model.init(rngkey, x, attention_mask)
         tx = optax.sgd(learning_rate=1e-2)
@@ -243,11 +245,9 @@ class DistSaveLoadTest(unittest.TestCase):
                                   dynamic_scale=None)
 
         # Compile
-        method = PipeshardParallel(num_micro_batches=2)
-        serial_train_step = get_bert_layer_train_step(None, None, None,
-                                                      n_layers, False)
-        parallel_train_step = get_bert_layer_train_step(method, True, False,
-                                                        n_layers, False)
+        method = PipeshardParallel(num_micro_batches=2, layer_option="manual")
+        serial_train_step = get_bert_layer_train_step(None, False)
+        parallel_train_step = get_bert_layer_train_step(method, False)
         executable = parallel_train_step.get_executable(state, batch)
 
         # Run before save

--- a/tests/runtime/test_memory_leak.py
+++ b/tests/runtime/test_memory_leak.py
@@ -5,8 +5,7 @@ import jax.numpy as jnp
 import ray
 
 from alpa import (init, shutdown, parallelize, grad, global_config,
-                  ShardParallel, PipeshardParallel,
-                  automatic_layer_construction)
+                  ShardParallel, PipeshardParallel, AutoLayerOption)
 from alpa.device_mesh import get_global_cluster
 
 from test_install import create_train_state_and_batch
@@ -50,10 +49,11 @@ class MemoryLeakTest(unittest.TestCase):
     def test_pipeline_parallel(self):
         layer_num = min(get_global_cluster().num_devices, 2)
 
-        @parallelize(method=PipeshardParallel(num_micro_batches=2))
+        @parallelize(method=PipeshardParallel(
+            num_micro_batches=2,
+            layer_option=AutoLayerOption(layer_num=layer_num)))
         def train_step(state, batch):
 
-            @automatic_layer_construction(layer_num=layer_num)
             def loss_func(params):
                 out = state.apply_fn(params, batch['x'])
                 return jnp.mean((out - batch['y'])**2)

--- a/tests/runtime/test_save_load.py
+++ b/tests/runtime/test_save_load.py
@@ -36,9 +36,9 @@ class SaveLoadTest(unittest.TestCase):
         state = create_train_state(rngkey, model, [x])
 
         # Compile
-        method = PipeshardParallel(num_micro_batches=2)
-        serial_train_step = get_mlp_train_step(None, None, None, False)
-        parallel_train_step = get_mlp_train_step(method, True, False, False)
+        method = PipeshardParallel(num_micro_batches=2, layer_option="manual")
+        serial_train_step = get_mlp_train_step(None, False)
+        parallel_train_step = get_mlp_train_step(method, False)
         executable = parallel_train_step.get_executable(state, batch)
 
         serial_state = state

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -10,8 +10,8 @@ import numpy as np
 import optax
 import ray
 
-from alpa import (init, parallelize, grad, ShardParallel,
-                  automatic_layer_construction, PipeshardParallel)
+from alpa import (init, parallelize, grad, ShardParallel, PipeshardParallel,
+                  AutoLayerOption)
 from alpa.device_mesh import get_global_cluster
 from alpa.testing import assert_allclose
 
@@ -87,7 +87,6 @@ class InstallationTest(unittest.TestCase):
 
         def train_step(state, batch):
 
-            @automatic_layer_construction(layer_num=layer_num)
             def loss_func(params):
                 out = state.apply_fn(params, batch['x'])
                 return jnp.mean((out - batch['y'])**2)
@@ -101,7 +100,10 @@ class InstallationTest(unittest.TestCase):
 
         # Parallel execution
         p_train_step = parallelize(
-            train_step, method=PipeshardParallel(num_micro_batches=2))
+            train_step,
+            method=PipeshardParallel(
+                num_micro_batches=2,
+                layer_option=AutoLayerOption(layer_num=layer_num)))
         actual_state = p_train_step(state, batch)
 
         # Check results

--- a/tests/torch_frontend/test_simple.py
+++ b/tests/torch_frontend/test_simple.py
@@ -69,7 +69,9 @@ class TorchSimpleTest(unittest.TestCase):
         optim_gen = torchoptim.adam(lr=1e-3)
         num_micro_batches = 2
         parallel_method = alpa.PipeshardParallel(
-            stage_mode="auto", num_micro_batches=num_micro_batches)
+            num_micro_batches=num_micro_batches,
+            layer_option=alpa.AutoLayerOption(layer_num=2),
+            stage_option="auto")
 
         train_torch_module(pt_module_gen, weight_init_func, dataloader,
                            loss_func, optim_gen, parallel_method)

--- a/tests/torch_frontend/test_zhen.py
+++ b/tests/torch_frontend/test_zhen.py
@@ -464,7 +464,9 @@ class TorchZHENTest(unittest.TestCase):
         optim_gen = torchoptim.adam(lr=1e-3)
         num_micro_batches = 2
         parallel_method = alpa.PipeshardParallel(
-            stage_mode="auto", num_micro_batches=num_micro_batches)
+            num_micro_batches=num_micro_batches,
+            layer_option=alpa.AutoLayerOption(layer_num=2),
+            stage_option="auto")
 
         _xla_client_mem_fraction_orig_value = alpa.global_config.xla_client_mem_fraction
         alpa.global_config.xla_client_mem_fraction = 0.7
@@ -497,7 +499,9 @@ class TorchZHENTest(unittest.TestCase):
         optim_gen = torchoptim.adam(lr=1e-3)
         num_micro_batches = 2
         parallel_method = alpa.PipeshardParallel(
-            stage_mode="auto", num_micro_batches=num_micro_batches)
+            num_micro_batches=num_micro_batches,
+            layer_option=alpa.AutoLayerOption(layer_num=2),
+            stage_option="auto")
 
         _xla_client_mem_fraction_orig_value = alpa.global_config.xla_client_mem_fraction
         alpa.global_config.xla_client_mem_fraction = 0.7


### PR DESCRIPTION
For pipeline parallelism, we currently have to add a layer construction decorator `@manual_layer_construction` or `@automatic_layer_construction` to the loss function. This has several disadvantages:

1. The interfaces of ShardParallel and PipeshardParallel are not the same.
2. The options of the parallel method are not specified in a single place.

This PR allows specifying layer construction options in `alpa.PipeshardParallel` and automatically applies the decorators during `alpa.grad`

## Old API
```python
@alpa.parallelize(method=alpa.PipeshardParallel(num_micro_batches=16))
def manual_pipeline_train_step(state, batch):

    @alpa.manual_layer_construction
    def loss_func(params):
        out = state.apply_fn(params, batch["x"])
        loss = jnp.mean((out - batch["y"])**2)
        return loss

    grads = alpa.grad(loss_func)(state.params)
    new_state = state.apply_gradients(grads=grads)
    return new_state
```

## New API
```python
@alpa.parallelize(method=alpa.PipeshardParallel(num_micro_batches=16, layer_option="manual"))
def manual_pipeline_train_step(state, batch):

    def loss_func(params):
        out = state.apply_fn(params, batch["x"])
        loss = jnp.mean((out - batch["y"])**2)
        return loss

    grads = alpa.grad(loss_func)(state.params)
    new_state = state.apply_gradients(grads=grads)
    return new_state
```

We can specify the arguments of layer construcitons.
```python
alpa.PipeshardParallel(num_micro_batches=16, layer_option=AutoLayerOption(layer_num=2, remat_layers=True))
```

For inference schedule, no need to call any decorators as well.

## Other changes
- Deprecate `ManualPipeshardParallel`
  - Old
    ```python
    method = ManualPipeshardParallel(
        num_micro_batches=num_micro_batches,
        default_auto_sharding_option=as_option,
        forward_stage_layer_ids=[[i] for i in range(pp)],
        submesh_physical_shapes=[physical_mesh_shape] * pp,
        submesh_logical_shapes=[logical_mesh_shape] * pp,
        submesh_autosharding_option_dicts=[{}] * pp)
     ```
  - New
    ```python
    method = PipeshardParallel(
        num_micro_batches=num_micro_batches,
        default_auto_sharding_option=as_option,
        layer_option="manual",
        stage_option=alpa.ManualStageOption(
            forward_stage_layer_ids=[[i] for i in range(pp)],
            submesh_physical_shapes=[physical_mesh_shape] * pp,
            submesh_logical_shapes=[logical_mesh_shape] * pp,
            submesh_autosharding_option_dicts=[{}] * pp))
    ```

## TODO
- [x] Fix tutorials and examples
- [x] Fix benchmark scripts
