### PR TITLE
[DataLoader] Use PlacementSpecs in data loader

### DIFF
--- a/alpa/create_state_parallel.py
+++ b/alpa/create_state_parallel.py
@@ -5,7 +5,7 @@ from typing import Sequence, Optional
 from jax._src.lib import xla_bridge as xb, xla_extension as xe
 from jax.core import ClosedJaxpr, Var
 from jax.interpreters import partial_eval as pe, pxla
-from jax.tree_util import tree_flatten, tree_unflatten, PyTreeDef
+from jax.tree_util import tree_flatten, tree_unflatten, PyTreeDef, tree_map
 
 from alpa.device_mesh import ReplicatedDistributedArray, PhysicalDeviceMeshGroup
 from alpa.mesh_executable import (NormalMeshDriverExecutable,
@@ -31,11 +31,13 @@ class CreateStateExecutable(PipeshardDriverExecutable):
                  mesh_group: PhysicalDeviceMeshGroup,
                  pipeshard_config: PipeshardConfig,
                  target_placement_specs: Sequence[PlacementSpec],
+                 in_tree: PyTreeDef,
                  out_tree: Optional[PyTreeDef] = None,
                  static_argnums: Optional[Sequence[int]] = None):
         super().__init__(mesh_group=mesh_group,
                          pipeshard_config=pipeshard_config,
                          num_batch=1,
+                         in_tree=in_tree,
                          out_tree=out_tree,
                          static_argnums=static_argnums)
         self.target_placement_specs = target_placement_specs
@@ -58,7 +60,7 @@ class CreateStateExecutable(PipeshardDriverExecutable):
                     indices = pxla.spec_to_indices(array.shape, sharding_spec)
                     dis_array = self.mesh_group[mesh_id].shard_args_to_arrays(
                         (array.aval,), (indices,), (sharding_spec,),
-                        (array,))[0]
+                        (array._value,))[0]
                     distributed_arrays.append(dis_array)
                 outputs[idx] = ReplicatedDistributedArray(
                     meshes, distributed_arrays)
@@ -134,6 +136,7 @@ def compile_create_state_executable(fun, in_tree, out_tree_thunk,
         return CreateStateExecutable(mesh_group=executable.mesh_group,
                                      pipeshard_config=pipeshard_config,
                                      target_placement_specs=placement_specs,
+                                     in_tree=in_tree,
                                      out_tree=out_tree_thunk(),
                                      static_argnums=static_argnums)
 

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -809,7 +809,7 @@ class LocalPhysicalDeviceMesh(PhysicalDeviceMesh):
         self.devices = devices if devices is not None else xb.local_devices()
         self.num_hosts = 1
         self.num_devices_per_host = len(self.devices)
-        self.mesh_id = 0
+        self.mesh_id = -1
         self.device_strs = []
         self.operation_executables = {}
 

--- a/alpa/global_env.py
+++ b/alpa/global_env.py
@@ -78,6 +78,7 @@ class GlobalConfig:
 
         ########## Options of logging ##########
         self.print_compilation_time = False
+        self.print_auto_layer_stats = False
 
 
 global_config = GlobalConfig()

--- a/alpa/pipeline_parallel/compile_executable.py
+++ b/alpa/pipeline_parallel/compile_executable.py
@@ -82,6 +82,7 @@ def compile_pipeshard_executable(
         mesh_group=virtual_mesh.launched_physical_mesh_group,
         pipeshard_config=pipeshard_config,
         num_batch=num_microbatch,
+        in_tree=in_tree,
         out_tree=out_tree_thunk(),
         static_argnums=static_argnums)
     debug_compilation_time("driver executable")
@@ -224,8 +225,7 @@ def compile_pipeshard_executable_internal(
         schedule=schedule,
         is_batch=batch_invars,
         num_batch=num_microbatch,
-        flop_count=total_flops,
-        in_tree=in_tree).compile()
+        flop_count=total_flops).compile()
 
     debug_compilation_time("runtime emitter")
     return pipeshard_config

--- a/alpa/pipeline_parallel/compile_executable.py
+++ b/alpa/pipeline_parallel/compile_executable.py
@@ -74,9 +74,9 @@ def compile_pipeshard_executable(
     debug_compilation_time("trace")
 
     pipeshard_config = compile_pipeshard_executable_internal(
-        closed_jaxpr, full_batch_closed_jaxpr, micro_batch_size, in_tree,
-        donated_invars, batch_invars, virtual_mesh, num_microbatch,
-        pipeline_schedule, default_as_option, stage_option, name_base, None)
+        closed_jaxpr, full_batch_closed_jaxpr, micro_batch_size, donated_invars,
+        batch_invars, virtual_mesh, num_microbatch, pipeline_schedule,
+        default_as_option, stage_option, name_base, None)
 
     executable = PipeshardDriverExecutable(
         mesh_group=virtual_mesh.launched_physical_mesh_group,
@@ -92,11 +92,10 @@ def compile_pipeshard_executable(
 def compile_pipeshard_executable_internal(
         closed_jaxpr: ClosedJaxpr,
         full_batch_closed_jaxpr: Optional[ClosedJaxpr], micro_batch_size: int,
-        in_tree: PyTreeDef, donated_invars: Sequence[bool],
-        batch_invars: Sequence[bool], virtual_mesh: VirtualPhysicalMesh,
-        num_microbatch: int, pipeline_schedule: str,
-        default_as_option: AutoShardingOption, stage_option: StageOption,
-        name_base: str,
+        donated_invars: Sequence[bool], batch_invars: Sequence[bool],
+        virtual_mesh: VirtualPhysicalMesh, num_microbatch: int,
+        pipeline_schedule: str, default_as_option: AutoShardingOption,
+        stage_option: StageOption, name_base: str,
         output_shardings: Optional[Sequence[pxla.ShardingSpec]]):
     global_invars = closed_jaxpr.jaxpr.invars
     global_outvars = closed_jaxpr.jaxpr.outvars

--- a/alpa/pipeline_parallel/layer_construction.py
+++ b/alpa/pipeline_parallel/layer_construction.py
@@ -13,9 +13,10 @@ from jax.core import (Var, Jaxpr, ClosedJaxpr, DropVar, Literal, jaxpr_as_fun,
                       new_jaxpr_eqn, gensym, raise_to_shaped, get_aval)
 from jax.interpreters.partial_eval import remat_call_p
 
+from alpa.global_env import global_config
 from alpa.pipeline_parallel.layer_stats import (global_invar_size,
                                                 is_nontrivial, eqn_flops,
-                                                heavy_count)
+                                                heavy_count, log_layer_slicing_stats)
 from alpa.pipeline_parallel.primitive_def import (pipeline_p,
                                                   mark_pipeline_jaxpreqn)
 from alpa.util import (clone_jaxpr, slices_to_jaxpr, OrderedSet,
@@ -448,6 +449,8 @@ def layer_level_jaxpr_transformation(fn: Callable,
                                                    eps,
                                                    costs,
                                                    cost_criteria=cost_criteria)
+            if global_config.print_auto_layer_stats:
+                log_layer_slicing_stats(jaxpr, sliced_eqns)
         else:
             sliced_eqns = slice_eqns_by_layer_boundary(jaxpr)
 

--- a/alpa/pipeline_parallel/layer_construction.py
+++ b/alpa/pipeline_parallel/layer_construction.py
@@ -16,7 +16,8 @@ from jax.interpreters.partial_eval import remat_call_p
 from alpa.global_env import global_config
 from alpa.pipeline_parallel.layer_stats import (global_invar_size,
                                                 is_nontrivial, eqn_flops,
-                                                heavy_count, log_layer_slicing_stats)
+                                                heavy_count,
+                                                log_layer_slicing_stats)
 from alpa.pipeline_parallel.primitive_def import (pipeline_p,
                                                   mark_pipeline_jaxpreqn)
 from alpa.util import (clone_jaxpr, slices_to_jaxpr, OrderedSet,

--- a/alpa/pipeline_parallel/pipeshard_executable.py
+++ b/alpa/pipeline_parallel/pipeshard_executable.py
@@ -44,6 +44,7 @@ class PipeshardDriverExecutable:
                  mesh_group: PhysicalDeviceMeshGroup,
                  pipeshard_config: PipeshardConfig,
                  num_batch: int,
+                 in_tree: PyTreeDef,
                  out_tree: Optional[PyTreeDef] = None,
                  static_argnums: Optional[Sequence[int]] = None):
         ##### Input arguments #####
@@ -51,6 +52,7 @@ class PipeshardDriverExecutable:
         self.num_mesh = len(mesh_group)
         self.num_batch = num_batch
         self.static_argnums = static_argnums
+        self.in_tree = in_tree
         self.out_tree = out_tree
 
         ##### For debugging and serialization #####
@@ -58,6 +60,7 @@ class PipeshardDriverExecutable:
         self.schedule = pipeshard_config.schedule
         self.flop_count = pipeshard_config.flop_count
         self.input_placement_specs = pipeshard_config.input_placement_specs
+        self.output_placement_specs = pipeshard_config.output_placement_specs
         # List[stage_idx -> str]
         self.fully_optimized_hlo_texts = []
         self.sharding_annotated_hlo_texts = (
@@ -193,7 +196,10 @@ class PipeshardDriverExecutable:
 
     def get_input_placement_specs(self):
         """Return the preferred placement specs for input arguments."""
-        return self.input_placement_specs
+        return tree_unflatten(self.in_tree, self.input_placement_specs)
+
+    def get_output_placement_specs(self):
+        return tree_unflatten(self.out_tree, self.output_placement_specs)
 
     def __call__(self, *args):
         """Fast call without signature matching."""

--- a/alpa/pipeline_parallel/pipeshard_executable.py
+++ b/alpa/pipeline_parallel/pipeshard_executable.py
@@ -195,10 +195,19 @@ class PipeshardDriverExecutable:
         return self.outs_handler(self.mesh_group, output_bufs)
 
     def get_input_placement_specs(self):
-        """Return the preferred placement specs for input arguments."""
+        """
+        Return the preferred placement specs for input arguments.
+        The return value is a pytree of PlacementSpec
+        with the same structure as the input pytree.
+        """
         return tree_unflatten(self.in_tree, self.input_placement_specs)
 
     def get_output_placement_specs(self):
+        """
+        Return the preferred placement specs for outputs.
+        The return value is a pytree of PlacementSpec
+        with the same structure as the output pytree.
+        """
         return tree_unflatten(self.out_tree, self.output_placement_specs)
 
     def __call__(self, *args):

--- a/alpa/pipeline_parallel/runtime_emitter.py
+++ b/alpa/pipeline_parallel/runtime_emitter.py
@@ -5,7 +5,6 @@ import enum
 import logging
 from typing import Any, Callable, Dict, Optional, Sequence, Union, Set
 
-from jax._src.tree_util import PyTreeDef, tree_unflatten
 from jax.core import Var
 from jax.interpreters import pxla
 from jax.lib import xla_bridge as xb
@@ -935,8 +934,8 @@ class PipelineInstEmitter:
                 spec_list.append(spec)
                 indices_list.append(pxla.spec_to_indices(aval.shape, spec))
 
-                output_placement_specs.append(PlacementSpec(
-                    aval, (mesh_idx_list[-1],), (spec_list[-1],)))
+                output_placement_specs.append(
+                    PlacementSpec(aval, (mesh_idx_list[-1],), (spec_list[-1],)))
             else:
                 # for RepliatedDistributedArray
                 mesh_idx_list.append([])
@@ -953,8 +952,9 @@ class PipelineInstEmitter:
                     spec_list[-1].append(spec)
                     indices_list[-1].append(
                         pxla.spec_to_indices(aval.shape, spec))
-                output_placement_specs.append(PlacementSpec(
-                    aval, tuple(mesh_idx_list[-1]), tuple(spec_list[-1])))
+                output_placement_specs.append(
+                    PlacementSpec(aval, tuple(mesh_idx_list[-1]),
+                                  tuple(spec_list[-1])))
 
         def outs_handler(mesh_group, refs):
             ret = []

--- a/alpa/pipeline_parallel/runtime_emitter.py
+++ b/alpa/pipeline_parallel/runtime_emitter.py
@@ -250,8 +250,9 @@ class PipeshardConfig:
     # Output configs
     output_local_uuid_list: Sequence[Sequence[int]]
     outs_handler: Callable
-    # Others
+    # Others (debug info)
     input_placement_specs: Sequence[PlacementSpec]
+    output_placement_specs: Sequence[PlacementSpec]
     sharding_annotated_hlo_texts: Sequence[str]
     flop_count: int
 
@@ -266,7 +267,7 @@ class PipelineInstEmitter:
                                                                           Var],
                  mesh_group: PhysicalDeviceMeshGroup,
                  schedule: PipelineSchedule, is_batch: Sequence[bool],
-                 num_batch: int, in_tree: PyTreeDef, flop_count: int):
+                 num_batch: int, flop_count: int):
         ##### Input arguments #####
         self.stages = stages
         self.global_invars = global_invars
@@ -278,7 +279,6 @@ class PipelineInstEmitter:
         self.schedule = schedule
         self.is_batch = is_batch
         self.num_batch = num_batch
-        self.in_tree = in_tree
         self.flop_count = flop_count
         self.sharding_annotated_hlo_texts = [x.get_hlo_text() for x in stages]
 
@@ -416,8 +416,9 @@ class PipelineInstEmitter:
         # Compile information for outputs
         output_local_uuid_list, mesh_output_indices, output_spec_list = (
             self._compile_collect_outputs())
-        outs_handler = self._get_outs_handler(mesh_output_indices,
-                                              output_spec_list)
+        outs_handler, output_placement_specs = self._get_outs_handler(
+            mesh_output_indices, output_spec_list)
+
         # Add gradient accumulation buffer
         reduced_var_uuid_lists = []
         for mesh_idx in range(num_mesh):
@@ -459,6 +460,7 @@ class PipelineInstEmitter:
             outs_handler,
             # Others
             input_placement_specs,
+            output_placement_specs,
             self.sharding_annotated_hlo_texts,
             self.flop_count)
 
@@ -919,6 +921,7 @@ class PipelineInstEmitter:
         outvar_index_on_mesh_list = []
         spec_list = []
         indices_list = []
+        output_placement_specs = []
 
         # Generate cached info
         for i, aval in enumerate(avals):
@@ -931,6 +934,9 @@ class PipelineInstEmitter:
                 outvar_index_on_mesh_list.append(outvar_index_on_mesh)
                 spec_list.append(spec)
                 indices_list.append(pxla.spec_to_indices(aval.shape, spec))
+
+                output_placement_specs.append(PlacementSpec(
+                    aval, (mesh_idx_list[-1],), (spec_list[-1],)))
             else:
                 # for RepliatedDistributedArray
                 mesh_idx_list.append([])
@@ -947,6 +953,8 @@ class PipelineInstEmitter:
                     spec_list[-1].append(spec)
                     indices_list[-1].append(
                         pxla.spec_to_indices(aval.shape, spec))
+                output_placement_specs.append(PlacementSpec(
+                    aval, tuple(mesh_idx_list[-1]), tuple(spec_list[-1])))
 
         def outs_handler(mesh_group, refs):
             ret = []
@@ -980,12 +988,10 @@ class PipelineInstEmitter:
                 ret.append(arr)
             return ret
 
-        return outs_handler
+        return outs_handler, output_placement_specs
 
     def _compile_input_placement_spec(self, mesh_arg_indices,
                                       input_shard_specs):
-        assert self.in_tree is not None
-
         # build spec_arr: List[flatten global index -> PlacementSpec]
         spec_arr = [None] * len(self.is_batch)
         for mesh_idx, physical_mesh in enumerate(self.mesh_group):
@@ -1002,7 +1008,7 @@ class PipelineInstEmitter:
                         old_val.mesh_ids + (physical_mesh.mesh_id,),
                         old_val.sharding_specs + (shard_spec,))
 
-        return tree_unflatten(self.in_tree, spec_arr)
+        return spec_arr
 
     # TODO(yonghao): set empty buffer is not compatiable with local allgather
     @staticmethod

--- a/alpa/torch/optim/adam.py
+++ b/alpa/torch/optim/adam.py
@@ -27,7 +27,7 @@ def adam(lr=1e-4):
         def optim_func(params, optim_state, params_grad):
             for k in params:
                 params[k] = params[k] + params_grad[k] * lr
-                optim_state[k] = optim_state[k] + 1
+                optim_state[k] = optim_state[k] + params_grad[k]
             return params, optim_state
 
         optim_state = copy.deepcopy(params)


### PR DESCRIPTION
- Use the more generate `PlacementSpecs` instead of `ShardingSpec` in data loaders.
- Add `get_output_placement_specs` in mesh executables.