### PR TITLE
[Docs] Move test install to alpa package

### DIFF
--- a/alpa/test_install.py
+++ b/alpa/test_install.py
@@ -6,7 +6,6 @@ from flax import linen as nn
 from flax.training.train_state import TrainState
 import jax
 import jax.numpy as jnp
-import numpy as np
 import optax
 import ray
 

--- a/alpa/test_install.py
+++ b/alpa/test_install.py
@@ -1,3 +1,4 @@
+# pylint: disable=missing-class-docstring
 """Some basic tests to test installation."""
 import os
 import unittest
@@ -7,7 +8,6 @@ from flax.training.train_state import TrainState
 import jax
 import jax.numpy as jnp
 import optax
-import ray
 
 from alpa import (init, parallelize, grad, ShardParallel, PipeshardParallel,
                   AutoLayerOption)
@@ -60,8 +60,8 @@ class InstallationTest(unittest.TestCase):
         def train_step(state, batch):
 
             def loss_func(params):
-                out = state.apply_fn(params, batch['x'])
-                return jnp.mean((out - batch['y'])**2)
+                out = state.apply_fn(params, batch["x"])
+                return jnp.mean((out - batch["y"])**2)
 
             grads = grad(loss_func)(state.params)
             new_state = state.apply_gradients(grads=grads)
@@ -87,8 +87,8 @@ class InstallationTest(unittest.TestCase):
         def train_step(state, batch):
 
             def loss_func(params):
-                out = state.apply_fn(params, batch['x'])
-                return jnp.mean((out - batch['y'])**2)
+                out = state.apply_fn(params, batch["x"])
+                return jnp.mean((out - batch["y"])**2)
 
             grads = grad(loss_func)(state.params)
             new_state = state.apply_gradients(grads=grads)
@@ -110,10 +110,10 @@ class InstallationTest(unittest.TestCase):
 
 
 def suite():
-    suite = unittest.TestSuite()
-    suite.addTest(InstallationTest("test_1_shard_parallel"))
-    suite.addTest(InstallationTest("test_2_pipeline_parallel"))
-    return suite
+    s = unittest.TestSuite()
+    s.addTest(InstallationTest("test_1_shard_parallel"))
+    s.addTest(InstallationTest("test_2_pipeline_parallel"))
+    return s
 
 
 if __name__ == "__main__":

--- a/docs/developer/developer_guide.rst
+++ b/docs/developer/developer_guide.rst
@@ -44,6 +44,22 @@ Use the following script to format the code and check linting errors:
 
 Unittest
 --------
-Every New feature should come with a unittest.
+Every New feature should come with a unittest. See this `README.md <https://github.com/alpa-projects/alpa/tree/main/tests/README.md>`_ on how to run tests locally.
 
-`How to run unit test locally <https://github.com/alpa-projects/alpa/tree/main/tests/README.md>`_
+Update submodule tensorflow-alpa
+--------------------------------
+Alpa repo stores a commit hash of the submodule tensorflow-alpa, so git knows which version of tensorflow-alpa should be used.
+However, commands like ``git pull`` do not update the submodule to the lastest stored commit. You need to additionaly use the commands below.
+
+.. code-block:: bash
+
+    git submodule update --init --recursive
+
+Contribute to submodule tensorflow-alpa
+---------------------------------------
+If you want to contribute code to tensorflow-alpa, you can follow the steps below
+
+1. Contributors send a pull request to tensorflow-alpa.
+2. Maintainers review the pull request and merge it to tensorflow-alpa.
+3. Contributors send a pull request to alpa. The pull request should update the stored hash commit of the submodule and other modifications to alpa if necessary.
+4. Maintainers review the pull request and merge it to alpa.

--- a/docs/developer/developer_guide.rst
+++ b/docs/developer/developer_guide.rst
@@ -42,21 +42,21 @@ Use the following script to format the code and check linting errors:
 
     ./format.sh
 
-Unittest
---------
-Every New feature should come with a unittest. See this `README.md <https://github.com/alpa-projects/alpa/tree/main/tests/README.md>`_ on how to run tests locally.
+Unit Testing
+------------
+Every New feature should come with a unit test. See this `README.md <https://github.com/alpa-projects/alpa/tree/main/tests/README.md>`_ on how to run tests locally.
 
-Update submodule tensorflow-alpa
---------------------------------
+Updating submodule tensorflow-alpa
+----------------------------------
 Alpa repo stores a commit hash of the submodule tensorflow-alpa, so git knows which version of tensorflow-alpa should be used.
-However, commands like ``git pull`` do not update the submodule to the lastest stored commit. You need to additionaly use the commands below.
+However, commands like ``git pull`` do not update the submodule to the latest stored commit. You need to additionally use the commands below.
 
 .. code-block:: bash
 
     git submodule update --init --recursive
 
-Contribute to submodule tensorflow-alpa
----------------------------------------
+Contributing to submodule tensorflow-alpa
+-----------------------------------------
 If you want to contribute code to tensorflow-alpa, you can follow the steps below
 
 1. Contributors send a pull request to tensorflow-alpa.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -42,11 +42,12 @@ Regardless of installing from wheels or from source, there are a few prerequisit
   If it prints nothing, then NCCL has already been installed.
   Otherwise, follow the printed instructions to install NCCL.
 
-.. _install-from-wheels:
 
 Methods
 -------
 Choose one of the methods below.
+
+.. _install-from-wheels:
 
 Method 1: Install from Python Wheels
 ####################################
@@ -124,13 +125,12 @@ Method 2: Install from Source
 
 Check Installation
 ------------------
-You can check the installation by running the following test script.
+You can check the installation by running the following commands.
 
 .. code:: bash
 
-  cd alpa
   ray start --head
-  python3 tests/test_install.py
+  python3 -m alpa.test_install
 
 [Optional] PyTorch Frontend
 -------------------------------------
@@ -158,6 +158,10 @@ Please look at ``tests/torch_frontend/test_simple.py`` for usage examples.
 
 Troubleshooting
 ---------------
+
+Unhandled Cuda Error
+####################
+If you see errors like ``cupy_backends.cuda.libs.nccl.NcclError: NCCL_ERROR_UNHANDLED_CUDA_ERROR: unhandled cuda error``, it is mainly due to the compatibility issues between CUDA, NCCL, and GPU driver versions. Please double check these versions and see `Issue #496 <https://github.com/alpa-projects/alpa/issues/496>`_ for more details.
 
 Using Alpa on Slurm
 ###################

--- a/tests/runtime/test_install.py
+++ b/tests/runtime/test_install.py
@@ -1,0 +1,7 @@
+import unittest
+
+from alpa.test_install import suite
+
+if __name__ == "__main__":
+    runner = unittest.TextTestRunner()
+    runner.run(suite())


### PR DESCRIPTION
Now we can use the commands below to test the installation, so people who install alpa by wheel can also run the tests
```
python3 -m alpa.test_install
```