### PR TITLE
[FEATURE] Serialize Parallel Plan

### DIFF
--- a/alpa/__init__.py
+++ b/alpa/__init__.py
@@ -14,6 +14,7 @@ from alpa.mesh_profiling import ProfilingResultDatabase
 from alpa.parallel_method import (ShardParallel, PipeshardParallel,
                                   DataParallel, Zero2Parallel, Zero3Parallel,
                                   CreateStateParallel)
+from alpa.parallel_plan import plan_to_method
 from alpa.pipeline_parallel.primitive_def import mark_pipeline_boundary
 from alpa.pipeline_parallel.layer_construction import (manual_remat,
                                                        automatic_remat,

--- a/alpa/create_state_parallel.py
+++ b/alpa/create_state_parallel.py
@@ -38,6 +38,7 @@ class CreateStateExecutable(PipeshardDriverExecutable):
         super().__init__(mesh_group=mesh_group,
                          pipeshard_config=pipeshard_config,
                          num_batch=1,
+                         layer_option=None,
                          in_tree=in_tree,
                          out_tree=out_tree,
                          static_argnums=static_argnums)

--- a/alpa/parallel_method.py
+++ b/alpa/parallel_method.py
@@ -164,7 +164,7 @@ class PipeshardParallel(ParallelMethod):
           Possible choices are {"manual", alpa.AutoLayerOption,
                                  alpa.ManualLayerOption}
         stage_option: Options of grouping layers into pipeline stages.
-          Possible choices are {"uniform", "auto", alpa.AutoStageOption,,
+          Possible choices are {"uniform", "auto", alpa.AutoStageOption,
                                  alpa.ManualStageOption}
     """
 
@@ -178,7 +178,8 @@ class PipeshardParallel(ParallelMethod):
             stage_option: Optional[Union[StageOption, str]] = None):
         self.devices = devices
         self.num_micro_batches = num_micro_batches
-        self.as_option = default_auto_sharding_option or AutoShardingOption()
+        self.as_option = (default_auto_sharding_option or
+                          AutoShardingOption(prefer_reduce_scatter=True))
         self.pipeline_schedule = pipeline_schedule
         if layer_option == "manual":
             layer_option = ManualLayerOption()

--- a/alpa/parallel_plan.py
+++ b/alpa/parallel_plan.py
@@ -8,7 +8,6 @@ from typing import Sequence, Tuple
 import numpy as np
 from jax.core import ShapedArray
 from jax.interpreters import pxla
-from jax.tree_util import PyTreeDef
 
 
 @dataclass
@@ -26,6 +25,7 @@ class StagePlan:
     logical_mesh_shape: Tuple[int]
     all_gather_threshold: int
     all_reduce_threshold: int
+    auto_sharding_option: "AutoShardingOption"
     auto_sharding_solution_vector: np.ndarray
     auto_sharding_objective: int
 
@@ -33,16 +33,39 @@ class StagePlan:
 @dataclass
 class PipelinePlan:
     """The parallel plan for a pipeline."""
-    forward_stage_layer_ids: Sequence[Sequence[int]]
-    submesh_physical_shapes: Sequence[Sequence[int]]
-    submesh_logical_shapes: Sequence[Sequence[int]]
-    submesh_autosharding_option_dicts: Sequence[dict]
+    pipeline_schedule: str
+    layer_option: "LayerOption"
+    manual_stage_option: "ManualStageOption"
+
+
+@dataclass
+class ClusterInfo:
+    num_hosts: int
+    num_devices_per_host: int
 
 
 @dataclass
 class ParallelPlan:
     """The global parallel plan."""
+    cluster_info: ClusterInfo
+    num_micro_batches: int
+    auto_sharding_option: "AutoShardingOption"
     pipeline_plan: PipelinePlan
-    stage_plans: Sequence[StagePlan]
-    input_placement: PyTreeDef
-    version: str
+    input_placement_specs: Sequence[PlacementSpec]
+
+
+def plan_to_method(plan: ParallelPlan) -> "ParallelMethod":
+    """Convert a parallel plan to a parallel method."""
+    # pylint: disable=import-outside-toplevel
+    from alpa.parallel_method import ShardParallel, PipeshardParallel
+
+    if plan.pipeline_plan is None:
+        return ShardParallel(num_micro_batches=plan.num_micro_batches,
+                             auto_sharding_option=plan.auto_sharding_option)
+    else:
+        return PipeshardParallel(
+            num_micro_batches=plan.num_micro_batches,
+            default_auto_sharding_option=plan.auto_sharding_option,
+            pipeline_schedule=plan.pipeline_plan.pipeline_schedule,
+            layer_option=plan.pipeline_plan.layer_option,
+            stage_option=plan.pipeline_plan.manual_stage_option)

--- a/alpa/pipeline_parallel/computation.py
+++ b/alpa/pipeline_parallel/computation.py
@@ -24,7 +24,8 @@ from alpa.pipeline_parallel.primitive_def import (mark_hook_jaxpreqn,
 from alpa.shard_parallel.auto_sharding import (run_auto_sharding_pass,
                                                run_spmd_partitioner_pass,
                                                get_input_output_sharding_specs,
-                                               hlo_sharding_to_sharding_spec)
+                                               hlo_sharding_to_sharding_spec,
+                                               AutoShardingOption)
 from alpa.global_env import global_config
 from alpa.util import (OrderedSet, clone_jaxpr, get_compile_options,
                        jaxpr_to_hlo_module, setup_computation_alias,
@@ -214,7 +215,8 @@ class XlaShardedPipelineComputation(PipelineComputation):
         backend_name = "gpu"
         backend = xb.get_backend(backend_name)
         stage_plan = StagePlan(global_config.compile_random_seed,
-                               logical_mesh_shape, 1, 1, None, 0)
+                               logical_mesh_shape, 1, 1, AutoShardingOption(),
+                               None, 0)
         compiled = compile_dummy_zero_constant(backend,
                                                np.prod(logical_mesh_shape))
         sharding_annotated_module = compiled.hlo_modules()[0]

--- a/alpa/pipeline_parallel/schedules.py
+++ b/alpa/pipeline_parallel/schedules.py
@@ -77,6 +77,11 @@ class PipelineSchedule(metaclass=ABCMeta):
 
         self._schedules: List[List[Tuple]] = self._generate_schedule()
 
+    @property
+    @abstractmethod
+    def name(self):
+        raise NotImplementedError()
+
     @abstractmethod
     def _generate_schedule(self):
         """Implementation of the schedule."""
@@ -181,6 +186,10 @@ class PipelineSchedule(metaclass=ABCMeta):
 class GpipeSchedule(PipelineSchedule):
     """Construct a Gpipe-like schedule."""
 
+    @property
+    def name(self):
+        return "gpipe"
+
     def _generate_schedule(self):
         """
         Generate a Gpipe-like schedule.
@@ -268,6 +277,10 @@ class PipeDreamFlush(PipelineSchedule):
 
     It has similar latency to GPipe but is more memory-efficient.
     """
+
+    @property
+    def name(self):
+        return "1f1b"
 
     def _generate_schedule(self):
         m = self.num_batch
@@ -377,6 +390,10 @@ class PipeDreamFlush(PipelineSchedule):
 
 class InferenceSchedule(PipelineSchedule):
     """Construct a Gpipe-like schedule."""
+
+    @property
+    def name(self):
+        return "inference"
 
     def _generate_schedule(self):
         """

--- a/alpa/shard_parallel/auto_sharding.py
+++ b/alpa/shard_parallel/auto_sharding.py
@@ -363,7 +363,7 @@ def run_auto_sharding_pass(
 
     stage_plan = StagePlan(build_random_seed, logical_mesh.shape,
                            all_gather_threshold, as_option.all_reduce_threshold,
-                           last_s_val, last_objective)
+                           as_option, last_s_val, last_objective)
 
     if return_mode == "single":
         return hlo_module, stage_plan

--- a/playground/jax_basic/test_sharding_spec.py
+++ b/playground/jax_basic/test_sharding_spec.py
@@ -1,25 +1,22 @@
 from functools import partial
+import pickle
 
 import numpy as np
 
 from jax.interpreters import pxla
-from jax.interpreters.pxla import Chunked, NoSharding, Replicated, ShardedAxis
+from jax.interpreters.pxla import ShardingSpec, Chunked, NoSharding, Replicated, ShardedAxis
 
 
 def test_order():
-    a = pxla.ShardingSpec(
-        sharding=(Chunked([2]), NoSharding()),
-        mesh_mapping=(ShardedAxis(0), Replicated(2))
-    )
+    a = pxla.ShardingSpec(sharding=(Chunked([2]), NoSharding()),
+                          mesh_mapping=(ShardedAxis(0), Replicated(2)))
 
     print("--")
     print(a.indices((4, 4)).flatten()[0])
     print(a.indices((4, 4)).flatten()[1])
 
-    b = pxla.ShardingSpec(
-        sharding=(Chunked([2]), NoSharding()),
-        mesh_mapping=(Replicated(2), ShardedAxis(0))
-    )
+    b = pxla.ShardingSpec(sharding=(Chunked([2]), NoSharding()),
+                          mesh_mapping=(Replicated(2), ShardedAxis(0)))
 
     print("--")
     print(b.indices((4, 4)).flatten()[0])
@@ -27,10 +24,8 @@ def test_order():
 
 
 def test_equivalent():
-    a = pxla.ShardingSpec(
-        sharding=(Chunked([4]), Chunked([1])),
-        mesh_mapping=(ShardedAxis(0), ShardedAxis(1))
-    )
+    a = pxla.ShardingSpec(sharding=(Chunked([4]), Chunked([1])),
+                          mesh_mapping=(ShardedAxis(0), ShardedAxis(1)))
 
     print("--")
     print(a.indices((4, 4)).flatten()[0])
@@ -38,10 +33,8 @@ def test_equivalent():
     print(a.indices((4, 4)).flatten()[2])
     print(a.indices((4, 4)).flatten()[3])
 
-    a = pxla.ShardingSpec(
-        sharding=(Chunked([4]), NoSharding()),
-        mesh_mapping=(Replicated(1), ShardedAxis(0))
-    )
+    a = pxla.ShardingSpec(sharding=(Chunked([4]), NoSharding()),
+                          mesh_mapping=(Replicated(1), ShardedAxis(0)))
 
     print("--")
     print(a.indices((4, 4)).flatten()[0])
@@ -51,18 +44,82 @@ def test_equivalent():
 
 
 def test_multiple_chunks():
-    a = pxla.ShardingSpec(
-        sharding=(Chunked([2, 2]),),
-        mesh_mapping=(ShardedAxis(1), ShardedAxis(0))
-    )
+    a = pxla.ShardingSpec(sharding=(Chunked([2, 2]),),
+                          mesh_mapping=(ShardedAxis(1), ShardedAxis(0)))
 
     print(a.indices((4,)).flatten()[0])
     print(a.indices((4,)).flatten()[1])
     print(a.indices((4,)).flatten()[2])
     print(a.indices((4,)).flatten()[3])
 
+
+def test_pickle():
+    a = pxla.ShardingSpec(sharding=(Chunked([2, 2]),),
+                          mesh_mapping=(ShardedAxis(1), ShardedAxis(0)))
+
+    pickle.dump(a, open("tmp.pkl", "wb"))
+
+    b = pickle.load(open("tmp.pkl", "rb"))
+
+    assert a == b
+
+
+def sharding_spec_getstate(self):
+    sharding = []
+    for x in self.sharding:
+        if isinstance(x, pxla.NoSharding):
+            sharding.append((0,))
+        elif isinstance(x, pxla.Chunked):
+            sharding.append((1, x.chunks))
+        elif isinstance(x, pxla.Unstacked):
+            sharding.append((2, x.size))
+        else:
+            raise ValueError(f"Invalid sharding: {x}")
+    mesh_mapping = []
+    for x in self.mesh_mapping:
+        if isinstance(x, pxla.ShardedAxis):
+            mesh_mapping.append((0, x.axis))
+        elif isinstance(x, pxla.Replicated):
+            mesh_mapping.append((1, x.replicas))
+        else:
+            raise ValueError(f"Invalid sharding: {x}")
+    return (sharding, mesh_mapping)
+
+
+def sharding_spec_setstate(self, state_tuple):
+    sharding_encoding, mesh_mapping_encoding = state_tuple
+
+    sharding = []
+    for x in sharding_encoding:
+        if x[0] == 0:
+            sharding.append(pxla.NoSharding())
+        elif x[0] == 1:
+            sharding.append(pxla.Chunked(x[1]))
+        elif x[0] == 2:
+            sharding.append(pxla.Unstacked(x[1]))
+        else:
+            raise ValueError(f"Invalid sharding: {x}")
+
+    mesh_mapping = []
+    for x in mesh_mapping_encoding:
+        if x[0] == 0:
+            mesh_mapping.append(pxla.ShardedAxis(x[1]))
+        elif x[0] == 1:
+            mesh_mapping.append(pxla.Replicated(x[1]))
+        else:
+            raise ValueError(f"Invalid sharding: {x}")
+
+    self.__init__(
+        sharding=sharding,
+        mesh_mapping=mesh_mapping,
+    )
+
+
+setattr(pxla.ShardingSpec, "__getstate__", sharding_spec_getstate)
+setattr(pxla.ShardingSpec, "__setstate__", sharding_spec_setstate)
+
 if __name__ == "__main__":
     #test_order()
     #test_equivalent()
-    test_multiple_chunks()
-
+    #test_multiple_chunks()
+    test_pickle()

--- a/tests/runtime/test_parallel_plan.py
+++ b/tests/runtime/test_parallel_plan.py
@@ -1,0 +1,83 @@
+"""Some basic tests to test installation."""
+import os
+import pickle
+import unittest
+
+from alpa import (init, shutdown, parallelize, ShardParallel, PipeshardParallel,
+                  AutoLayerOption, plan_to_method, AutoShardingOption,
+                  AutoStageOption)
+from alpa.device_mesh import get_global_cluster
+from alpa.testing import assert_allclose, get_mlp_train_state_and_step
+
+
+class ParallelPlanTest(unittest.TestCase):
+
+    def setUp(self):
+        init(cluster="ray")
+
+    def tearDown(self):
+        shutdown()
+
+    def test_shard_parallel(self):
+        state, batch, train_step = get_mlp_train_state_and_step(batch_size=128,
+                                                                hidden_size=128,
+                                                                num_layers=4)
+
+        method = ShardParallel(
+            num_micro_batches=2,
+            auto_sharding_option=AutoShardingOption(force_data_parallel=True))
+        p_train_step = parallelize(train_step, method=method)
+
+        executable1 = p_train_step.get_executable(state, batch)
+        plan = executable1.get_parallel_plan()
+
+        with open("tmp_plan.pkl", "wb") as fout:
+            pickle.dump(plan, fout)
+
+        with open("tmp_plan.pkl", "rb") as fin:
+            plan = pickle.load(fin)
+
+        p_train_step = parallelize(train_step, method=plan_to_method(plan))
+        executable2 = p_train_step.get_executable(state, batch)
+
+        assert (executable1.auto_sharding_objective ==
+                executable2.auto_sharding_objective)
+
+    def test_pipeshard_parallel(self):
+        state, batch, train_step = get_mlp_train_state_and_step(batch_size=128,
+                                                                hidden_size=128,
+                                                                num_layers=4)
+
+        method = PipeshardParallel(
+            num_micro_batches=2,
+            layer_option=AutoLayerOption(layer_num=2),
+            stage_option=AutoStageOption(
+                submesh_logical_shape_space="data_parallel_only"))
+        p_train_step = parallelize(train_step, method=method)
+
+        executable1 = p_train_step.get_executable(state, batch)
+        plan = executable1.get_parallel_plan()
+
+        with open("tmp_plan.pkl", "wb") as fout:
+            pickle.dump(plan, fout)
+
+        with open("tmp_plan.pkl", "rb") as fin:
+            plan = pickle.load(fin)
+
+        p_train_step = parallelize(train_step, method=plan_to_method(plan))
+        executable2 = p_train_step.get_executable(state, batch)
+
+        assert (executable1.get_input_placement_specs() ==
+                executable2.get_input_placement_specs())
+
+
+def suite():
+    s = unittest.TestSuite()
+    #s.addTest(ParallelPlanTest("test_shard_parallel"))
+    s.addTest(ParallelPlanTest("test_pipeshard_parallel"))
+    return s
+
+
+if __name__ == "__main__":
+    runner = unittest.TextTestRunner()
+    runner.run(suite())

--- a/tests/runtime/test_parallel_plan.py
+++ b/tests/runtime/test_parallel_plan.py
@@ -33,7 +33,6 @@ class ParallelPlanTest(unittest.TestCase):
 
         with open("tmp_plan.pkl", "wb") as fout:
             pickle.dump(plan, fout)
-
         with open("tmp_plan.pkl", "rb") as fin:
             plan = pickle.load(fin)
 
@@ -51,8 +50,7 @@ class ParallelPlanTest(unittest.TestCase):
         method = PipeshardParallel(
             num_micro_batches=2,
             layer_option=AutoLayerOption(layer_num=2),
-            stage_option=AutoStageOption(
-                submesh_logical_shape_space="data_parallel_only"))
+            stage_option="uniform")
         p_train_step = parallelize(train_step, method=method)
 
         executable1 = p_train_step.get_executable(state, batch)
@@ -60,7 +58,6 @@ class ParallelPlanTest(unittest.TestCase):
 
         with open("tmp_plan.pkl", "wb") as fout:
             pickle.dump(plan, fout)
-
         with open("tmp_plan.pkl", "rb") as fin:
             plan = pickle.load(fin)
 
@@ -73,7 +70,7 @@ class ParallelPlanTest(unittest.TestCase):
 
 def suite():
     s = unittest.TestSuite()
-    #s.addTest(ParallelPlanTest("test_shard_parallel"))
+    s.addTest(ParallelPlanTest("test_shard_parallel"))
     s.addTest(ParallelPlanTest("test_pipeshard_parallel"))
     return s
 

--- a/tests/runtime/test_parallel_plan.py
+++ b/tests/runtime/test_parallel_plan.py
@@ -47,10 +47,9 @@ class ParallelPlanTest(unittest.TestCase):
                                                                 hidden_size=128,
                                                                 num_layers=4)
 
-        method = PipeshardParallel(
-            num_micro_batches=2,
-            layer_option=AutoLayerOption(layer_num=2),
-            stage_option="uniform")
+        method = PipeshardParallel(num_micro_batches=2,
+                                   layer_option=AutoLayerOption(layer_num=2),
+                                   stage_option="uniform")
         p_train_step = parallelize(train_step, method=method)
 
         executable1 = p_train_step.get_executable(state, batch)


### PR DESCRIPTION
Now we can serialize a parallel plan and reuse it. Currently, it only supports pickle, which is not good for backward compatibility. We can design a better format later.

```python
plan = executable1.get_parallel_plan()

with open("tmp_plan.pkl", "wb") as fout:
    pickle.dump(plan, fout)
with open("tmp_plan.pkl", "rb") as fin:
    plan = pickle.load(fin)

p_train_step = parallelize(train_step, method=plan_to_method(plan))
executable2 = p_train_step.get_executable(state, batch)
```