### PR TITLE
[OPT] Unify forward-only and autoregressive benchmark

### DIFF
--- a/examples/opt_serving/model/opt_model.py
+++ b/examples/opt_serving/model/opt_model.py
@@ -734,6 +734,7 @@ def get_pipeshard_executable(config,
         assert batch_size % num_micro_batches == 0, "cannot divide batch_size by num_micro_batches"
         micro_batch_size = batch_size // num_micro_batches
 
+        alpa.global_config.always_donate_micro_batch_vars = False
         executable = inference_step_with_cache.get_executable(
             params, {
                 "input_ids":


### PR DESCRIPTION
This PR unifies two benchmark modes for OPT. Specifically:
1. Forward-only mode now takes cache.
2. Forward-only mode will use `test_prompts` if the user-specified decoder length matches any of them.
3. Unify the wrapper interface `__call__` by moving the prompt decomposing logic to autoregressive specific inference function.

I'll further debug the cache issue with this PR.

cc @merrymercy 