### PR TITLE
[Doc] Update path to jaxlib build

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -130,7 +130,7 @@ You can check the installation by running the following commands from the root o
 .. code:: bash
 
   ray start --head
-  python3 tests/test_install.py
+  python3 -m alpa.test_install
 
 [Optional] PyTorch Frontend
 -------------------------------------

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -109,7 +109,7 @@ Method 2: Install from Source
 
   .. code:: bash
 
-    cd alpa/build_jaxlib
+    cd build_jaxlib
     python3 build/build.py --enable_cuda --dev_install --tf_path=$(pwd)/../third_party/tensorflow-alpa
     cd dist
 
@@ -125,12 +125,12 @@ Method 2: Install from Source
 
 Check Installation
 ------------------
-You can check the installation by running the following commands.
+You can check the installation by running the following commands from the root of the repository.
 
 .. code:: bash
 
   ray start --head
-  python3 -m alpa.test_install
+  python3 tests/test_install.py
 
 [Optional] PyTorch Frontend
 -------------------------------------

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -125,7 +125,7 @@ Method 2: Install from Source
 
 Check Installation
 ------------------
-You can check the installation by running the following commands from the root of the repository.
+You can check the installation by running the following commands.
 
 .. code:: bash
 


### PR DESCRIPTION
We are already in the alpa folder at this point, we hence need to move one step shorter. The instructions to runs installation verification tests are also not working as is, and the instructions have been amended as such.