### PR TITLE
[Feature] Support input sharding specs assignment

### DIFF
--- a/alpa/create_state_parallel.py
+++ b/alpa/create_state_parallel.py
@@ -134,7 +134,7 @@ def compile_create_state_executable(fun, in_tree, out_tree_thunk,
             new_jaxpr, None, 1, [False] * len(avals), [False] * len(avals),
             executable.mesh_group.parent, 1, "inference",
             AutoShardingOption(enable_auto_sharding=False),
-            UniformStageOption(), name, output_shardings)
+            UniformStageOption(), name, output_shardings, None)
 
         return CreateStateExecutable(mesh_group=executable.mesh_group,
                                      pipeshard_config=pipeshard_config,

--- a/alpa/parallel_method.py
+++ b/alpa/parallel_method.py
@@ -17,6 +17,7 @@ from typing import Callable, Optional, Sequence, Union, Any
 
 from jax import linear_util as lu
 from jax.core import AbstractValue
+from jax.interpreters import pxla
 from jax.tree_util import PyTreeDef
 import numpy as np
 
@@ -166,6 +167,7 @@ class PipeshardParallel(ParallelMethod):
         stage_option: Options of grouping layers into pipeline stages.
           Possible choices are {"uniform", "auto", alpa.AutoStageOption,
                                  alpa.ManualStageOption}
+        TBA
     """
 
     def __init__(
@@ -175,7 +177,9 @@ class PipeshardParallel(ParallelMethod):
             default_auto_sharding_option: Optional[AutoShardingOption] = None,
             pipeline_schedule: str = "1f1b",
             layer_option: Optional[Union[LayerOption, str]] = None,
-            stage_option: Optional[Union[StageOption, str]] = None):
+            stage_option: Optional[Union[StageOption, str]] = None,
+            input_sharding: Optional[Sequence[Sequence[
+                pxla.ShardingSpec]]] = None):
         self.devices = devices
         self.num_micro_batches = num_micro_batches
         self.as_option = (default_auto_sharding_option or
@@ -196,6 +200,7 @@ class PipeshardParallel(ParallelMethod):
         elif stage_option == "uniform":
             stage_option = UniformStageOption()
         self.stage_option = stage_option or UniformStageOption()
+        self.input_sharding = input_sharding
 
     def compile_executable(
         self,
@@ -220,7 +225,8 @@ class PipeshardParallel(ParallelMethod):
         return compile_pipeshard_executable(
             fun, in_tree, out_tree_thunk, static_argnums, donated_invars,
             batch_invars, mesh, self.num_micro_batches, self.pipeline_schedule,
-            self.as_option, self.layer_option, self.stage_option, *avals)
+            self.as_option, self.layer_option, self.stage_option,
+            self.input_sharding, *avals)
 
 
 class LocalPipelineParallel(ParallelMethod):

--- a/alpa/parallel_method.py
+++ b/alpa/parallel_method.py
@@ -167,7 +167,7 @@ class PipeshardParallel(ParallelMethod):
         stage_option: Options of grouping layers into pipeline stages.
           Possible choices are {"uniform", "auto", alpa.AutoStageOption,
                                  alpa.ManualStageOption}
-        stage_input_sharing: Options of input sharding specs for each stage.
+        stage_input_sharings: Options of input sharding specs for each stage.
           Shape: [num_pipeline_stages, num_input_vars_in_hlo_module].
     """
 
@@ -179,7 +179,7 @@ class PipeshardParallel(ParallelMethod):
         pipeline_schedule: str = "1f1b",
         layer_option: Optional[Union[LayerOption, str]] = None,
         stage_option: Optional[Union[StageOption, str]] = None,
-        stage_input_sharing: Optional[Sequence[Sequence[
+        stage_input_sharings: Optional[Sequence[Sequence[
             pxla.ShardingSpec]]] = None):
         self.devices = devices
         self.num_micro_batches = num_micro_batches
@@ -201,7 +201,7 @@ class PipeshardParallel(ParallelMethod):
         elif stage_option == "uniform":
             stage_option = UniformStageOption()
         self.stage_option = stage_option or UniformStageOption()
-        self.stage_input_sharing = stage_input_sharing
+        self.stage_input_sharings = stage_input_sharings
 
     def compile_executable(
         self,
@@ -227,7 +227,7 @@ class PipeshardParallel(ParallelMethod):
             fun, in_tree, out_tree_thunk, static_argnums, donated_invars,
             batch_invars, mesh, self.num_micro_batches, self.pipeline_schedule,
             self.as_option, self.layer_option, self.stage_option,
-            self.stage_input_sharing, *avals)
+            self.stage_input_sharings, *avals)
 
 
 class LocalPipelineParallel(ParallelMethod):

--- a/alpa/parallel_method.py
+++ b/alpa/parallel_method.py
@@ -172,15 +172,15 @@ class PipeshardParallel(ParallelMethod):
     """
 
     def __init__(
-            self,
-            devices: Optional[VirtualPhysicalMesh] = None,
-            num_micro_batches: int = 1,
-            default_auto_sharding_option: Optional[AutoShardingOption] = None,
-            pipeline_schedule: str = "1f1b",
-            layer_option: Optional[Union[LayerOption, str]] = None,
-            stage_option: Optional[Union[StageOption, str]] = None,
-            stage_input_sharing: Optional[Sequence[Sequence[
-                pxla.ShardingSpec]]] = None):
+        self,
+        devices: Optional[VirtualPhysicalMesh] = None,
+        num_micro_batches: int = 1,
+        default_auto_sharding_option: Optional[AutoShardingOption] = None,
+        pipeline_schedule: str = "1f1b",
+        layer_option: Optional[Union[LayerOption, str]] = None,
+        stage_option: Optional[Union[StageOption, str]] = None,
+        stage_input_sharing: Optional[Sequence[Sequence[
+            pxla.ShardingSpec]]] = None):
         self.devices = devices
         self.num_micro_batches = num_micro_batches
         self.as_option = (default_auto_sharding_option or

--- a/alpa/parallel_method.py
+++ b/alpa/parallel_method.py
@@ -168,7 +168,7 @@ class PipeshardParallel(ParallelMethod):
           Possible choices are {"uniform", "auto", alpa.AutoStageOption,
                                  alpa.ManualStageOption}
         input_sharding: Options of input sharding specs for each stage.
-          The shape should be [num_pipeline_stages, num_input_vars_in_hlo_module].
+          Shape: [num_pipeline_stages, num_input_vars_in_hlo_module].
     """
 
     def __init__(

--- a/alpa/parallel_method.py
+++ b/alpa/parallel_method.py
@@ -167,7 +167,7 @@ class PipeshardParallel(ParallelMethod):
         stage_option: Options of grouping layers into pipeline stages.
           Possible choices are {"uniform", "auto", alpa.AutoStageOption,
                                  alpa.ManualStageOption}
-        stage_input_sharings: Options of input sharding specs for each stage.
+        stage_input_shardings: Options of input sharding specs for each stage.
           Shape: [num_pipeline_stages, num_input_vars_in_hlo_module].
     """
 
@@ -179,7 +179,7 @@ class PipeshardParallel(ParallelMethod):
         pipeline_schedule: str = "1f1b",
         layer_option: Optional[Union[LayerOption, str]] = None,
         stage_option: Optional[Union[StageOption, str]] = None,
-        stage_input_sharings: Optional[Sequence[Sequence[
+        stage_input_shardings: Optional[Sequence[Sequence[
             pxla.ShardingSpec]]] = None):
         self.devices = devices
         self.num_micro_batches = num_micro_batches
@@ -201,7 +201,7 @@ class PipeshardParallel(ParallelMethod):
         elif stage_option == "uniform":
             stage_option = UniformStageOption()
         self.stage_option = stage_option or UniformStageOption()
-        self.stage_input_sharings = stage_input_sharings
+        self.stage_input_shardings = stage_input_shardings
 
     def compile_executable(
         self,
@@ -227,7 +227,7 @@ class PipeshardParallel(ParallelMethod):
             fun, in_tree, out_tree_thunk, static_argnums, donated_invars,
             batch_invars, mesh, self.num_micro_batches, self.pipeline_schedule,
             self.as_option, self.layer_option, self.stage_option,
-            self.stage_input_sharings, *avals)
+            self.stage_input_shardings, *avals)
 
 
 class LocalPipelineParallel(ParallelMethod):

--- a/alpa/parallel_method.py
+++ b/alpa/parallel_method.py
@@ -167,7 +167,7 @@ class PipeshardParallel(ParallelMethod):
         stage_option: Options of grouping layers into pipeline stages.
           Possible choices are {"uniform", "auto", alpa.AutoStageOption,
                                  alpa.ManualStageOption}
-        input_sharding: Options of input sharding specs for each stage.
+        stage_input_sharing: Options of input sharding specs for each stage.
           Shape: [num_pipeline_stages, num_input_vars_in_hlo_module].
     """
 
@@ -179,7 +179,7 @@ class PipeshardParallel(ParallelMethod):
             pipeline_schedule: str = "1f1b",
             layer_option: Optional[Union[LayerOption, str]] = None,
             stage_option: Optional[Union[StageOption, str]] = None,
-            input_sharding: Optional[Sequence[Sequence[
+            stage_input_sharing: Optional[Sequence[Sequence[
                 pxla.ShardingSpec]]] = None):
         self.devices = devices
         self.num_micro_batches = num_micro_batches
@@ -201,7 +201,7 @@ class PipeshardParallel(ParallelMethod):
         elif stage_option == "uniform":
             stage_option = UniformStageOption()
         self.stage_option = stage_option or UniformStageOption()
-        self.input_sharding = input_sharding
+        self.stage_input_sharing = stage_input_sharing
 
     def compile_executable(
         self,
@@ -227,7 +227,7 @@ class PipeshardParallel(ParallelMethod):
             fun, in_tree, out_tree_thunk, static_argnums, donated_invars,
             batch_invars, mesh, self.num_micro_batches, self.pipeline_schedule,
             self.as_option, self.layer_option, self.stage_option,
-            self.input_sharding, *avals)
+            self.stage_input_sharing, *avals)
 
 
 class LocalPipelineParallel(ParallelMethod):

--- a/alpa/parallel_method.py
+++ b/alpa/parallel_method.py
@@ -167,7 +167,8 @@ class PipeshardParallel(ParallelMethod):
         stage_option: Options of grouping layers into pipeline stages.
           Possible choices are {"uniform", "auto", alpa.AutoStageOption,
                                  alpa.ManualStageOption}
-        TBA
+        input_sharding: Options of input sharding specs for each stage.
+          The shape should be [num_pipeline_stages, num_input_vars_in_hlo_module].
     """
 
     def __init__(

--- a/alpa/pipeline_parallel/compile_executable.py
+++ b/alpa/pipeline_parallel/compile_executable.py
@@ -46,6 +46,7 @@ def compile_pipeshard_executable(
         virtual_mesh: VirtualPhysicalMesh, num_microbatch: int,
         pipeline_schedule: str, default_as_option: AutoShardingOption,
         layer_option: LayerOption, stage_option: StageOption,
+        input_sharding: Optional[Sequence[Sequence[pxla.ShardingSpec]]],
         *avals: Sequence[AbstractValue]):
     """
     Compile a callable for pipeshard parallel which combines
@@ -76,7 +77,7 @@ def compile_pipeshard_executable(
     pipeshard_config = compile_pipeshard_executable_internal(
         closed_jaxpr, full_batch_closed_jaxpr, micro_batch_size, donated_invars,
         batch_invars, virtual_mesh, num_microbatch, pipeline_schedule,
-        default_as_option, stage_option, name_base, None)
+        default_as_option, stage_option, name_base, None, input_sharding)
 
     executable = PipeshardDriverExecutable(
         mesh_group=virtual_mesh.launched_physical_mesh_group,
@@ -97,7 +98,8 @@ def compile_pipeshard_executable_internal(
         virtual_mesh: VirtualPhysicalMesh, num_microbatch: int,
         pipeline_schedule: str, default_as_option: AutoShardingOption,
         stage_option: StageOption, name_base: str,
-        output_shardings: Optional[Sequence[pxla.ShardingSpec]]):
+        output_shardings: Optional[Sequence[pxla.ShardingSpec]],
+        input_shardings: Optional[Sequence[Sequence[pxla.ShardingSpec]]]):
     global_invars = closed_jaxpr.jaxpr.invars
     global_outvars = closed_jaxpr.jaxpr.outvars
     gensym_func = gensym([closed_jaxpr.jaxpr])
@@ -204,7 +206,8 @@ def compile_pipeshard_executable_internal(
         grad_in_to_out, global_invars, acc_grad_outvars, donate_invars_dict,
         num_microbatch, manual_stage_option.submesh_logical_shapes,
         manual_stage_option.submesh_autosharding_option_dicts,
-        default_as_option, output_sharding_dict, name_base, gensym_func)
+        default_as_option, output_sharding_dict, input_shardings, name_base,
+        gensym_func)
     total_flops *= num_microbatch
     debug_compilation_time("shard stages")
 
@@ -237,8 +240,8 @@ def shard_each_stage(jax_all_stages, virtual_meshes, schedule, n_stages,
                      num_meshes, grad_in_to_out, global_invars,
                      acc_grad_outvars, donate_invars_dict, num_microbatch,
                      logical_mesh_shapes, autosharding_option_dicts,
-                     default_as_option, output_sharding_dict, name_base,
-                     gensym_func):
+                     default_as_option, output_sharding_dict, input_shardings,
+                     name_base, gensym_func):
     """Run intra-op parallelism compilation for a stage."""
     # Initialize donation mapping
     stage_dict = [[] for _ in range(num_meshes)]
@@ -249,6 +252,10 @@ def shard_each_stage(jax_all_stages, virtual_meshes, schedule, n_stages,
     donatable_list = get_donatable_intermediate(
         jax_all_stages, mesh_stage_mapping,
         OrderedSet(global_invars).union(grad_in_to_out.keys()))
+
+    if input_shardings is None:
+        input_shardings = [None for _ in range(num_meshes)]
+    assert len(input_shardings) == num_meshes
 
     for i, stage in enumerate(jax_all_stages):
         mesh_indices = list(schedule.stage_placement(i))
@@ -276,6 +283,7 @@ def shard_each_stage(jax_all_stages, virtual_meshes, schedule, n_stages,
             logical_mesh_shapes[mesh_idx])
         autosharding_option = dataclasses.replace(
             default_as_option, **autosharding_option_dicts[mesh_idx])
+        input_sharding = input_shardings[mesh_idx]
 
         # Setup dummy stages
         for i in dummy_stage_id_dict[mesh_idx]:
@@ -289,7 +297,7 @@ def shard_each_stage(jax_all_stages, virtual_meshes, schedule, n_stages,
         if distributed_compile:
             module, flops = (generate_sharded_xla_computations_arguments(
                 f"{name_base}_mesh_{mesh_idx}", stage_dict[mesh_idx],
-                stage_donate_invars, output_sharding_dict))
+                stage_donate_invars, output_sharding_dict, input_sharding))
             other_kwargs = {
                 "logical_mesh": logical_mesh,
                 "return_mode": "stages",
@@ -306,7 +314,7 @@ def shard_each_stage(jax_all_stages, virtual_meshes, schedule, n_stages,
                 f"{name_base}_mesh_{mesh_idx}", stage_dict[mesh_idx],
                 stage_donate_invars, donatable_dict[mesh_idx], acc_grad_outvars,
                 num_microbatch, logical_mesh, autosharding_option,
-                output_sharding_dict)
+                output_sharding_dict, input_sharding)
             total_flops += flops
             for i, xla_stage in zip(stage_id_dict[mesh_idx],
                                     sharded_xla_stages):

--- a/alpa/pipeline_parallel/compile_executable.py
+++ b/alpa/pipeline_parallel/compile_executable.py
@@ -297,7 +297,8 @@ def shard_each_stage(jax_all_stages, virtual_meshes, schedule, n_stages,
         if distributed_compile:
             module, flops = (generate_sharded_xla_computations_arguments(
                 f"{name_base}_mesh_{mesh_idx}", stage_dict[mesh_idx],
-                stage_donate_invars, output_sharding_dict, stage_input_sharding))
+                stage_donate_invars, output_sharding_dict,
+                stage_input_sharding))
             other_kwargs = {
                 "logical_mesh": logical_mesh,
                 "return_mode": "stages",

--- a/alpa/pipeline_parallel/compile_executable.py
+++ b/alpa/pipeline_parallel/compile_executable.py
@@ -240,8 +240,8 @@ def shard_each_stage(jax_all_stages, virtual_meshes, schedule, n_stages,
                      num_meshes, grad_in_to_out, global_invars,
                      acc_grad_outvars, donate_invars_dict, num_microbatch,
                      logical_mesh_shapes, autosharding_option_dicts,
-                     default_as_option, output_sharding_dict, stage_input_sharings,
-                     name_base, gensym_func):
+                     default_as_option, output_sharding_dict,
+                     stage_input_sharings, name_base, gensym_func):
     """Run intra-op parallelism compilation for a stage."""
     # Initialize donation mapping
     stage_dict = [[] for _ in range(num_meshes)]

--- a/alpa/pipeline_parallel/compile_executable.py
+++ b/alpa/pipeline_parallel/compile_executable.py
@@ -253,9 +253,9 @@ def shard_each_stage(jax_all_stages, virtual_meshes, schedule, n_stages,
         jax_all_stages, mesh_stage_mapping,
         OrderedSet(global_invars).union(grad_in_to_out.keys()))
 
-    if input_shardings is None:
-        input_shardings = [None for _ in range(num_meshes)]
-    assert len(input_shardings) == num_meshes
+    if stage_input_sharings is None:
+        stage_input_sharings = [None for _ in range(num_meshes)]
+    assert len(stage_input_sharings) == num_meshes
 
     for i, stage in enumerate(jax_all_stages):
         mesh_indices = list(schedule.stage_placement(i))

--- a/alpa/pipeline_parallel/compile_executable.py
+++ b/alpa/pipeline_parallel/compile_executable.py
@@ -46,7 +46,7 @@ def compile_pipeshard_executable(
         virtual_mesh: VirtualPhysicalMesh, num_microbatch: int,
         pipeline_schedule: str, default_as_option: AutoShardingOption,
         layer_option: LayerOption, stage_option: StageOption,
-        stage_input_sharings: Optional[Sequence[Sequence[pxla.ShardingSpec]]],
+        stage_input_shardings: Optional[Sequence[Sequence[pxla.ShardingSpec]]],
         *avals: Sequence[AbstractValue]):
     """
     Compile a callable for pipeshard parallel which combines
@@ -77,7 +77,7 @@ def compile_pipeshard_executable(
     pipeshard_config = compile_pipeshard_executable_internal(
         closed_jaxpr, full_batch_closed_jaxpr, micro_batch_size, donated_invars,
         batch_invars, virtual_mesh, num_microbatch, pipeline_schedule,
-        default_as_option, stage_option, name_base, None, stage_input_sharings)
+        default_as_option, stage_option, name_base, None, stage_input_shardings)
 
     executable = PipeshardDriverExecutable(
         mesh_group=virtual_mesh.launched_physical_mesh_group,
@@ -99,7 +99,7 @@ def compile_pipeshard_executable_internal(
         pipeline_schedule: str, default_as_option: AutoShardingOption,
         stage_option: StageOption, name_base: str,
         output_shardings: Optional[Sequence[pxla.ShardingSpec]],
-        stage_input_sharings: Optional[Sequence[Sequence[pxla.ShardingSpec]]]):
+        stage_input_shardings: Optional[Sequence[Sequence[pxla.ShardingSpec]]]):
     global_invars = closed_jaxpr.jaxpr.invars
     global_outvars = closed_jaxpr.jaxpr.outvars
     gensym_func = gensym([closed_jaxpr.jaxpr])
@@ -206,7 +206,7 @@ def compile_pipeshard_executable_internal(
         grad_in_to_out, global_invars, acc_grad_outvars, donate_invars_dict,
         num_microbatch, manual_stage_option.submesh_logical_shapes,
         manual_stage_option.submesh_autosharding_option_dicts,
-        default_as_option, output_sharding_dict, stage_input_sharings,
+        default_as_option, output_sharding_dict, stage_input_shardings,
         name_base, gensym_func)
     total_flops *= num_microbatch
     debug_compilation_time("shard stages")
@@ -241,7 +241,7 @@ def shard_each_stage(jax_all_stages, virtual_meshes, schedule, n_stages,
                      acc_grad_outvars, donate_invars_dict, num_microbatch,
                      logical_mesh_shapes, autosharding_option_dicts,
                      default_as_option, output_sharding_dict,
-                     stage_input_sharings, name_base, gensym_func):
+                     stage_input_shardings, name_base, gensym_func):
     """Run intra-op parallelism compilation for a stage."""
     # Initialize donation mapping
     stage_dict = [[] for _ in range(num_meshes)]
@@ -253,9 +253,9 @@ def shard_each_stage(jax_all_stages, virtual_meshes, schedule, n_stages,
         jax_all_stages, mesh_stage_mapping,
         OrderedSet(global_invars).union(grad_in_to_out.keys()))
 
-    if stage_input_sharings is None:
-        stage_input_sharings = [None for _ in range(num_meshes)]
-    assert len(stage_input_sharings) == num_meshes
+    if stage_input_shardings is None:
+        stage_input_shardings = [None for _ in range(num_meshes)]
+    assert len(stage_input_shardings) == num_meshes
 
     for i, stage in enumerate(jax_all_stages):
         mesh_indices = list(schedule.stage_placement(i))
@@ -283,7 +283,7 @@ def shard_each_stage(jax_all_stages, virtual_meshes, schedule, n_stages,
             logical_mesh_shapes[mesh_idx])
         autosharding_option = dataclasses.replace(
             default_as_option, **autosharding_option_dicts[mesh_idx])
-        stage_input_sharing = stage_input_sharings[mesh_idx]
+        stage_input_sharding = stage_input_shardings[mesh_idx]
 
         # Setup dummy stages
         for i in dummy_stage_id_dict[mesh_idx]:
@@ -297,7 +297,7 @@ def shard_each_stage(jax_all_stages, virtual_meshes, schedule, n_stages,
         if distributed_compile:
             module, flops = (generate_sharded_xla_computations_arguments(
                 f"{name_base}_mesh_{mesh_idx}", stage_dict[mesh_idx],
-                stage_donate_invars, output_sharding_dict, stage_input_sharing))
+                stage_donate_invars, output_sharding_dict, stage_input_sharding))
             other_kwargs = {
                 "logical_mesh": logical_mesh,
                 "return_mode": "stages",
@@ -314,7 +314,7 @@ def shard_each_stage(jax_all_stages, virtual_meshes, schedule, n_stages,
                 f"{name_base}_mesh_{mesh_idx}", stage_dict[mesh_idx],
                 stage_donate_invars, donatable_dict[mesh_idx], acc_grad_outvars,
                 num_microbatch, logical_mesh, autosharding_option,
-                output_sharding_dict, stage_input_sharing)
+                output_sharding_dict, stage_input_sharding)
             total_flops += flops
             for i, xla_stage in zip(stage_id_dict[mesh_idx],
                                     sharded_xla_stages):

--- a/alpa/pipeline_parallel/compile_executable.py
+++ b/alpa/pipeline_parallel/compile_executable.py
@@ -99,7 +99,7 @@ def compile_pipeshard_executable_internal(
         pipeline_schedule: str, default_as_option: AutoShardingOption,
         stage_option: StageOption, name_base: str,
         output_shardings: Optional[Sequence[pxla.ShardingSpec]],
-        stage_input_sharing: Optional[Sequence[Sequence[pxla.ShardingSpec]]]):
+        stage_input_sharings: Optional[Sequence[Sequence[pxla.ShardingSpec]]]):
     global_invars = closed_jaxpr.jaxpr.invars
     global_outvars = closed_jaxpr.jaxpr.outvars
     gensym_func = gensym([closed_jaxpr.jaxpr])
@@ -206,8 +206,8 @@ def compile_pipeshard_executable_internal(
         grad_in_to_out, global_invars, acc_grad_outvars, donate_invars_dict,
         num_microbatch, manual_stage_option.submesh_logical_shapes,
         manual_stage_option.submesh_autosharding_option_dicts,
-        default_as_option, output_sharding_dict, input_shardings, name_base,
-        gensym_func)
+        default_as_option, output_sharding_dict, stage_input_sharings,
+        name_base, gensym_func)
     total_flops *= num_microbatch
     debug_compilation_time("shard stages")
 

--- a/alpa/pipeline_parallel/computation.py
+++ b/alpa/pipeline_parallel/computation.py
@@ -828,7 +828,7 @@ def generate_sharded_xla_computations_arguments(
         name: str, jax_computations: Sequence[JaxPipelineComputation],
         computation_donate_invars: Sequence[bool],
         output_sharding_dict: Dict[Var, pxla.ShardingSpec],
-        stage_input_sharing: Optional[Sequence[pxla.ShardingSpec]]):
+        stage_input_sharding: Optional[Sequence[pxla.ShardingSpec]]):
     """
     Generates the arguments for distributed compilation.
 
@@ -874,10 +874,10 @@ def generate_sharded_xla_computations_arguments(
         ]
         xe.set_hlo_module_output_shardings(hlo_module, sharding_protos)
 
-    if stage_input_sharing:
+    if stage_input_sharding:
         sharding_protos = [
             sharding_spec.sharding_proto()
-            for sharding_spec in stage_input_sharing
+            for sharding_spec in stage_input_sharding
         ]
         xe.set_hlo_module_input_shardings(hlo_module, sharding_protos)
 
@@ -889,7 +889,7 @@ def generate_sharded_xla_computations(
         name: str, jax_computations: Sequence[JaxPipelineComputation],
         computation_donate_invars, donatable_lists, acc_grad_outvars,
         num_micro_batches, logical_mesh, autosharding_option,
-        output_sharding_dict, stage_input_sharing):
+        output_sharding_dict, stage_input_sharding):
     """
     Generate sharded XLA computations.
 
@@ -899,7 +899,7 @@ def generate_sharded_xla_computations(
     """
     hlo_module, flops = generate_sharded_xla_computations_arguments(
         name, jax_computations, computation_donate_invars, output_sharding_dict,
-        stage_input_sharing)
+        stage_input_sharding)
 
     #  pylint: disable=unbalanced-tuple-unpacking
     (computation_names, computation_modules,

--- a/alpa/pipeline_parallel/computation.py
+++ b/alpa/pipeline_parallel/computation.py
@@ -876,7 +876,8 @@ def generate_sharded_xla_computations_arguments(
 
     if stage_input_sharing:
         sharding_protos = [
-            sharding_spec.sharding_proto() for sharding_spec in stage_input_sharing
+            sharding_spec.sharding_proto()
+            for sharding_spec in stage_input_sharing
         ]
         xe.set_hlo_module_input_shardings(hlo_module, sharding_protos)
 

--- a/alpa/pipeline_parallel/computation.py
+++ b/alpa/pipeline_parallel/computation.py
@@ -2,7 +2,7 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 import logging
-from typing import Sequence, Any, Dict
+from typing import Sequence, Any, Dict, Optional
 
 import jax
 from jax import jit
@@ -827,7 +827,8 @@ def generate_computations_from_modules(jax_computations, computation_names,
 def generate_sharded_xla_computations_arguments(
         name: str, jax_computations: Sequence[JaxPipelineComputation],
         computation_donate_invars: Sequence[bool],
-        output_sharding_dict: Dict[Var, pxla.ShardingSpec]):
+        output_sharding_dict: Dict[Var, pxla.ShardingSpec],
+        input_sharding: Optional[Sequence[pxla.ShardingSpec]]):
     """
     Generates the arguments for distributed compilation.
 
@@ -873,6 +874,12 @@ def generate_sharded_xla_computations_arguments(
         ]
         xe.set_hlo_module_output_shardings(hlo_module, sharding_protos)
 
+    if input_sharding:
+        sharding_protos = [
+            sharding_spec.sharding_proto() for sharding_spec in input_sharding
+        ]
+        xe.set_hlo_module_input_shardings(hlo_module, sharding_protos)
+
     flops = xe.hlo_module_count_flop_dot_conv_only(hlo_module)
     return hlo_module, flops
 
@@ -881,7 +888,7 @@ def generate_sharded_xla_computations(
         name: str, jax_computations: Sequence[JaxPipelineComputation],
         computation_donate_invars, donatable_lists, acc_grad_outvars,
         num_micro_batches, logical_mesh, autosharding_option,
-        output_sharding_dict):
+        output_sharding_dict, input_sharding):
     """
     Generate sharded XLA computations.
 
@@ -890,7 +897,8 @@ def generate_sharded_xla_computations(
     them together to get a sharding strategy config.
     """
     hlo_module, flops = generate_sharded_xla_computations_arguments(
-        name, jax_computations, computation_donate_invars, output_sharding_dict)
+        name, jax_computations, computation_donate_invars, output_sharding_dict,
+        input_sharding)
 
     #  pylint: disable=unbalanced-tuple-unpacking
     (computation_names, computation_modules,

--- a/alpa/pipeline_parallel/computation.py
+++ b/alpa/pipeline_parallel/computation.py
@@ -828,7 +828,7 @@ def generate_sharded_xla_computations_arguments(
         name: str, jax_computations: Sequence[JaxPipelineComputation],
         computation_donate_invars: Sequence[bool],
         output_sharding_dict: Dict[Var, pxla.ShardingSpec],
-        input_sharding: Optional[Sequence[pxla.ShardingSpec]]):
+        stage_input_sharing: Optional[Sequence[pxla.ShardingSpec]]):
     """
     Generates the arguments for distributed compilation.
 
@@ -874,9 +874,9 @@ def generate_sharded_xla_computations_arguments(
         ]
         xe.set_hlo_module_output_shardings(hlo_module, sharding_protos)
 
-    if input_sharding:
+    if stage_input_sharing:
         sharding_protos = [
-            sharding_spec.sharding_proto() for sharding_spec in input_sharding
+            sharding_spec.sharding_proto() for sharding_spec in stage_input_sharing
         ]
         xe.set_hlo_module_input_shardings(hlo_module, sharding_protos)
 
@@ -888,7 +888,7 @@ def generate_sharded_xla_computations(
         name: str, jax_computations: Sequence[JaxPipelineComputation],
         computation_donate_invars, donatable_lists, acc_grad_outvars,
         num_micro_batches, logical_mesh, autosharding_option,
-        output_sharding_dict, input_sharding):
+        output_sharding_dict, stage_input_sharing):
     """
     Generate sharded XLA computations.
 
@@ -898,7 +898,7 @@ def generate_sharded_xla_computations(
     """
     hlo_module, flops = generate_sharded_xla_computations_arguments(
         name, jax_computations, computation_donate_invars, output_sharding_dict,
-        input_sharding)
+        stage_input_sharing)
 
     #  pylint: disable=unbalanced-tuple-unpacking
     (computation_names, computation_modules,

--- a/alpa/pipeline_parallel/pipeshard_executable.py
+++ b/alpa/pipeline_parallel/pipeshard_executable.py
@@ -62,7 +62,7 @@ class PipeshardDriverExecutable:
         self.stages = pipeshard_config.xla_stages
         self.schedule = pipeshard_config.schedule
         self.flop_count = pipeshard_config.flop_count
-        self.input_shard_specs = pipeshard_config.input_shard_specs
+        self.stage_input_shard_specs = pipeshard_config.stage_input_shard_specs
         self.input_placement_specs = pipeshard_config.input_placement_specs
         self.output_placement_specs = pipeshard_config.output_placement_specs
         # List[stage_idx -> str]

--- a/alpa/pipeline_parallel/pipeshard_executable.py
+++ b/alpa/pipeline_parallel/pipeshard_executable.py
@@ -62,6 +62,7 @@ class PipeshardDriverExecutable:
         self.stages = pipeshard_config.xla_stages
         self.schedule = pipeshard_config.schedule
         self.flop_count = pipeshard_config.flop_count
+        self.input_shard_specs = pipeshard_config.input_shard_specs
         self.input_placement_specs = pipeshard_config.input_placement_specs
         self.output_placement_specs = pipeshard_config.output_placement_specs
         # List[stage_idx -> str]

--- a/alpa/pipeline_parallel/runtime_emitter.py
+++ b/alpa/pipeline_parallel/runtime_emitter.py
@@ -252,7 +252,7 @@ class PipeshardConfig:
     output_local_uuid_list: Sequence[Sequence[int]]
     outs_handler: Callable
     # Others (debug info)
-    input_shard_specs: Sequence[Sequence[pxla.ShardingSpec]]
+    stage_input_shard_specs: Sequence[Sequence[pxla.ShardingSpec]]
     input_placement_specs: Sequence[PlacementSpec]
     output_placement_specs: Sequence[PlacementSpec]
     default_auto_sharding_option: AutoShardingOption

--- a/alpa/pipeline_parallel/runtime_emitter.py
+++ b/alpa/pipeline_parallel/runtime_emitter.py
@@ -252,6 +252,7 @@ class PipeshardConfig:
     output_local_uuid_list: Sequence[Sequence[int]]
     outs_handler: Callable
     # Others (debug info)
+    input_shard_specs: Sequence[Sequence[pxla.ShardingSpec]]
     input_placement_specs: Sequence[PlacementSpec]
     output_placement_specs: Sequence[PlacementSpec]
     default_auto_sharding_option: AutoShardingOption
@@ -448,6 +449,13 @@ class PipelineInstEmitter:
         # Compile load info
         input_placement_specs = self._compile_input_placement_spec(
             input_config.mesh_arg_indices, input_shard_specs)
+
+        # Keep the input sharding specs based on pipeline stages
+        input_shard_specs = [
+            self.stages[idx].input_sharding_specs
+            for idx in self.schedule.mesh_stage_mapping
+        ]
+
         return PipeshardConfig(
             # Executable configs
             instruction_lists,
@@ -466,6 +474,7 @@ class PipelineInstEmitter:
             output_local_uuid_list,
             outs_handler,
             # Others
+            input_shard_specs,
             input_placement_specs,
             output_placement_specs,
             self.default_auto_sharding_option,

--- a/tests/pipeline_parallel/test_set_input_shard.py
+++ b/tests/pipeline_parallel/test_set_input_shard.py
@@ -1,0 +1,87 @@
+import jax
+import jax.numpy as jnp
+import unittest
+
+from alpa import init, parallelize, AutoShardingOption, PipeshardParallel
+from alpa.testing import MLPModel
+
+
+class SetInputShardSpecTest(unittest.TestCase):
+
+    def setUp(self):
+        init(cluster="ray")
+
+    def run_set_input_shard_spec(self):
+        hidden_size = 64
+
+        rngkey = jax.random.PRNGKey(0)
+
+        # Make a MLP model with 2 pipeline stages.
+        model = MLPModel(num_layers=4,
+                         hidden_size=hidden_size,
+                         add_manual_pipeline_marker=True)
+        data = jax.core.ShapedArray((1, hidden_size), jnp.float32)
+        params = jax.eval_shape(model.init, rngkey, data)
+        params = jax.tree_map(
+            lambda x: jax.ShapeDtypeStruct(x.shape, jnp.float32), params)
+
+        def infer_fn(params, batch):
+            return model.apply(params, batch["x"])
+
+        method = PipeshardParallel(
+            num_micro_batches=1,
+            pipeline_schedule="inference",
+            layer_option="manual",
+            default_auto_sharding_option=AutoShardingOption(
+                force_batch_dim_to_mesh_dim=None,
+                allow_all_to_all=False,
+                allow_all_gather=False,
+            ))
+
+        # Compile with batch size 1
+        executable_1 = parallelize(
+            infer_fn, batch_argnums=(1,), method=method).get_executable(
+                params,
+                {"x": jax.core.ShapedArray((1, hidden_size), jnp.float32)})
+
+        # Make another parallel method with the same input shard spec.
+        method_with_input_shard = PipeshardParallel(
+            num_micro_batches=1,
+            pipeline_schedule="inference",
+            layer_option="manual",
+            default_auto_sharding_option=AutoShardingOption(
+                force_batch_dim_to_mesh_dim=None,
+                allow_all_to_all=False,
+                allow_all_gather=False,
+            ),
+            input_sharding=executable_1.input_shard_specs)
+
+        # Compile with a different batch size
+        executable_2 = parallelize(
+            infer_fn, batch_argnums=(1,), method=method).get_executable(
+                params,
+                {"x": jax.core.ShapedArray((8, hidden_size), jnp.float32)})
+
+        # Compile with a different batch size but the same input shard specs
+        executable_3 = parallelize(
+            infer_fn, batch_argnums=(1,),
+            method=method_with_input_shard).get_executable(
+                params,
+                {"x": jax.core.ShapedArray((8, hidden_size), jnp.float32)})
+
+        assert executable_2.input_shard_specs != executable_3.input_shard_specs
+        assert executable_1.input_shard_specs == executable_3.input_shard_specs
+
+    def test_set_input_shard_spec(self):
+        self.run_set_input_shard_spec()
+
+
+def suite():
+    suite = unittest.TestSuite()
+    suite.addTest(SetInputShardSpecTest('test_set_input_shard_spec'))
+    return suite
+
+
+if __name__ == "__main__":
+    runner = unittest.TextTestRunner()
+    runner.run(suite())

--- a/tests/pipeline_parallel/test_set_input_shard.py
+++ b/tests/pipeline_parallel/test_set_input_shard.py
@@ -54,7 +54,7 @@ class SetInputShardSpecTest(unittest.TestCase):
                 allow_all_to_all=False,
                 allow_all_gather=False,
             ),
-            input_sharding=executable_1.input_shard_specs)
+            stage_input_shardings=executable_1.stage_input_shard_specs)
 
         # Compile with a different batch size
         executable_2 = parallelize(
@@ -69,8 +69,8 @@ class SetInputShardSpecTest(unittest.TestCase):
                 params,
                 {"x": jax.core.ShapedArray((8, hidden_size), jnp.float32)})
 
-        assert executable_2.input_shard_specs != executable_3.input_shard_specs
-        assert executable_1.input_shard_specs == executable_3.input_shard_specs
+        assert executable_2.stage_input_shard_specs != executable_3.stage_input_shard_specs
+        assert executable_1.stage_input_shard_specs == executable_3.stage_input_shard_specs
 
     def test_set_input_shard_spec(self):
         self.run_set_input_shard_spec()


### PR DESCRIPTION
A part of #550: Manual inter-operator parallelism and sharding-propagation based intra-operator parallelism

Improve `PipeshardParallel` to optionally accept `input_sharding`. When given, the input of each HLO module will be sharded accordingly.

See unit test for details.

cc @merrymercy @zhuohan123 