### PR TITLE
[Internal feature: Ray Placement Grp] adding the placement group 

### DIFF
--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -966,8 +966,7 @@ class DistributedPhysicalDeviceMesh(PhysicalDeviceMesh):
         # get the sorted bundle index list
         device_bundle_idx_list = get_bundle_idx(placement_group,
                                                 self.device_ips)
-        
-        print(self.num_devices_per_host)
+
         for i in range(self.num_hosts):
             bundle_index = device_bundle_idx_list[i]
 

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -963,7 +963,6 @@ class DistributedPhysicalDeviceMesh(PhysicalDeviceMesh):
         self.workers = []
 
         _placement_group = global_cluster._placement_group
-        
         # get the sorted bundle index list
         device_bundle_idx_list = get_bundle_idx(_placement_group,
                                                 self.device_ips)

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -2129,6 +2129,8 @@ def init_global_cluster(cluster: str):
             len(global_cluster.host_num_devices), global_cluster.host_num_devices[0])
         global_virtual_physical_mesh = (
             global_cluster.get_virtual_physical_mesh())
+    
+        print('hello, ', alpa.device_mesh.global_placement_group)
 
 
 def shutdown_global_cluster():

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -45,7 +45,6 @@ import numpy as np
 import ray
 from ray.util.placement_group import remove_placement_group
 
-import alpa
 from alpa import mesh_profiling
 import alpa.collective as col
 from alpa.global_env import global_config
@@ -963,8 +962,6 @@ class DistributedPhysicalDeviceMesh(PhysicalDeviceMesh):
         # Launch workers
         self.workers = []
 
-        print(alpa.device_mesh.global_cluster)
-        import traceback; traceback.print_stack()
         # retrieve the placement group
         placement_group = retrieve_placement_group()
 

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -43,7 +43,7 @@ from jax.lib import xla_client
 import jax.numpy as jnp
 import numpy as np
 import ray
-from ray.util.placement_group import remove_placement_group
+from ray.util.placement_group import remove_placement_group, get_placement_group
 
 import alpa
 from alpa import mesh_profiling
@@ -970,8 +970,9 @@ class DistributedPhysicalDeviceMesh(PhysicalDeviceMesh):
         else: 
             for name, info in ray._private.state.state.placement_group_table().items(): 
                 if info['state'] == 'CREATED':
-                    placement_group = ray.util.placement_group.get_placement_group(name)
-            alpa.device_mesh.global_placement_group
+                    placement_group = get_placement_group(name)
+                    
+        print(placement_group)
         # get the sorted bundle index list
         device_bundle_idx_list = get_bundle_idx(placement_group,
                                                 self.device_ips)

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -939,7 +939,7 @@ class DistributedPhysicalDeviceMesh(PhysicalDeviceMesh):
             ip = self.host_info[i]["NodeManagerAddress"]
             self.device_strs.extend(
                 [device_id_to_str(ip, j) for j in devices[i]])
-            self.device_ips.append(ip)
+            self.node_ips.append(ip)
         self._launch_xla_servers()
 
         self.to_delete_remote_refs = []

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -964,6 +964,7 @@ class DistributedPhysicalDeviceMesh(PhysicalDeviceMesh):
         self.workers = []
 
         print(alpa.device_mesh.global_cluster)
+        import traceback; traceback.print_exc()
         # retrieve the placement group
         placement_group = retrieve_placement_group()
 

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -45,6 +45,7 @@ import numpy as np
 import ray
 from ray.util.placement_group import remove_placement_group
 
+import alpa
 from alpa import mesh_profiling
 import alpa.collective as col
 from alpa.global_env import global_config
@@ -962,6 +963,7 @@ class DistributedPhysicalDeviceMesh(PhysicalDeviceMesh):
         # Launch workers
         self.workers = []
 
+        print(alpa.device_mesh.global_cluster)
         # retrieve the placement group
         placement_group = retrieve_placement_group()
 

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -964,6 +964,7 @@ class DistributedPhysicalDeviceMesh(PhysicalDeviceMesh):
         self.workers = []
 
         print(ray.available_resources())
+        print(ray._private.state.state.placement_group_table())
         placement_group = alpa.device_mesh.global_placement_group
         # get the sorted bundle index list
         device_bundle_idx_list = get_bundle_idx(placement_group,

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -964,7 +964,7 @@ class DistributedPhysicalDeviceMesh(PhysicalDeviceMesh):
         self.workers = []
 
         print(alpa.device_mesh.global_cluster)
-        import traceback; traceback.print_exc()
+        import traceback; traceback.print_stack()
         # retrieve the placement group
         placement_group = retrieve_placement_group()
 

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -43,7 +43,7 @@ from jax.lib import xla_client
 import jax.numpy as jnp
 import numpy as np
 import ray
-from ray.util.placement_group import remove_placement_group, get_placement_group
+from ray.util.placement_group import remove_placement_group, PlacementGroup
 
 import alpa
 from alpa import mesh_profiling
@@ -970,8 +970,14 @@ class DistributedPhysicalDeviceMesh(PhysicalDeviceMesh):
         else: 
             for name, info in ray._private.state.state.placement_group_table().items(): 
                 if info['state'] == 'CREATED':
-                    placement_group = get_placement_group(name)
+                    from ray._private.utils import hex_to_binary
+                    from ray._raylet import PlacementGroupID
+
+                    # placement_group = get_placement_group(name)
                     
+                    placement_group = PlacementGroup(
+                        PlacementGroupID(hex_to_binary(name))
+                    )
         print(placement_group)
         # get the sorted bundle index list
         device_bundle_idx_list = get_bundle_idx(placement_group,

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -966,8 +966,7 @@ class DistributedPhysicalDeviceMesh(PhysicalDeviceMesh):
         placement_group = retrieve_placement_group()
 
         # get the sorted bundle index list
-        device_bundle_idx_list = get_bundle_idx(placement_group,
-                                                self.node_ips)
+        device_bundle_idx_list = get_bundle_idx(placement_group, self.node_ips)
 
         for i in range(self.num_hosts):
             bundle_index = device_bundle_idx_list[i]

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -1016,7 +1016,8 @@ class DistributedPhysicalDeviceMesh(PhysicalDeviceMesh):
                 placement_group_bundle_index=bundle_index).remote()
 
             # Launch the MeshHostWorker
-            cls = ray.remote(num_cpus=0, num_gpus=self.num_devices_per_host)(MeshHostWorker)
+            cls = ray.remote(num_cpus=0,
+                             num_gpus=self.num_devices_per_host)(MeshHostWorker)
             worker = cls.options(placement_group=placement_group,
                                  placement_group_bundle_index=bundle_index,
                                  runtime_env={

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -963,6 +963,7 @@ class DistributedPhysicalDeviceMesh(PhysicalDeviceMesh):
         # Launch workers
         self.workers = []
 
+        print(ray.available_resources())
         placement_group = alpa.device_mesh.global_placement_group
         # get the sorted bundle index list
         device_bundle_idx_list = get_bundle_idx(placement_group,

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -933,7 +933,6 @@ class DistributedPhysicalDeviceMesh(PhysicalDeviceMesh):
         self.devices = devices
         self.device_strs = []
         self.device_ips = []
-
         for i in range(self.num_hosts):
             ip = self.host_info[i]["NodeManagerAddress"]
             self.device_strs.extend(

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -1016,7 +1016,7 @@ class DistributedPhysicalDeviceMesh(PhysicalDeviceMesh):
                 placement_group_bundle_index=bundle_index).remote()
 
             # Launch the MeshHostWorker
-            cls = ray.remote(num_cpus=1, num_gpus=self.num_devices_per_host)(MeshHostWorker)
+            cls = ray.remote(num_cpus=0, num_gpus=self.num_devices_per_host)(MeshHostWorker)
             worker = cls.options(placement_group=placement_group,
                                  placement_group_bundle_index=bundle_index,
                                  runtime_env={

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -1683,7 +1683,6 @@ class VirtualPhysicalMesh:
         self.launched_physical_mesh = None
         self.launched_physical_mesh_group = None
 
-        ic(self.host_ids, self.host_info)
         if devices is not None:
             if len(devices) != len(host_ids):
                 raise RuntimeError(
@@ -1813,7 +1812,6 @@ class VirtualPhysicalMesh:
         assert self.launched_physical_mesh is None, \
             "Physical mesh can only be launched once."
 
-        # ic(mesh_id, self.device_strs, self.host_ids, self.host_info)
         self.launched_physical_mesh = DistributedPhysicalDeviceMesh(
             host_ids=self.host_ids,
             host_info=self.host_info,

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -2023,6 +2023,8 @@ class DeviceCluster:
             assert number.is_integer()
             self.host_num_devices.append(int(number))
 
+        import traceback
+        traceback.print_stack()
         print(ray.available_resources())
         self._placement_group = create_placement_group(
             len(self.host_num_devices), self.host_num_devices[0])

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -963,7 +963,7 @@ class DistributedPhysicalDeviceMesh(PhysicalDeviceMesh):
         # Launch workers
         self.workers = []
 
-        # print(ray.available_resources())
+        print(ray.available_resources())
         # print(ray._private.state.state.placement_group_table())
         if alpa.device_mesh.global_placement_group: 
             placement_group = alpa.device_mesh.global_placement_group

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -1733,7 +1733,6 @@ class VirtualPhysicalMesh:
             # slicing along the host dimension
             host_ids = [self.host_ids[x] for x in indices]
             host_info = [self.host_info[x] for x in host_ids]
-
             return VirtualPhysicalMesh(
                 host_ids=host_ids,
                 host_info=host_info,

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -934,7 +934,7 @@ class DistributedPhysicalDeviceMesh(PhysicalDeviceMesh):
 
         self.devices = devices
         self.device_strs = []
-        self.device_ips = []
+        self.node_ips = []
         for i in range(self.num_hosts):
             ip = self.host_info[i]["NodeManagerAddress"]
             self.device_strs.extend(

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -58,7 +58,7 @@ from alpa.timer import timers
 from alpa.util import (benchmark_func, list_gpu_info, OrderedSet,
                        update_jax_platform, is_ray_node_resource,
                        try_import_ray_worker, create_placement_group,
-                       get_bundle_idx)
+                       get_bundle_idx, try_import_ray_state)
 
 ray_worker = try_import_ray_worker()
 
@@ -965,13 +965,11 @@ class DistributedPhysicalDeviceMesh(PhysicalDeviceMesh):
         # Launch workers
         self.workers = []
 
-        print(ray.available_resources())
-        # print(ray._private.state.state.placement_group_table())
         if alpa.device_mesh.global_placement_group:
             placement_group = alpa.device_mesh.global_placement_group
         else:
-            for name, info in ray._private.state.state.placement_group_table(
-            ).items():
+            ray_state = try_import_ray_state()
+            for name, info in ray_state.state.placement_group_table().items():
                 if info["state"] == "CREATED":
                     placement_group = PlacementGroup(
                         PlacementGroupID(hex_to_binary(name)))

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -2023,6 +2023,7 @@ class DeviceCluster:
             assert number.is_integer()
             self.host_num_devices.append(int(number))
 
+        print(ray.available_resources())
         self._placement_group = create_placement_group(
             len(self.host_num_devices), self.host_num_devices[0])
 

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -963,9 +963,15 @@ class DistributedPhysicalDeviceMesh(PhysicalDeviceMesh):
         # Launch workers
         self.workers = []
 
-        print(ray.available_resources())
-        print(ray._private.state.state.placement_group_table())
-        placement_group = alpa.device_mesh.global_placement_group
+        # print(ray.available_resources())
+        # print(ray._private.state.state.placement_group_table())
+        if alpa.device_mesh.global_placement_group: 
+            placement_group = alpa.device_mesh.global_placement_group
+        else: 
+            for name, info in ray._private.state.state.placement_group_table(): 
+                if info['state'] == 'CREATED':
+                    placement_group = ray.util.placement_group.get_placement_group(name)
+            alpa.device_mesh.global_placement_group
         # get the sorted bundle index list
         device_bundle_idx_list = get_bundle_idx(placement_group,
                                                 self.device_ips)

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -2141,7 +2141,7 @@ def init_global_cluster(cluster: str):
 def shutdown_global_cluster():
     global global_cluster, global_physical_mesh, global_virtual_physical_mesh
 
-    global_cluster.clean_up_placement_group()
+    _placement_group = global_cluster._placement_group
     global_cluster = None
     update_jax_platform("gpu")
 
@@ -2153,7 +2153,8 @@ def shutdown_global_cluster():
         if global_virtual_physical_mesh.launched_physical_mesh_group:
             global_virtual_physical_mesh.launched_physical_mesh_group.shutdown()
         global_virtual_physical_mesh = None
-
+    
+    remove_placement_group(_placement_group)
 
 def set_global_cluster(cluster: DeviceCluster):
     global global_cluster

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -1010,13 +1010,13 @@ class DistributedPhysicalDeviceMesh(PhysicalDeviceMesh):
                 })
 
             # Launch the DaemonMoveWorker
-            cls = ray.remote(DaemonMoveWorker)
+            cls = ray.remote(num_cpus=1e-3)(DaemonMoveWorker)
             move_worker = cls.options(
                 placement_group=placement_group,
                 placement_group_bundle_index=bundle_index).remote()
 
             # Launch the MeshHostWorker
-            cls = ray.remote(num_cpus=0,
+            cls = ray.remote(num_cpus=1e-3,
                              num_gpus=self.num_devices_per_host)(MeshHostWorker)
             worker = cls.options(placement_group=placement_group,
                                  placement_group_bundle_index=bundle_index,

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -967,7 +967,7 @@ class DistributedPhysicalDeviceMesh(PhysicalDeviceMesh):
 
         # get the sorted bundle index list
         device_bundle_idx_list = get_bundle_idx(placement_group,
-                                                self.device_ips)
+                                                self.node_ips)
 
         for i in range(self.num_hosts):
             bundle_index = device_bundle_idx_list[i]

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -966,7 +966,8 @@ class DistributedPhysicalDeviceMesh(PhysicalDeviceMesh):
         # get the sorted bundle index list
         device_bundle_idx_list = get_bundle_idx(placement_group,
                                                 self.device_ips)
-
+        
+        print(self.num_devices_per_host)
         for i in range(self.num_hosts):
             bundle_index = device_bundle_idx_list[i]
 

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -1016,7 +1016,7 @@ class DistributedPhysicalDeviceMesh(PhysicalDeviceMesh):
                 placement_group_bundle_index=bundle_index).remote()
 
             # Launch the MeshHostWorker
-            cls = ray.remote(num_gpus=self.num_devices_per_host)(MeshHostWorker)
+            cls = ray.remote(num_cpus=1, num_gpus=self.num_devices_per_host)(MeshHostWorker)
             worker = cls.options(placement_group=placement_group,
                                  placement_group_bundle_index=bundle_index,
                                  runtime_env={

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -968,7 +968,7 @@ class DistributedPhysicalDeviceMesh(PhysicalDeviceMesh):
         if alpa.device_mesh.global_placement_group: 
             placement_group = alpa.device_mesh.global_placement_group
         else: 
-            for name, info in ray._private.state.state.placement_group_table(): 
+            for name, info in ray._private.state.state.placement_group_table().items(): 
                 if info['state'] == 'CREATED':
                     placement_group = ray.util.placement_group.get_placement_group(name)
             alpa.device_mesh.global_placement_group

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -938,8 +938,6 @@ class DistributedPhysicalDeviceMesh(PhysicalDeviceMesh):
         # if len(self.host_info) == 1: 
         #     import traceback
         #     traceback.print_stack()
-
-
         
         for i in range(self.num_hosts):
             ip = self.host_info[i]["NodeManagerAddress"]
@@ -968,7 +966,7 @@ class DistributedPhysicalDeviceMesh(PhysicalDeviceMesh):
         # Launch workers
         self.workers = []
 
-        ic(ray.available_resources())
+        # ic(ray.available_resources())
         # create placement group
         self._placement_group = create_placement_group(
             self.num_hosts, self.num_devices_per_host)
@@ -1327,7 +1325,7 @@ class DistributedPhysicalDeviceMesh(PhysicalDeviceMesh):
             ray.get([w.shutdown.remote() for w in self.workers])
         for worker in self.workers:
             ray.kill(worker)
-        ic(self._placement_group)
+        # ic(self._placement_group)
         if self._placement_group:
             remove_placement_group(self._placement_group)
             self._placement_group = None
@@ -1827,7 +1825,7 @@ class VirtualPhysicalMesh:
         assert self.launched_physical_mesh is None, \
             "Physical mesh can only be launched once."
 
-        ic(mesh_id, self.device_strs, self.host_ids, self.host_info)
+        # ic(mesh_id, self.device_strs, self.host_ids, self.host_info)
         self.launched_physical_mesh = DistributedPhysicalDeviceMesh(
             host_ids=self.host_ids,
             host_info=self.host_info,
@@ -2039,6 +2037,10 @@ class DeviceCluster:
             assert number.is_integer()
             self.host_num_devices.append(int(number))
 
+        
+        self._placement_group = create_placement_group(
+            len(self.host_num_devices), self.host_num_devices[0])
+        
     @property
     def num_cpus(self):
         return sum(

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -2026,6 +2026,7 @@ class DeviceCluster:
             assert number.is_integer()
             self.host_num_devices.append(int(number))
 
+        print('hello, ', alpa.device_mesh.global_placement_group)
         # import traceback
         # traceback.print_stack()
         # print(ray.available_resources())

--- a/alpa/pipeline_parallel/stage_construction.py
+++ b/alpa/pipeline_parallel/stage_construction.py
@@ -14,7 +14,6 @@ import numpy as np
 from ray.exceptions import RayActorError
 import tqdm
 
-import alpa
 from alpa.device_mesh import DeviceCluster, VirtualPhysicalMesh
 from alpa.global_env import global_config
 from alpa.pipeline_parallel.computation import (

--- a/alpa/pipeline_parallel/stage_construction.py
+++ b/alpa/pipeline_parallel/stage_construction.py
@@ -462,6 +462,7 @@ def get_compute_cost(
         tic = time()
         if global_config.profile_with_whole_ray_cluster:
             global_cluster = alpa.device_mesh.global_cluster
+            print('inside', global_cluster)
             whole_cluster_virtual_mesh = global_cluster.\
                 get_virtual_physical_mesh()
             sliced_virtual_meshes = (

--- a/alpa/pipeline_parallel/stage_construction.py
+++ b/alpa/pipeline_parallel/stage_construction.py
@@ -14,7 +14,7 @@ import numpy as np
 from ray.exceptions import RayActorError
 import tqdm
 
-from alpa.device_mesh import DeviceCluster, VirtualPhysicalMesh
+from alpa.device_mesh import global_cluster, VirtualPhysicalMesh
 from alpa.global_env import global_config
 from alpa.pipeline_parallel.computation import (
     JaxPipelineComputation, merge_marked_jaxprs_with_named_call)
@@ -460,8 +460,8 @@ def get_compute_cost(
         num_hosts, num_devices = submesh
         tic = time()
         if global_config.profile_with_whole_ray_cluster:
-            whole_cluster_virtual_mesh = DeviceCluster(
-            ).get_virtual_physical_mesh()
+            whole_cluster_virtual_mesh = global_cluster.\
+                get_virtual_physical_mesh()
             sliced_virtual_meshes = (
                 whole_cluster_virtual_mesh.slice_profiling_submeshes(
                     num_hosts, num_devices))

--- a/alpa/pipeline_parallel/stage_construction.py
+++ b/alpa/pipeline_parallel/stage_construction.py
@@ -461,12 +461,8 @@ def get_compute_cost(
         num_hosts, num_devices = submesh
         tic = time()
         if global_config.profile_with_whole_ray_cluster:
-            if alpa.api.is_initialized:
-                whole_cluster = alpa.device_mesh.global_cluster
-            else: 
-                whole_cluster = DeviceCluster()
-            whole_cluster_virtual_mesh = whole_cluster\
-                .get_virtual_physical_mesh()
+            whole_cluster_virtual_mesh = DeviceCluster(
+            ).get_virtual_physical_mesh()
             sliced_virtual_meshes = (
                 whole_cluster_virtual_mesh.slice_profiling_submeshes(
                     num_hosts, num_devices))

--- a/alpa/pipeline_parallel/stage_construction.py
+++ b/alpa/pipeline_parallel/stage_construction.py
@@ -14,6 +14,7 @@ import numpy as np
 from ray.exceptions import RayActorError
 import tqdm
 
+import alpa
 from alpa.device_mesh import DeviceCluster, VirtualPhysicalMesh
 from alpa.global_env import global_config
 from alpa.pipeline_parallel.computation import (
@@ -460,8 +461,12 @@ def get_compute_cost(
         num_hosts, num_devices = submesh
         tic = time()
         if global_config.profile_with_whole_ray_cluster:
-            whole_cluster_virtual_mesh = DeviceCluster(
-            ).get_virtual_physical_mesh()
+            if alpa.api.initialized:
+                whole_cluster = alpa.device_mesh.global_cluster
+            else: 
+                whole_cluster = DeviceCluster()
+            whole_cluster_virtual_mesh = whole_cluster\
+                .get_virtual_physical_mesh()
             sliced_virtual_meshes = (
                 whole_cluster_virtual_mesh.slice_profiling_submeshes(
                     num_hosts, num_devices))

--- a/alpa/pipeline_parallel/stage_construction.py
+++ b/alpa/pipeline_parallel/stage_construction.py
@@ -461,7 +461,7 @@ def get_compute_cost(
         num_hosts, num_devices = submesh
         tic = time()
         if global_config.profile_with_whole_ray_cluster:
-            if alpa.api.initialized:
+            if alpa.api.is_initialized:
                 whole_cluster = alpa.device_mesh.global_cluster
             else: 
                 whole_cluster = DeviceCluster()

--- a/alpa/pipeline_parallel/stage_construction.py
+++ b/alpa/pipeline_parallel/stage_construction.py
@@ -461,7 +461,7 @@ def get_compute_cost(
         num_hosts, num_devices = submesh
         tic = time()
         if global_config.profile_with_whole_ray_cluster:
-            global_cluster = alpa.device_cluster.global_cluster
+            global_cluster = alpa.device_mesh.global_cluster
             whole_cluster_virtual_mesh = global_cluster.\
                 get_virtual_physical_mesh()
             sliced_virtual_meshes = (

--- a/alpa/pipeline_parallel/stage_construction.py
+++ b/alpa/pipeline_parallel/stage_construction.py
@@ -14,8 +14,7 @@ import numpy as np
 from ray.exceptions import RayActorError
 import tqdm
 
-import alpa
-from alpa.device_mesh import VirtualPhysicalMesh
+from alpa.device_mesh import DeviceCluster, VirtualPhysicalMesh
 from alpa.global_env import global_config
 from alpa.pipeline_parallel.computation import (
     JaxPipelineComputation, merge_marked_jaxprs_with_named_call)
@@ -461,10 +460,8 @@ def get_compute_cost(
         num_hosts, num_devices = submesh
         tic = time()
         if global_config.profile_with_whole_ray_cluster:
-            global_cluster = alpa.device_mesh.global_cluster
-            print('inside', global_cluster)
-            whole_cluster_virtual_mesh = global_cluster.\
-                get_virtual_physical_mesh()
+            whole_cluster_virtual_mesh = DeviceCluster(
+            ).get_virtual_physical_mesh()
             sliced_virtual_meshes = (
                 whole_cluster_virtual_mesh.slice_profiling_submeshes(
                     num_hosts, num_devices))

--- a/alpa/pipeline_parallel/stage_construction.py
+++ b/alpa/pipeline_parallel/stage_construction.py
@@ -14,7 +14,8 @@ import numpy as np
 from ray.exceptions import RayActorError
 import tqdm
 
-from alpa.device_mesh import global_cluster, VirtualPhysicalMesh
+import alpa
+from alpa.device_mesh import VirtualPhysicalMesh
 from alpa.global_env import global_config
 from alpa.pipeline_parallel.computation import (
     JaxPipelineComputation, merge_marked_jaxprs_with_named_call)
@@ -460,6 +461,7 @@ def get_compute_cost(
         num_hosts, num_devices = submesh
         tic = time()
         if global_config.profile_with_whole_ray_cluster:
+            global_cluster = alpa.device_cluster.global_cluster
             whole_cluster_virtual_mesh = global_cluster.\
                 get_virtual_physical_mesh()
             sliced_virtual_meshes = (

--- a/alpa/pipeline_parallel/stage_profiling.py
+++ b/alpa/pipeline_parallel/stage_profiling.py
@@ -347,7 +347,7 @@ class ProfileWorkerPool(BaseWorkerPoolWrapper):
 
     def __init__(self, virtual_meshes):
         super().__init__()
-        print('out-in-out', virtual_meshes, 'global cluster', alpa.device_mesh.global_cluster)
+        print('out-in-out', virtual_meshes, 'global cluster', alpa.device_mesh.global_cluster, 'palcemebt', alpa.device_mesh.global_cluster.placement_group)
         worker_cls = ray.remote(num_cpus=1e-3)(ProfileWorker)
         self.actors = [worker_cls.remote(mesh) for mesh in virtual_meshes]
         self.pool = ActorPool(self.actors)

--- a/alpa/pipeline_parallel/stage_profiling.py
+++ b/alpa/pipeline_parallel/stage_profiling.py
@@ -249,7 +249,7 @@ class ProfileWorker:
     def __init__(self, virtual_mesh: VirtualPhysicalMesh):
         self.mesh = virtual_mesh.get_physical_mesh()
         self.virtual_mesh = virtual_mesh
-
+        print(self.mesh, self.virtual_mesh)
     def _profile_impl(self, stage_id, compiled_output, profile_info,
                       intermediate_size, initial_size):
         """Implementation of profile function.

--- a/alpa/pipeline_parallel/stage_profiling.py
+++ b/alpa/pipeline_parallel/stage_profiling.py
@@ -16,6 +16,7 @@ import ray
 from ray.exceptions import RayActorError
 from ray.util import ActorPool
 
+import alpa
 from alpa.device_mesh import (DistributedArray, PhysicalDeviceMesh,
                               VirtualPhysicalMesh, _shard_device_array)
 from alpa.global_env import global_config
@@ -247,7 +248,7 @@ class ProfileWorker:
     """
 
     def __init__(self, virtual_mesh: VirtualPhysicalMesh):
-        print('outside', virtual_mesh)
+        print('outside', virtual_mesh, 'global cluster', alpa.device_mesh.global_cluster)
         self.mesh = virtual_mesh.get_physical_mesh()
         self.virtual_mesh = virtual_mesh
     def _profile_impl(self, stage_id, compiled_output, profile_info,

--- a/alpa/pipeline_parallel/stage_profiling.py
+++ b/alpa/pipeline_parallel/stage_profiling.py
@@ -347,6 +347,7 @@ class ProfileWorkerPool(BaseWorkerPoolWrapper):
 
     def __init__(self, virtual_meshes):
         super().__init__()
+        print('out-in-out', virtual_meshes, 'global cluster', alpa.device_mesh.global_cluster)
         worker_cls = ray.remote(num_cpus=1e-3)(ProfileWorker)
         self.actors = [worker_cls.remote(mesh) for mesh in virtual_meshes]
         self.pool = ActorPool(self.actors)

--- a/alpa/pipeline_parallel/stage_profiling.py
+++ b/alpa/pipeline_parallel/stage_profiling.py
@@ -247,9 +247,9 @@ class ProfileWorker:
     """
 
     def __init__(self, virtual_mesh: VirtualPhysicalMesh):
+        print('outside', virtual_mesh)
         self.mesh = virtual_mesh.get_physical_mesh()
         self.virtual_mesh = virtual_mesh
-        print(self.mesh, self.virtual_mesh)
     def _profile_impl(self, stage_id, compiled_output, profile_info,
                       intermediate_size, initial_size):
         """Implementation of profile function.

--- a/alpa/pipeline_parallel/stage_profiling.py
+++ b/alpa/pipeline_parallel/stage_profiling.py
@@ -16,7 +16,6 @@ import ray
 from ray.exceptions import RayActorError
 from ray.util import ActorPool
 
-import alpa
 from alpa.device_mesh import (DistributedArray, PhysicalDeviceMesh,
                               VirtualPhysicalMesh, _shard_device_array)
 from alpa.global_env import global_config
@@ -250,6 +249,7 @@ class ProfileWorker:
     def __init__(self, virtual_mesh: VirtualPhysicalMesh):
         self.mesh = virtual_mesh.get_physical_mesh()
         self.virtual_mesh = virtual_mesh
+
     def _profile_impl(self, stage_id, compiled_output, profile_info,
                       intermediate_size, initial_size):
         """Implementation of profile function.
@@ -349,8 +349,10 @@ class ProfileWorkerPool(BaseWorkerPoolWrapper):
         worker_cls = ray.remote(num_cpus=1e-3)(ProfileWorker)
         # retrieve the placement group
         placement_group = retrieve_placement_group()
-        self.actors = [worker_cls.options(placement_group=placement_group
-                                          ).remote(mesh) for mesh in virtual_meshes]
+        self.actors = [
+            worker_cls.options(placement_group=placement_group).remote(mesh)
+            for mesh in virtual_meshes
+        ]
         self.pool = ActorPool(self.actors)
 
 

--- a/alpa/util.py
+++ b/alpa/util.py
@@ -1227,7 +1227,6 @@ def is_ray_node_resource(resource_key):
 ##### Ray Compatibilityu API Utilities
 ########################################
 
-
 def try_import_ray_worker(error: bool = False):
     """Tries importing `ray.worker` and returns the module (or None).
 

--- a/alpa/util.py
+++ b/alpa/util.py
@@ -36,7 +36,6 @@ from ray.util.placement_group import get_current_placement_group
 import tqdm
 
 from alpa.global_env import global_config, is_worker
-from icecream import ic
 
 PLACEMENT_GROUP_TIMEOUT_S_ENV = "ALPA_PLACEMENT_GROUP_TIMEOUT_S_ENV"
 

--- a/alpa/util.py
+++ b/alpa/util.py
@@ -1503,7 +1503,7 @@ def retrieve_placement_group():
         return alpa_placement_group
 
     # case 3:
-    # Get the placement group from ray global state
+    # Get placement group from ray global state
     # Note: this case happens when the placement group can not be retrieved
     # from the global variables of alpa or not inside ray tune, and the
     # solution is to get the placement from ray global state environment.

--- a/alpa/util.py
+++ b/alpa/util.py
@@ -1463,6 +1463,7 @@ def get_placement_group_from_id(placement_group_id: str):
     """Get the placement group from the unique id"""
     return PlacementGroup(PlacementGroupID(hex_to_binary(placement_group_id)))
 
+
 def retrieve_placement_group():
     """retrieve the placement group to support node affinity scheduling
 

--- a/alpa/util.py
+++ b/alpa/util.py
@@ -1227,6 +1227,7 @@ def is_ray_node_resource(resource_key):
 ##### Ray Compatibilityu API Utilities
 ########################################
 
+
 def try_import_ray_worker(error: bool = False):
     """Tries importing `ray.worker` and returns the module (or None).
 

--- a/alpa/util.py
+++ b/alpa/util.py
@@ -1476,7 +1476,7 @@ def retrieve_placement_group():
     # case 1:
     # Get the current placement group which a task or actor is using
     current_placement_group = get_current_placement_group()
-    if current_placement_group is None:
+    if current_placement_group:
         return current_placement_group
 
     # case 2:

--- a/alpa/util.py
+++ b/alpa/util.py
@@ -1485,8 +1485,7 @@ def retrieve_placement_group():
 
     If already inside the placement group, retrieve the current placement
     group (case I). Then, if the placement group is detected globally in
-    alpa, retrieve the global placement group (case II). Last, we can try
-    to retrieve the placement group from the ray cluster global state (III).
+    alpa, retrieve the global placement group (case II).
 
     """
     # case 1:
@@ -1501,17 +1500,6 @@ def retrieve_placement_group():
     if global_cluster and global_cluster.placement_group:
         alpa_placement_group = global_cluster.placement_group
         return alpa_placement_group
-
-    # case 3:
-    # Get placement group from ray global state
-    # Note: this case happens when the placement group can not be retrieved
-    # from the global variables of alpa or not inside ray tune, and the
-    # solution is to get the placement from ray global state environment.
-    ray_state = try_import_ray_state()
-    for pg_id, info in ray_state.state.placement_group_table().items():
-        if info["state"] == "CREATED":
-            created_placement_group = get_placement_group_from_id(pg_id)
-            return created_placement_group
 
     raise ValueError(
         "The alpa training is not inside the ray tasks or actor or "

--- a/alpa/util.py
+++ b/alpa/util.py
@@ -1483,12 +1483,16 @@ def retrieve_placement_group():
 
     # case 2:
     # Get the placement group created when alpa.init('ray')
-    if alpa.device_mesh.global_cluster.placement_group:
-        alpa_placement_group = alpa.device_mesh.global_cluster.placement_group
+    global_cluster = alpa.device_mesh.global_cluster
+    if global_cluster and global_cluster.placement_group:
+        alpa_placement_group = global_cluster.placement_group
         return alpa_placement_group
 
     # case 3:
     # Get the placement group from ray global state
+    # Note: this case happens when the placement group can not be retrieved
+    # from the global variables of alpa or not inside ray tune, and the
+    # solution is to get the placement from ray global state environment.
     ray_state = try_import_ray_state()
     for pg_id, info in ray_state.state.placement_group_table().items():
         if info["state"] == "CREATED":

--- a/alpa/util.py
+++ b/alpa/util.py
@@ -1446,9 +1446,9 @@ def get_bundle_idx(placement_group, device_ips):
         if bundle_spec.get("GPU", 0) > 0
     ]
 
-    if len(device_bundle_idx_list) != len(device_ips):
-        raise ValueError("The number of bundles with GPU resources "
-                         "is not equal to the number of device IPs.")
+    # if len(device_bundle_idx_list) != len(device_ips):
+    #     raise ValueError("The number of bundles with GPU resources "
+    #                      "is not equal to the number of device IPs.")
 
     # device IP -> bundle index
     bundle_ip2idx = {bundle_ips[i]: i for i in device_bundle_idx_list}

--- a/alpa/util.py
+++ b/alpa/util.py
@@ -1306,7 +1306,6 @@ def get_bundle2ip(pg=None):
     for resource in resources_list:
         resource_name_list = resource.keys()
 
-        # ic(resource_name_list, pg_id)
         node_ip = None
         bundle_index_list = []
         for resource_name in resource_name_list:
@@ -1381,7 +1380,6 @@ def create_placement_group(num_hosts,
         current_placement_group is None or
         not should_capture_child_tasks_in_placement_group)
 
-    ic(current_placement_group, should_capture_child_tasks_in_placement_group, ray.available_resources())
     if should_create_placement_group:
         additional_resources_per_host = (additional_resources_per_host or {})
         bundle = {
@@ -1439,16 +1437,15 @@ def get_bundle_idx(placement_group, device_ips):
     bundle_ips = get_bundle2ip(placement_group)
     bundle_specs = placement_group.bundle_specs
 
-    ic(bundle_ips, bundle_specs, device_ips)
     # filter out the bundle index with device (GPUs)
     device_bundle_idx_list = [
         i for i, bundle_spec in enumerate(bundle_specs)
         if bundle_spec.get("GPU", 0) > 0
     ]
 
-    # if len(device_bundle_idx_list) != len(device_ips):
-    #     raise ValueError("The number of bundles with GPU resources "
-    #                      "is not equal to the number of device IPs.")
+    if len(device_bundle_idx_list) < len(device_ips):
+        raise ValueError("The number of bundles with GPU resources "
+                         "is no less than the number of device IPs.")
 
     # device IP -> bundle index
     bundle_ip2idx = {bundle_ips[i]: i for i in device_bundle_idx_list}

--- a/alpa/util.py
+++ b/alpa/util.py
@@ -1382,7 +1382,7 @@ def create_placement_group(num_hosts,
     if should_create_placement_group:
         additional_resources_per_host = (additional_resources_per_host or {})
         bundle = {
-            "CPU": 2,
+            "CPU": 1,
             "GPU": num_devices_per_host,
             **additional_resources_per_host,
         }

--- a/alpa/util.py
+++ b/alpa/util.py
@@ -1483,8 +1483,8 @@ def retrieve_placement_group():
 
     # case 2:
     # Get the placement group created when alpa.init('ray')
-    if alpa.device_mesh.global_placement_group:
-        alpa_placement_group = alpa.device_mesh.global_placement_group
+    if alpa.device_mesh.global_cluster.placement_group:
+        alpa_placement_group = alpa.device_mesh.global_cluster.placement_group
         return alpa_placement_group
 
     # case 3:

--- a/alpa/util.py
+++ b/alpa/util.py
@@ -1382,7 +1382,7 @@ def create_placement_group(num_hosts,
     if should_create_placement_group:
         additional_resources_per_host = (additional_resources_per_host or {})
         bundle = {
-            "CPU": 1,
+            "CPU": 2,
             "GPU": num_devices_per_host,
             **additional_resources_per_host,
         }

--- a/setup.py
+++ b/setup.py
@@ -102,9 +102,8 @@ doc_require_list = [
 
 def get_alpa_version():
     with open(os.path.join(ROOT_DIR, "alpa", "version.py")) as fp:
-        version_match = re.search(
-            r"^__version__ = ['\"]([^'\"]*)['\"]", fp.read(), re.M
-        )
+        version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                                  fp.read(), re.M)
         if version_match:
             return version_match.group(1)
     raise RuntimeError("Unable to find version string.")

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ def get_cuda_version_str(no_dot=False):
 
 install_require_list = [
     "tqdm",
-    "ray[default]",
+    "ray>=1.13.0",
     "jax==0.3.5",
     "flax==0.4.1",
     "pulp",


### PR DESCRIPTION
This PR is to make use of placement group to create meshworkers. This new approach gives alpa more freedom to allocate the resources. 

Previous issue: #618 

- [x] adding the placement to replace `node_resources: 1e-3` 
- [x] figure out which parts of the node is not necessary after using the placement.

----
benefits: 
- [x] resource will be homogeneous now, i.e. `{gpu: 2}` can be on node A or B or C, but `{gpu: 2, ip_A: 1e-3}` can only be on node A.
- [ ] potentially this leads to more easier implementation of elastic training. (i.e. using ray to deal with the resource management.)



---------
# More details: 

why: currently alpa prefix the actor to the ip which might not be that flexible for the ray tune; if we have ip-address as the resources for ray tune, the tune process can not go to another machine.

        Example: 2 node with 4 gpu each
        Expected tune behaviors: "GPU": 1 as the resource for each tune process, then 8 process tuning together with 4 on each node.
        Currently behaviors: "GPU": 1, "ip_A": 1e-3 as the resources, the process is fixed on ip_A

Action: use the workergroup defined here (https://github.com/ray-project/ray/blob/master/python/ray/train/_internal/worker_group.py#L72-L84), and there are some method to get the ip address and node id. The overall benefit is no need to add the ip address to the resources. If necessary, we can add https://docs.ray.io/en/latest/ray-core/placement-group.html#strategy-types (STRICT_SPREAD) to strict force different node.

Alert: ray is trying to get rid of ip address support in the resource allocation.