### PR TITLE
[OPT] 1-D OPT model with fused MHA

### DIFF
--- a/examples/opt_serving/model/opt_model.py
+++ b/examples/opt_serving/model/opt_model.py
@@ -211,9 +211,6 @@ class OPTSelfAttention(nn.Module):
                                  value_states)
         attn_output = attn_output.reshape(attn_output.shape[:2] + (-1,))
 
-        # FIXME: Output attn_output for debugging. Remove this line when done.
-        attention_cache = attn_output
-
         outputs = (attn_output, attention_cache,
                    attn_weights) if output_attentions else (attn_output,
                                                             attention_cache)

--- a/examples/opt_serving/model/opt_model_1d.py
+++ b/examples/opt_serving/model/opt_model_1d.py
@@ -156,11 +156,10 @@ class OPTSelfAttention(nn.Module):
             qkv_combined_states.shape[:1] +
             (self.config.decoder_attention_heads, head_dim, 3))
 
-        qvk_combined_bias_trans = self.qkv_combined_bias.transpose((1, 2, 0))
-        qkv_combined_states_w_bias = qkv_combined_states + qvk_combined_bias_trans
-
         # Shape: [1D seq, 3, heads, head_dim]
         qkv_combined_states = qkv_combined_states.transpose((0, 3, 1, 2))
+
+        qkv_combined_states_w_bias = qkv_combined_states + self.qkv_combined_bias
 
         # Shape of cache_key and cache_value: [batch * max_length, heads, head_dim]
         # Shape of cache_index: [batch * max_length]
@@ -175,7 +174,7 @@ class OPTSelfAttention(nn.Module):
         # be updated outside the model.
         _, key_states, value_states = jnp.split(qkv_combined_states_w_bias,
                                                 3,
-                                                axis=3)
+                                                axis=1)
         attention_cache = (key_states, value_states)
 
         if output_attentions:

--- a/examples/opt_serving/model/opt_model_1d.py
+++ b/examples/opt_serving/model/opt_model_1d.py
@@ -1,11 +1,10 @@
-"""OPT model implementation."""
 import dataclasses
 from dataclasses import dataclass
 from functools import partial
 import itertools
 import math
 import os
-from typing import Callable, Optional, Tuple, Dict, Sequence
+from typing import Callable, Optional, Tuple, Dict
 
 import alpa
 from alpa.device_mesh import (DistributedArray, ReplicatedDistributedArray,
@@ -23,6 +22,8 @@ import jaxlib.xla_extension as jax_xla
 import numpy as np
 import ray
 from tqdm import tqdm
+
+from ft_mha import fused_mmha
 
 ACT2FN = {
     "gelu": partial(nn.gelu, approximate=False),
@@ -129,94 +130,53 @@ class OPTSelfAttention(nn.Module):
         self.qkv_combined = nn.Dense(
             self.config.decoder_embed_dim * 3,
             dtype=self.dtype,
+            use_bias=False,
         )
+
+        # The fused_mmha kernel fuses the bias add, so we do not load the bias in Dense and
+        # instead feed it into the kernel.
+        head_dim = self.config.decoder_embed_dim // self.config.decoder_attention_heads
+        self.qkv_combined_bias = self.param(
+            'qkv_combined_bias', flax.linen.initializers.zeros,
+            (3, self.config.decoder_attention_heads, head_dim), self.dtype)
 
     def __call__(self,
                  hidden_states,
+                 batch_idxs,
                  output_attentions: bool = False,
-                 attention_cache=None,
-                 attention_mask=None):
+                 attention_cache=None):
         head_dim = self.config.decoder_embed_dim // self.config.decoder_attention_heads
+        assert attention_cache is not None, "Attention cache must be provided for now"
 
+        # Shape: [1D seq, heads, head_dim, 3]
         qkv_combined_states = self.qkv_combined(hidden_states)
         qkv_combined_states = qkv_combined_states.reshape(
-            qkv_combined_states.shape[:2] + (-1, 3))
-        query_states, key_states, value_states = jnp.split(qkv_combined_states,
-                                                           3,
-                                                           axis=3)
+            qkv_combined_states.shape[:1] +
+            (self.config.decoder_attention_heads, head_dim, 3))
 
-        # shape: [B, S, #head, head_dim]
-        query_states = query_states.reshape(hidden_states.shape[:2] + (
-            self.config.decoder_attention_heads, head_dim))
-        # shape: [B, S, #head, head_dim]
-        value_states = value_states.reshape(hidden_states.shape[:2] + (
-            self.config.decoder_attention_heads, head_dim))
-        # shape: [B, S, #head, head_dim]
-        key_states = key_states.reshape(hidden_states.shape[:2] +
-                                        (self.config.decoder_attention_heads,
-                                         head_dim))
+        # Shape: [1D seq, 3, heads, head_dim]
+        qkv_combined_states = qkv_combined_states.transpose((0, 3, 1, 2))
 
-        batch_size = hidden_states.shape[0]
-        if attention_cache is None:
-            query_len, key_len = query_states.shape[1], key_states.shape[1]
-            assert query_len == key_len
-            # shape: [B, 1, S_max, S_max]
-            causal_mask = nn.make_causal_mask(
-                jnp.ones((batch_size, key_len)), dtype="bool")
-            # shape: [B, 1, 1, S_max]
-            input_mask = attention_mask
-            # shape: [B, 1, S_max, S_max]
-            mask = nn.combine_masks(causal_mask, input_mask, dtype="bool")
-        else:
-            cache_key, cache_value, cache_index = attention_cache
-            cache_index_ = cache_index[0]
-            update_indices = (0, cache_index_, 0, 0)
-            # shape: [B, S_max, #head, head_dim]
-            key_states = lax.dynamic_update_slice(cache_key, key_states, update_indices)
-            # shape: [B, S_max, #head, head_dim]
-            value_states = lax.dynamic_update_slice(cache_value, value_states, update_indices)
-            query_len, key_len = query_states.shape[1], key_states.shape[1]
+        # Shape of cache_key and cache_value: [batch * max_length, heads, head_dim]
+        # Shape of cache_index: [batch * max_length]
+        cache_key, cache_value, cache_index = attention_cache
 
-            # Handle a special kind of internal padding added by alpa.
-            # Note that this kind of internal padding is different from
-            # the padding added by the tokenizer. This internal padding
-            # should not update cache and step_ct
-            # shape: [B, 1, 1, S_max]
-            is_internal_padding = (attention_mask == 2)
-            num_internal_pad = jnp.sum(is_internal_padding, axis=3).reshape(-1)
-            attention_mask = (attention_mask == 1)
+        attn_output = fused_mmha(qkv_combined_states, self.qkv_combined_bias,
+                                 batch_idxs, cache_key, cache_value,
+                                 cache_index)
+        attn_output = attn_output.reshape(attn_output.shape[:1] + (-1,))
 
-            attention_cache = key_states, value_states, cache_index + query_len - num_internal_pad
-
-            # shape: [B, 1, S_max, S_max]
-            causal_mask = nn.make_causal_mask(
-                jnp.ones((batch_size, key_len)), dtype="bool")
-            # shape: [B, 1, S, S_max]
-            causal_mask = lax.dynamic_slice(causal_mask,
-                (0, 0, cache_index_, 0), (batch_size, 1, query_len, key_len))
-            # shape: [B, 1, 1, S_max]
-            input_mask = attention_mask
-            # shape: [B, 1, S, S_max]
-            mask = nn.combine_masks(causal_mask, input_mask, dtype="bool")
-
-        attn_weights = nn.attention.dot_product_attention_weights(
-            query_states,
-            key_states,
-            mask=mask,
-            dtype=self.dtype,
-            precision=None,
-        )
-
-        attn_output = jnp.einsum("...hqk,...khd->...qhd", attn_weights,
-                                 value_states)
-        attn_output = attn_output.reshape(attn_output.shape[:2] + (-1,))
+        # TODO: Update cache
+        # Note that assuming the maxiumn length of current input prompts is Lmax,
+        # the values of updated cache_index are organized as follows:
+        # [<1 x L1>, <0 x (Lmax-L1)>, <1 x L2>, <0 x (Lmax-L2)>, ..., 0, ...]
 
         # FIXME: Output attn_output for debugging. Remove this line when done.
         attention_cache = attn_output
 
-        outputs = (attn_output, attention_cache,
-                   attn_weights) if output_attentions else (attn_output,
-                                                            attention_cache)
+        if output_attentions:
+            print("Do not support output_attentions")
+        outputs = (attn_output, attention_cache)
         return outputs
 
 
@@ -236,15 +196,15 @@ class OPTAttention(nn.Module):
 
     def __call__(self,
                  hidden_states,
+                 batch_idxs,
                  output_attentions: bool = False,
-                 attention_cache=None,
-                 attention_mask=None):
+                 attention_cache=None):
         residual = hidden_states
         hidden_states = self.layer_norm(hidden_states)
         attn_outputs = self.self(hidden_states,
+                                 batch_idxs,
                                  output_attentions=output_attentions,
-                                 attention_cache=attention_cache,
-                                 attention_mask=attention_mask)
+                                 attention_cache=attention_cache)
         attn_output = attn_outputs[0]
         attention_cache = attn_outputs[1]
         hidden_states = self.dense(attn_output)
@@ -298,14 +258,14 @@ class OPTTransformerLayer(nn.Module):
 
     def __call__(self,
                  hidden_states,
+                 batch_idxs,
                  output_attentions: bool = False,
-                 attention_cache=None,
-                 attention_mask=None):
+                 attention_cache=None):
 
         attention_outputs = self.attention(hidden_states,
+                                           batch_idxs,
                                            output_attentions=output_attentions,
-                                           attention_cache=attention_cache,
-                                           attention_mask=attention_mask)
+                                           attention_cache=attention_cache)
         attention_output = attention_outputs[0]
         attention_cache = attention_outputs[1]
 
@@ -331,11 +291,11 @@ class OPTTransformerLayerCollection(nn.Module):
     def __call__(
         self,
         hidden_states,
+        batch_idxs,
         output_attentions: bool = False,
         output_hidden_states: bool = False,
         return_dict: bool = True,
         attention_cache=None,
-        attention_mask=None
     ):
         all_attentions = () if output_attentions else None
         all_hidden_states = () if output_hidden_states else None
@@ -358,9 +318,9 @@ class OPTTransformerLayerCollection(nn.Module):
             if attention_cache is not None:
                 layer_attention_cache = attention_cache[i]
             layer_outputs = layer(hidden_states,
+                                  batch_idxs,
                                   output_attentions=output_attentions,
-                                  attention_cache=layer_attention_cache,
-                                  attention_mask=attention_mask)
+                                  attention_cache=layer_attention_cache)
             hidden_states = layer_outputs[0]
             if attention_cache is not None:
                 new_attention_cache += (layer_outputs[1],)
@@ -398,20 +358,20 @@ class OPTTransformerModule(nn.Module):
         self,
         input_ids,
         position_ids,
+        batch_idxs,
         output_attentions: bool = False,
         output_hidden_states: bool = False,
         return_dict: bool = True,
         attention_cache=None,
-        attention_mask=None
     ):
         hidden_states = self.embeddings(input_ids, position_ids)
         outputs = self.encoder(
             hidden_states,
+            batch_idxs,
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
             attention_cache=attention_cache,
-            attention_mask=attention_mask
         )
         hidden_states = outputs[0]
         if self.config.version > 2:
@@ -454,21 +414,21 @@ class OPTForLMModule(nn.Module):
         self,
         input_ids,
         position_ids,
+        batch_idxs,
         output_attentions: bool = False,
         output_hidden_states: bool = False,
         return_dict: bool = True,
         attention_cache=None,
-        attention_mask=None
     ):
         # Model
         outputs = self.transformers(
             input_ids,
             position_ids,
+            batch_idxs,
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
             attention_cache=attention_cache,
-            attention_mask=attention_mask
         )
 
         hidden_states = outputs[0]
@@ -500,69 +460,20 @@ class OPTForLMModule(nn.Module):
         )
 
 
-def get_opt_config(name, **kwargs):
-    if name == "125M":
-        config = OPTConfig(
-            max_target_positions=2048, decoder_layers=12, decoder_attention_heads=12,
-            decoder_embed_dim=768, decoder_input_dim=768, decoder_ffn_embed_dim=768 * 4,
-            version=3,
-        )
-    elif name == "350M":
-        config = OPTConfig(
-            max_target_positions=2048, decoder_layers=24, decoder_attention_heads=16,
-            decoder_embed_dim=1024, decoder_input_dim=1024, decoder_ffn_embed_dim=1024 * 4,
-            version=2,
-        )
-        raise NotImplementedError()
-    elif name == "1.3B":
-        config = OPTConfig(
-            max_target_positions=2048, decoder_layers=24, decoder_attention_heads=32,
-            decoder_embed_dim=2048, decoder_input_dim=2048, decoder_ffn_embed_dim=2048 * 4,
-            version=3,
-        )
-    elif name == "2.7B":
-        config = OPTConfig(
-            max_target_positions=2048, decoder_layers=32, decoder_attention_heads=32,
-            decoder_embed_dim=2560, decoder_input_dim=2560, decoder_ffn_embed_dim=2560 * 4,
-            version=3,
-        )
-    elif name == "6.7B":
-        config = OPTConfig(
-            max_target_positions=2048, decoder_layers=32, decoder_attention_heads=32,
-            decoder_embed_dim=4096, decoder_input_dim=4096, decoder_ffn_embed_dim=4096 * 4,
-            version=3,
-        )
-    elif name == "30B":
-        config = OPTConfig(
-            max_target_positions=2048, decoder_layers=48, decoder_attention_heads=56,
-            decoder_embed_dim=7168, decoder_input_dim=7168, decoder_ffn_embed_dim=7168 * 4,
-            version=3,
-        )
-    elif name == "66B":
-        config = OPTConfig(
-            max_target_positions=2048, decoder_layers=64, decoder_attention_heads=72,
-            decoder_embed_dim=9216, decoder_input_dim=9216, decoder_ffn_embed_dim=9216 * 4,
-            version=3,
-        )
-    elif name == "175B":
-        config = OPTConfig(
-            max_target_positions=2048, decoder_layers=96, decoder_attention_heads=96,
-            decoder_embed_dim=12288, decoder_input_dim=12288, decoder_ffn_embed_dim=12288 * 4,
-            version=3,
-        )
-    else:
-        raise ValueError(f"Invalid model name: {name}")
-
-    return dataclasses.replace(config, **kwargs)
-
-
-def init_model_aval(config):
+def init_model_aval(config, batch_size=1, max_length=128):
     """Initialize model with parameters with abstract values (shape-only arrays)."""
     model = OPTForLMModule(config, dtype=config.dtype)
     rngkey = jax.core.ShapedArray((2,), jnp.uint32)
-    input_ids = jax.core.ShapedArray((1, 128), jnp.int32)
-    position_ids = jax.core.ShapedArray((1, 128), jnp.int32)
-    params = jax.eval_shape(model.init, rngkey, input_ids, position_ids)
+    input_ids = jax.core.ShapedArray((batch_size * max_length,), jnp.int32)
+    position_ids = jax.core.ShapedArray((batch_size * max_length,), jnp.int32)
+    batch_ids = jax.core.ShapedArray((batch_size * max_length,), jnp.int32)
+    cache = init_cache_aval(config, batch_size)
+    params = jax.eval_shape(model.init,
+                            rngkey,
+                            input_ids,
+                            position_ids,
+                            batch_ids,
+                            attention_cache=cache)
     params = jax.tree_map(lambda x: jax.ShapeDtypeStruct(x.shape, config.dtype),
                           params)
     return model, params
@@ -574,24 +485,19 @@ def init_cache_aval(config, batch_size):
     head_dim = config.decoder_embed_dim // config.decoder_attention_heads
 
     all_cache = []
-    for _ in range(config.decoder_layers):
+    for i in range(config.decoder_layers):
         layer_cache = (
-            jax.core.ShapedArray((batch_size, config.max_target_positions,
+            jax.core.ShapedArray((batch_size * config.max_target_positions,
                                   config.decoder_attention_heads, head_dim),
                                  dtype),
-            jax.core.ShapedArray((batch_size, config.max_target_positions,
+            jax.core.ShapedArray((batch_size * config.max_target_positions,
                                   config.decoder_attention_heads, head_dim),
                                  dtype),
-            jax.core.ShapedArray((batch_size,), jnp.int32),
+            jax.core.ShapedArray((batch_size * config.max_target_positions,),
+                                 jnp.int32),
         )
         all_cache.append(layer_cache)
     return tuple(all_cache)
-
-
-def init_mask_aval(config, batch_size):
-    """Initialize attention mask with abstract values (shape-only arrays)."""
-    mask = jax.core.ShapedArray((batch_size, 1, 1, config.max_target_positions), dtype=np.int8)
-    return mask
 
 
 def init_cache_np(config, batch_size):
@@ -602,13 +508,13 @@ def init_cache_np(config, batch_size):
     all_cache = []
     for i in range(config.decoder_layers):
         layer_cache = (
-            np.zeros((batch_size, config.max_target_positions,
+            np.zeros((batch_size * config.max_target_positions,
                       config.decoder_attention_heads, head_dim),
                      dtype=np_dtype),
-            np.zeros((batch_size, config.max_target_positions,
+            np.zeros((batch_size * config.max_target_positions,
                       config.decoder_attention_heads, head_dim),
                      dtype=np_dtype),
-            np.zeros((batch_size,), np.int32),
+            np.zeros((batch_size * config.max_target_positions,), np.int32),
         )
         all_cache.append(layer_cache)
     return tuple(all_cache)
@@ -616,25 +522,20 @@ def init_cache_np(config, batch_size):
 
 def build_position_ids(input_ids, padding_idx):
     mask = (input_ids != padding_idx).astype(np.int32)
-    position_ids = np.cumsum(mask, axis=1).astype(np.int32) * mask + padding_idx
+    position_ids = np.cumsum(mask).astype(np.int32) * mask + padding_idx
     return position_ids
 
 
-def inference_step_no_cache(params, batch, apply_func):
-    logits = apply_func(params, batch["input_ids"], batch["position_ids"])[0]
-    return logits
-
-
 def load_params_np(params, path, config, dummy=False):
-    """Load parameters with numpy arrays."""
+    """Load parameterswith numpy arrays."""
+    np_dtype = np.float32 if config.dtype == jnp.float32 else np.float16
     if dummy:
-        np_dtype = np.float32 if config.dtype == jnp.float32 else np.float16
         return jax.tree_map(lambda x: np.full(x.shape, 1e-9, np_dtype), params)
 
     def load_array(key):
         return np.load(os.path.join(path, key))
 
-    def load_param(param_key, loaded_array, is_position_embedding=False):
+    def load_param(param_key, loaded_array):
         param_dict = params
         param_keys = param_key.split('.')
         for i, key in enumerate(param_keys):
@@ -643,24 +544,20 @@ def load_params_np(params, path, config, dummy=False):
                     param_dict[key] = jax.core.ShapedArray(
                         param_dict[key].shape, param_dict[key].dtype)
                 else:
-                    if not is_position_embedding:
-                        assert param_dict[key].shape == loaded_array.shape, (
-                                f"{param_dict[key].shape} vs. {loaded_array.shape}")
-                    else:
-                        shape = param_dict[key].shape
-                        if shape != loaded_array.shape:
-                            assert shape[1] == loaded_array.shape[1]
-                            loaded_array = loaded_array[:shape[0], :]
+                    assert param_dict[key].shape == loaded_array.shape
+                    #assert param_dict[key].dtype == loaded_array.dtype
                     param_dict[key] = loaded_array
             else:
                 param_dict = param_dict[key]
+
+    head = config.decoder_attention_heads
+    head_dim = config.decoder_embed_dim // head
 
     params = params.unfreeze()
     load_param("params.transformers.embeddings.word_embeddings.embedding",
                load_array("decoder.embed_tokens.weight"))
     load_param("params.transformers.embeddings.position_embeddings.embedding",
-               load_array("decoder.embed_positions.weight"),
-               is_position_embedding=True)
+               load_array("decoder.embed_positions.weight"))
     if config.version > 2:
         load_param("params.transformers.layer_norm.scale",
                    load_array("decoder.layer_norm.weight"))
@@ -680,9 +577,12 @@ def load_params_np(params, path, config, dummy=False):
         bq = load_array(load_prefix + "self_attn.q_proj.bias")
         bk = load_array(load_prefix + "self_attn.k_proj.bias")
         bv = load_array(load_prefix + "self_attn.v_proj.bias")
+        # b_qkv = np.concatenate([bq, bk, bv], axis=0).reshape(
+        #     (3, dim)).transpose([1, 0]).reshape((-1,))
+        # load_param(param_prefix + "attention.self.qkv_combined.bias", b_qkv)
         b_qkv = np.concatenate([bq, bk, bv], axis=0).reshape(
-            (3, dim)).transpose([1, 0]).reshape((-1,))
-        load_param(param_prefix + "attention.self.qkv_combined.bias", b_qkv)
+            (3, head, head_dim)).astype(np_dtype)
+        load_param(param_prefix + "attention.self.qkv_combined_bias", b_qkv)
         load_param(
             param_prefix + "attention.dense.kernel",
             np.transpose(load_array(load_prefix + "self_attn.out_proj.weight")))
@@ -709,11 +609,9 @@ def load_params_np(params, path, config, dummy=False):
     return flax.core.freeze(params)
 
 
-def get_jax_executable(config: OPTConfig,
-                       encoder_chunk_sizes: Sequence[int],
-                       output_attentions: bool = False,
-                       output_hidden_states:bool = False):
-    """Get a single-gpu executable."""
+def get_jax_executable(config,
+                       support_output_attentions=False,
+                       support_output_hidden_states=False):
     model, params = init_model_aval(config)
 
     @jax.jit
@@ -722,25 +620,22 @@ def get_jax_executable(config: OPTConfig,
                              batch["input_ids"],
                              batch["position_ids"],
                              attention_cache=batch["cache"],
-                             attention_mask=batch["mask"],
-                             output_attentions=output_attentions,
-                             output_hidden_states=output_hidden_states)
+                             output_attentions=support_output_attentions,
+                             output_hidden_states=support_output_hidden_states)
         return output
 
-    executables = {}
-    for length in encoder_chunk_sizes:
-        executables[length] = inference_step
-    return executables, params
+    executable = inference_step
+    return executable, params
 
 
-def get_pipeshard_executable(config: OPTConfig,
-                             batch_size: int,
-                             encoder_chunk_sizes: Sequence[int],
-                             num_micro_batches: int = 1,
-                             output_attentions: bool = False,
-                             output_hidden_states: bool = False,
-                             autoregressive: bool = True):
-    """Get a parallel executable."""
+def get_pipeshard_executable(config,
+                             batch_size=1,
+                             num_micro_batches=1,
+                             decoding_length_per_step=1024,
+                             support_output_attentions=False,
+                             support_output_hidden_states=False,
+                             autoregressive=True):
+
     # Init model
     model, params = init_model_aval(config)
 
@@ -751,84 +646,36 @@ def get_pipeshard_executable(config: OPTConfig,
         layer_option="manual",
         default_auto_sharding_option=alpa.AutoShardingOption(
             # Force operator model parallel
-            force_batch_dim_to_mesh_dim=None if batch_size == 1 else 0,
+            force_batch_dim_to_mesh_dim=None,
             # Disabling all-to-all and all-gather generates better intra-op strategies.
             allow_all_to_all=False,
             allow_all_gather=False,
         ))
-    #method = alpa.ShardParallel()
 
     if autoregressive:
 
+        @alpa.parallelize(batch_argnums=(1,), method=method)
         def inference_step_with_cache(params, batch):
             output = model.apply(
                 params,
                 batch["input_ids"],
                 batch["position_ids"],
                 attention_cache=batch["cache"],
-                attention_mask=batch["mask"],
-                output_attentions=output_attentions,
-                output_hidden_states=output_hidden_states)
+                output_attentions=support_output_attentions,
+                output_hidden_states=support_output_hidden_states)
             return output
 
         alpa.global_config.always_donate_micro_batch_vars = False
-
-        cache = init_cache_aval(config, batch_size)
-        mask = init_mask_aval(config, batch_size)
-
-        executables = {}
-
-        # Compile an executable with sequence length 1
-        executable = alpa.parallelize(
-            inference_step_with_cache, batch_argnums=(1,),
-            method=method).get_executable(
-                params, {
-                    "input_ids":
-                        jax.core.ShapedArray((batch_size, 1), jnp.int32),
-                    "position_ids":
-                        jax.core.ShapedArray((batch_size, 1), jnp.int32),
-                    "cache":
-                        cache,
-                    "mask":
-                        mask,
-                })
-        executable.dump_debug_info("tmp_executable_1")
-        executables[1] = executable
-
-        # Create another parallel method with assigned input sharding specs
-        method_with_input_sharding = alpa.PipeshardParallel(
-            num_micro_batches=num_micro_batches,
-            pipeline_schedule="inference",
-            layer_option="manual",
-            default_auto_sharding_option=alpa.AutoShardingOption(
-                enable_auto_sharding=False,
-            ),
-            stage_input_shardings=executable.stage_input_shard_specs)
-
-        # Compile other executables
-        for seq_len in encoder_chunk_sizes:
-            executable = alpa.parallelize(
-                inference_step_with_cache,
-                batch_argnums=(1,),
-                method=method_with_input_sharding).get_executable(
-                    params, {
-                        "input_ids":
-                            jax.core.ShapedArray(
-                                (batch_size, seq_len), jnp.int32),
-                        "position_ids":
-                            jax.core.ShapedArray(
-                                (batch_size, seq_len), jnp.int32),
-                        "cache":
-                            cache,
-                        "mask":
-                            mask,
-                    })
-            executable.dump_debug_info("tmp_executable_%d" % seq_len)
-            executables[seq_len] = executable
-        return executables, params
+        executable = inference_step_with_cache.get_executable(
+            params, {
+                "input_ids":
+                    jax.core.ShapedArray((batch_size, 1), jnp.int32),
+                "position_ids":
+                    jax.core.ShapedArray((batch_size, 1), jnp.int32),
+                "cache":
+                    init_cache_aval(config, batch_size),
+            })
     else:
-        assert len(encoder_chunk_sizes) == 1
-        seq_len = encoder_chunk_sizes[0]
 
         @alpa.parallelize(batch_argnums=(1,), method=method)
         def inference_step(params, batch):
@@ -836,8 +683,8 @@ def get_pipeshard_executable(config: OPTConfig,
                 params,
                 batch["input_ids"],
                 batch["position_ids"],
-                output_attentions=output_attentions,
-                output_hidden_states=output_hidden_states)
+                output_attentions=support_output_attentions,
+                output_hidden_states=support_output_hidden_states)
             return output
 
         assert batch_size % num_micro_batches == 0, "cannot divide batch_size by num_micro_batches"
@@ -847,14 +694,14 @@ def get_pipeshard_executable(config: OPTConfig,
             params, {
                 "input_ids":
                     jax.core.ShapedArray(
-                        (batch_size, seq_len), jnp.int32),
+                        (batch_size, decoding_length_per_step), jnp.int32),
                 "position_ids":
                     jax.core.ShapedArray(
-                        (batch_size, seq_len), jnp.int32),
+                        (batch_size, decoding_length_per_step), jnp.int32),
             })
 
-        executable.dump_debug_info("tmp")
-    return {seq_len: executable}, params
+    executable.dump_debug_info("tmp")
+    return executable, params
 
 
 def load_opt_params_worker_func(self, path, prefix_to_idx, config, shapes,
@@ -864,20 +711,14 @@ def load_opt_params_worker_func(self, path, prefix_to_idx, config, shapes,
     def load_array(key):
         return np.load(os.path.join(path, key))
 
-    def load_param(param_key, loaded_array, is_position_embedding=False):
+    def load_param(param_key, loaded_array):
         i = prefix_to_idx[param_key]
 
         for j in range(len(mesh_ids[i])):
             if self.mesh_id != mesh_ids[i][j]:
                 continue
 
-            if not is_position_embedding:
-                assert shapes[i][j] == loaded_array.shape, (
-                    f"{shapes[i][j]} vs. {loaded_array.shape}")
-            else:
-                if shapes[i][j] != loaded_array.shape:
-                    assert shapes[i][j][1] == loaded_array.shape[1]
-                    loaded_array = loaded_array[:shapes[i][j][0], :]
+            assert shapes[i][j] == loaded_array.shape
             uuid = uuids[i][j]
             datas = []
             for k in range(len(self.local_devices)):
@@ -888,8 +729,7 @@ def load_opt_params_worker_func(self, path, prefix_to_idx, config, shapes,
     load_param("params.transformers.embeddings.word_embeddings.embedding",
                load_array("decoder.embed_tokens.weight"))
     load_param("params.transformers.embeddings.position_embeddings.embedding",
-               load_array("decoder.embed_positions.weight"),
-               is_position_embedding=True)
+               load_array("decoder.embed_positions.weight"))
 
     if config.version > 2:
         load_param("params.transformers.layer_norm.scale",
@@ -898,6 +738,8 @@ def load_opt_params_worker_func(self, path, prefix_to_idx, config, shapes,
                    load_array("decoder.layer_norm.bias"))
 
     layers_per_stage = config.decoder_layers // config.num_pp_stages
+    head = config.decoder_attention_heads
+    head_dim = config.decoder_embed_dim // head
 
     for i in range(config.decoder_layers):
         stage_id = i // layers_per_stage
@@ -917,9 +759,11 @@ def load_opt_params_worker_func(self, path, prefix_to_idx, config, shapes,
         bq = load_array(load_prefix + "self_attn.q_proj.bias")
         bk = load_array(load_prefix + "self_attn.k_proj.bias")
         bv = load_array(load_prefix + "self_attn.v_proj.bias")
+        # b_qkv = np.concatenate([bq, bk, bv], axis=0).reshape(
+        #     (3, dim)).transpose([1, 0]).reshape((-1,))
         b_qkv = np.concatenate([bq, bk, bv], axis=0).reshape(
-            (3, dim)).transpose([1, 0]).reshape((-1,))
-        load_param(param_prefix + "attention.self.qkv_combined.bias", b_qkv)
+            (3, head, head_dim))
+        load_param(param_prefix + "attention.self.qkv_combined_bias", b_qkv)
         load_param(
             param_prefix + "attention.dense.kernel",
             np.transpose(load_array(load_prefix + "self_attn.out_proj.weight")))
@@ -1050,43 +894,3 @@ def init_cache_dis_array(executable, config, batch_size, dummy=False):
             flat_info, flat_args)
     alpa.global_config.use_dummy_value_for_benchmarking = False
     return ret
-
-
-def load_multi_executable_params_dis_array(path,
-                                           executables,
-                                           params_aval,
-                                           config,
-                                           dummy=False):
-    """Load parameters to workers that will be used by all executables. Accordingly,
-    we need to make sure the parameter sharding specs are identical for all executables.
-    """
-    shared_input_shard_specs = None
-    for executable in executables.values():
-        stage_input_shard_specs = executable.stage_input_shard_specs
-        if shared_input_shard_specs is not None:
-            assert shared_input_shard_specs == stage_input_shard_specs, \
-                "All executables must have the same input sharding specs."
-        else:
-            shared_input_shard_specs = stage_input_shard_specs
-    return load_params_dis_array(path,
-                                 list(executables.values())[0], params_aval,
-                                 config, dummy)
-
-
-def init_multi_executable_cache_dis_array(executables,
-                                          config,
-                                          batch_size,
-                                          dummy=False):
-    """Initialize cache to workers that will be used by all executables. Accordingly,
-    we need to make sure all executables are using the same cache.
-    """
-    cache_info = None
-    for executable in executables.values():
-        _, batch_info = executable.get_input_placement_specs()
-        if cache_info is not None:
-            assert cache_info == batch_info["cache"], \
-                "All executables must share the same cache"
-        else:
-            cache_info = batch_info["cache"]
-    return init_cache_dis_array(
-        list(executables.values())[0], config, batch_size, dummy)

--- a/examples/opt_serving/model/test_1d.py
+++ b/examples/opt_serving/model/test_1d.py
@@ -6,14 +6,16 @@ import numpy as np
 from alpa.testing import assert_allclose
 from opt_serving.model import opt_model, opt_model_1d
 
+import pdb
+
 from transformers import AutoTokenizer
 
 input_id_list = [
     [45942, 2866, 16, 5, 892, 9, 44042, 8],
     [100, 261, 23888, 2426, 16, 10, 21624, 12, 4310, 3034, 9744, 25526, 11],
     [133, 589, 9, 886, 6, 10817, 16, 10, 285],
-    [5625, 16, 10, 205, 183, 8, 38, 236, 7],
-    [2264, 16, 5, 7440, 9, 16673, 873, 24214, 116],
+    # [5625, 16, 10, 205, 183, 8, 38, 236, 7],
+    # [2264, 16, 5, 7440, 9, 16673, 873, 24214, 116],
 ]
 
 
@@ -38,14 +40,15 @@ def init_2d_model(name, np_weights_folder, input_id_list):
 
     def runner(input_pool):
         # Run each sequence individually because their lengths are different
+        is_prompt = [cache[0][2][0] == 0 for _, cache in input_pool]
         logits_all = []
         for idx, (_input_ids, cache) in enumerate(input_pool):
             input_ids = np.array([_input_ids], dtype=np.int32)
             position_ids = opt_model.build_position_ids(input_ids, config.pad)
-            if cache[0][2][0] > 0:
+            if not is_prompt[idx]:
                 # Auto-regressive
-                input_ids = input_ids[:][-1]
-                position_ids = position_ids[:][-1:]
+                input_ids = input_ids[:, -1:]
+                position_ids = position_ids[:, -1:]
 
             logits, updated_cache = inference_step_2d(
                 params_2d, {
@@ -57,13 +60,14 @@ def init_2d_model(name, np_weights_folder, input_id_list):
             next_token = np.argmax(logits, axis=-1)[-1]
 
             # Append the generated token and updated cache.
+            #pdb.set_trace()
             input_pool[idx] = (_input_ids + [next_token.tolist()],
                                updated_cache)
 
-            # The logits are in shape (1, seq_len, vocab_size), so we squeeze the batch dimension
-            # and concat them together for verification.
-            logits_all.append(logits)
+            # For debugging
+            logits_all.append(logits[cache[0][2][0]:])
         logits_all = np.concatenate(logits_all, axis=0)
+        jnp.save("2d", logits_all)
         return input_pool
 
     return runner, input_pool_2d
@@ -93,72 +97,96 @@ def init_1d_model(name, np_weights_folder, input_id_list):
 
     def runner(input_pool):
         batch_size = len(input_pool)
+        is_prompt = [cache[0][2][0] == 0 for _, cache in input_pool]
 
-        # Concat promopts together
+        # Concat inputs together
         input_ids_flatten = []
         position_ids_flatten = []
         batch_idxs = []
-        for idx, (input_ids, _) in enumerate(input_pool):
+
+        # Promopts must go first, so we use this flag to make sure
+        # input pool does not have a pattern like [prompt1, token1, prompt2].
+        in_prompt = True
+
+        for idx, (input_ids, cache) in enumerate(input_pool):
+            position_ids = opt_model_1d.build_position_ids(
+                np.array(input_ids, dtype=np.int32), config.pad).tolist()
+
+            if not is_prompt[idx]:
+                # Auto-regressive
+                input_ids = input_ids[-1:]
+                position_ids = position_ids[-1:]
+                in_prompt = False
+            else:
+                assert in_prompt, "Prompts must be consecutive and before tokens"
+            input_ids_flatten += input_ids
+            position_ids_flatten += position_ids
+
             # fused_mmha kernel requires batch_idxs to be in shape sum(input_ids). Each element
             # in batch_idxs is the ID of the corresponding input sequence (starting from 1).
             batch_idxs += np.full(shape=(len(input_ids),),
                                   fill_value=idx + 1,
                                   dtype=np.int32).tolist()
-            input_ids_flatten += input_ids
-            position_ids = opt_model_1d.build_position_ids(
-                np.array(input_ids, dtype=np.int32), config.pad).tolist()
-            position_ids_flatten += position_ids
+
         input_ids_flatten = np.array(input_ids_flatten, dtype=np.int32)
         position_ids_flatten = np.array(position_ids_flatten, dtype=np.int32)
         batch_idxs = np.array(batch_idxs, dtype=np.int32)
 
         # Concate per-input cache together and generate cache index.
-        # Note that assuming the length of 3 input prompts are L1, L2, L3, and the maximum
-        # length is L2, then the values of updated cache_index are organized as follows:
-        # [<1 x L1>, <0 x (L2-L1)>, <1 x L2>, <1 x L3>, <0 x (L2-L3)>..., 0, ...]
-        max_len_in_pool = max(
-            [len(ids) - cache[0][2][0] for ids, cache in input_pool])
+        # Note that assuming the valid cache length of 3 inputs are L1, L2, L3,
+        # and the maximum length is L2, then the cache is organized as follows:
+        # [<1xL1>, <0x(L2-L1+1)>, <1xL2>, <0x1>, <1xL3>, <0x(L2-L3+1)>, 0, ...]
+        # And the total length is BxP, where B is the batch size and P is the
+        # maximum cache length. Here we set P to be the max_target_position.
+        target_cache_len = max([cache[0][2][0] for _, cache in input_pool]) + 1
         cache_1d_flatten = []
+        head_dim = config.decoder_embed_dim // config.decoder_attention_heads
         for batched_layer_cache in zip(*[cache for _, cache in input_pool]):
             batched_layer_key = []
             batched_layer_value = []
             batched_layer_index = []
             for bidx, (key, value, index) in enumerate(batched_layer_cache):
-                batched_layer_key.append(key)
-                batched_layer_value.append(value)
+                if is_prompt[bidx]:
+                    continue
+                curr_valid_len = index[0]
+                batched_layer_key.append(key[:target_cache_len])
+                batched_layer_value.append(value[:target_cache_len])
 
                 seq_ids = np.full(
-                    (index[0],),  # Valid cache length
+                    (curr_valid_len,),  # Valid cache length
                     bidx + 1,  # Sequence ID starting from 1
                     dtype=np.int32)
                 batched_layer_index.append(
                     np.concatenate([
                         seq_ids,
-                        np.zeros((config.max_target_positions - index[0],), dtype=np.int32)
-                    ]))                
+                        np.zeros((target_cache_len - curr_valid_len,),
+                                 dtype=np.int32)
+                    ]))
 
-                # The index for each cache is organized as the following format:
-                # <SeqID x L1>, <0 x (Lmax-L1)>, where Lmax is the maximum length
-                # in the CURRENT pool.
-                # seq_ids = np.full(
-                #     (index[0],),  # Valid cache length
-                #     bidx + 1,  # Sequence ID starting from 1
-                #     dtype=np.int32)
-                # batched_layer_index.append(
-                #     np.concatenate([
-                #         seq_ids,
-                #         np.zeros((max_len_in_pool - index[0],), dtype=np.int32)
-                #     ]))
-
-            key_flatten = np.concatenate(batched_layer_key, axis=0)
-            value_flatten = np.concatenate(batched_layer_value, axis=0)
-            index_flatten = np.concatenate(batched_layer_index, axis=0)
+            if batched_layer_key:
+                key_flatten = np.concatenate(batched_layer_key, axis=0)
+                value_flatten = np.concatenate(batched_layer_value, axis=0)
+                index_flatten = np.concatenate(batched_layer_index, axis=0)
+            else:
+                # In the case of all prompts we just put empty cache and pad all 0s.
+                key_flatten = np.empty(
+                    (0, config.decoder_attention_heads, head_dim),
+                    dtype=np.float32)
+                value_flatten = np.empty(
+                    (0, config.decoder_attention_heads, head_dim),
+                    dtype=np.float32)
+                index_flatten = np.empty((0,), dtype=np.int32)
 
             # Pad 0s to fixed length: batch_size * max_target_positions
-            # padding = np.zeros(
-            #     (batch_size * config.max_target_positions - index_flatten.shape[0],),
-            #     dtype=np.int32)
-            # index_flatten = np.concatenate([index_flatten, padding], axis=0)
+            pad_len = batch_size * config.max_target_positions - index_flatten.shape[
+                0]
+            key_val_pad = np.zeros((pad_len,) + key_flatten.shape[1:],
+                                   dtype=np.float32)
+            key_flatten = np.concatenate([key_flatten, key_val_pad], axis=0)
+            value_flatten = np.concatenate([value_flatten, key_val_pad], axis=0)
+
+            index_pad = np.zeros((pad_len,), dtype=np.int32)
+            index_flatten = np.concatenate([index_flatten, index_pad], axis=0)
             cache_1d_flatten.append((key_flatten, value_flatten, index_flatten))
 
         logits, cache_1d_updated = inference_step_1d(
@@ -168,6 +196,12 @@ def init_1d_model(name, np_weights_folder, input_id_list):
                 "batch_idxs": batch_idxs,
                 "cache": cache_1d_flatten,
             })
+        jnp.save("1d", logits)
+
+        updated_lengths = [
+            len(ids) if prompt else 1
+            for prompt, (ids, _) in zip(is_prompt, input_pool)
+        ]
 
         # Recover and update the cache.
         # The output cache only includes the new values of the current generated token,
@@ -181,14 +215,19 @@ def init_1d_model(name, np_weights_folder, input_id_list):
                 curr_index = cache[lidx][2][0]
 
                 # Determine the length of updated cache.
-                updated_length = len(input_pool[bidx][0]) - curr_index
-                update_end = update_start + updated_length
-                new_index = curr_index + updated_length
+                update_end = update_start + updated_lengths[bidx]
+                new_index = curr_index + updated_lengths[bidx]
 
                 # Slice update.
-                cache[lidx][0][curr_index:new_index][:][:] = \
+                if lidx == 0:
+                    if bidx == 0:
+                        print("Key", key_flatten.shape)
+                    print(
+                        "Seq %d update %d:%d from %d:%d" %
+                        (bidx, curr_index, new_index, update_start, update_end))
+                cache[lidx][0][curr_index:new_index] = \
                     key_flatten[update_start:update_end]
-                cache[lidx][1][curr_index:new_index][:][:] = \
+                cache[lidx][1][curr_index:new_index] = \
                     value_flatten[update_start:update_end]
                 cache[lidx][2][0] = new_index
                 input_pool[bidx] = (input_pool[bidx][0], cache)
@@ -197,31 +236,13 @@ def init_1d_model(name, np_weights_folder, input_id_list):
 
         # Append the generated token.
         update_start = 0
+        update_end = 0
         for bidx, (_input_ids, cache) in enumerate(input_pool):
-            updated_length = len(_input_ids)  # FIXME
-            update_end = update_start + updated_length
+            update_end = update_start + updated_lengths[bidx]
             next_token = np.argmax(logits[update_start:update_end], axis=-1)[-1]
             input_pool[bidx] = (_input_ids + [next_token.tolist()], cache)
             update_start = update_end
-
-        # Recover the cache.
-        # The output cache only includes the new values of the current generated token,
-        # so we perform dynamic slice update on the original cache.
-        # for layer_idx, (key_flatten, value_flatten) in enumerate(cache_1d_updated):
-        #     update_start = 0
-        #     key_flatten = key_flatten.squeeze()
-        #     value_flatten = value_flatten.squeeze()
-        #     for batch_idx in range(batch_size):
-        #         updated_length = len(input_pool[batch_idx])
-        #         update_end = update_start + updated_length
-        #         curr_index = cache_1ds[batch_idx][layer_idx][2][0]
-        #         new_index = curr_index + updated_length
-        #         cache_1ds[batch_idx][layer_idx][0][curr_index:new_index][:][:] = \
-        #             key_flatten[update_start:update_end]
-        #         cache_1ds[batch_idx][layer_idx][1][curr_index:new_index][:][:] = \
-        #             value_flatten[update_start:update_end]
-        #         cache_1ds[batch_idx][layer_idx][2][0] = new_index
-        #         update_start = update_end
+        assert update_end == logits.shape[0]
         return input_pool
 
     return runner, input_pool_1d
@@ -230,20 +251,39 @@ def init_1d_model(name, np_weights_folder, input_id_list):
 def verify_status(result_1d, result_2d):
     """Verify the current sequence and cache values."""
     print("Verifying results", flush=True)
-    for (seq_1d, cache_1d), (seq_2d, cache_2d) in zip(result_1d, result_2d):
+    success = True
+
+    for bidx, ((seq_1d, cache_1d),
+               (seq_2d, cache_2d)) in enumerate(zip(result_1d, result_2d)):
         # Verify sequence.
-        assert_allclose(seq_1d, seq_2d)
+        try:
+            assert_allclose(seq_1d, seq_2d)
+        except AssertionError as err:
+            print("Result of seq %d does not match" % bidx)
+            success = False
 
         # Verify cache.
-        for layer_2d, layer_1d in zip(cache_2d, cache_1d):
+        for lidx, (layer_2d, layer_1d) in enumerate(zip(cache_2d, cache_1d)):
             # Layer
             assert len(layer_2d) == len(layer_1d), \
-                "KVI length mismatch: %d vs. %d" % (len(layer_2d), len(layer_1d))
+                "KV length mismatch: %d vs. %d" % (len(layer_2d), len(layer_1d))
 
-            key_2d, value_2d, _ = layer_2d
             key_1d, value_1d, _ = layer_1d
-            assert_allclose(key_2d.reshape(key_1d.shape), key_1d)
-            assert_allclose(value_2d.reshape(value_1d.shape), value_1d)
+            key_2d, value_2d, _ = layer_2d
+            key_2d = key_2d.reshape(key_1d.shape)
+            value_2d = value_2d.reshape(value_1d.shape)
+            for cidx, (col_2d, col_1d) in enumerate(zip(key_2d, key_1d)):
+                try:
+                    assert_allclose(col_2d, col_1d)
+                except AssertionError as err:
+                    print("KV value mismatch for seq %d at layer %d column %d" %
+                            (bidx, lidx, cidx))
+                    print(str(err))
+                    success = False
+    if not success:
+        raise RuntimeError("Failed")
+    print("Passed")
+
 
 
 def simulate_serving(runner_n_pool, ref_runner_n_pool=None):
@@ -255,24 +295,28 @@ def simulate_serving(runner_n_pool, ref_runner_n_pool=None):
     if ref_runner_n_pool is not None:
         ref_runner, ref_input_pool = ref_runner_n_pool
 
-    # 1. Run the model with the first 3 prompts
-    updated_input_pool = runner(input_pool[:3])
+    # 1. Run the model with the last 2 prompts
+    updated_input_pool = runner(input_pool[1:])
     print("Batch 1 done", flush=True)
     if ref_runner_n_pool is not None:
-        ref_updated_input_pool = ref_runner(ref_input_pool[:3])
+        ref_updated_input_pool = ref_runner(ref_input_pool[1:])
         verify_status(updated_input_pool, ref_updated_input_pool)
 
-    # 2. Run the model with first 3 (auto-regressive) and rest 2 (prompt)
-    updated_input_pool = runner(updated_input_pool + input_pool[3:])
+    # 2. Run the model with first 1 (prompt) and 2 (auto-regressive).
+    # Note that 1-D OPT requires prompts to go first.
+    updated_input_pool = runner(input_pool[:1] + updated_input_pool)
     print("Batch 2 done", flush=True)
     if ref_runner_n_pool is not None:
-        ref_updated_input_pool = ref_runner(ref_updated_input_pool +
-                                            ref_input_pool[3:])
+        ref_updated_input_pool = ref_runner(ref_input_pool[:1] +
+                                            ref_updated_input_pool)
         verify_status(updated_input_pool, ref_updated_input_pool)
 
-    # # 3. Run the model with all 5 (auto-regessive)
-    # updated_input_pool = runner(updated_input_pool[:1])
+    # # 3. Run the model with all 3 (auto-regessive)
+    # updated_input_pool = runner(updated_input_pool)
     # print("Batch 3 done", flush=True)
+    # if ref_runner_n_pool is not None:
+    #     ref_updated_input_pool = ref_runner(ref_updated_input_pool)
+    #     verify_status(updated_input_pool, ref_updated_input_pool)
 
 
 def test_opt_125M():
@@ -288,115 +332,6 @@ def test_opt_125M():
     # tokenizer = AutoTokenizer.from_pretrained("facebook/opt-30b",
     #                                           use_fast=False)
     # print(tokenizer.decode(result_2d[0][0]))
-
-    # batch_size = len(input_pool)
-    # logistic_ref, cache_refs = run_2d_model_ref(name, np_weights_folder,
-    #                                             input_pool)
-
-    # # Init 1D model
-    # print("Running 1D OPT model", flush=True)
-    # config = opt_model.get_opt_config(name, dtype=jnp.float32)
-    # model_1d, params_1d = opt_model_1d.init_model_aval(config, batch_size)
-    # params_1d = opt_model_1d.load_params_np(params_1d, np_weights_folder,
-    #                                         config)
-    # params_1d = jax.tree_map(jnp.array, params_1d)
-    # cache_1ds = [
-    #     opt_model_1d.init_cache_np(config) for _ in range(len(input_pool))
-    # ]
-
-    # @jax.jit
-    # def inference_step_1d(params, batch):
-    #     output = model_1d.apply(params,
-    #                             batch["input_ids"],
-    #                             batch["position_ids"],
-    #                             batch["batch_idxs"],
-    #                             attention_cache=batch["cache"])
-    #     return output.logits, output.attention_cache
-
-    # # Concat promopts together
-    # input_ids_flatten = []
-    # position_ids_flatten = []
-    # batch_idxs = []
-    # for idx, input_ids in enumerate(input_pool):
-    #     # fused_mmha kernel requires batch_idxs to be in shape sum(input_ids). Each element
-    #     # in batch_idxs is the ID of the corresponding input sequence (starting from 1).
-    #     batch_idxs += np.full(shape=(len(input_ids),),
-    #                           fill_value=idx + 1,
-    #                           dtype=np.int32).tolist()
-    #     input_ids_flatten += input_ids
-    #     position_ids = opt_model_1d.build_position_ids(
-    #         np.array(input_ids, dtype=np.int32), config.pad).tolist()
-    #     position_ids_flatten += position_ids
-    # input_ids_flatten = np.array(input_ids_flatten, dtype=np.int32)
-    # position_ids_flatten = np.array(position_ids_flatten, dtype=np.int32)
-    # batch_idxs = np.array(batch_idxs, dtype=np.int32)
-
-    # # Concate per-input cache together and generate cache index.
-    # # Note that assuming the length of 3 input prompts are L1, L2, L3, and the maximum
-    # # length is L2, then the values of updated cache_index are organized as follows:
-    # # [<1 x L1>, <0 x (L2-L1)>, <1 x L2>, <1 x L3>, <0 x (L2-L3)>..., 0, ...]
-    # cache_1d_flatten = []
-    # for batched_layer_cache in zip(*cache_1ds):
-    #     batched_layer_key = []
-    #     batched_layer_value = []
-    #     batched_layer_index = []
-    #     for key, value, index in batched_layer_cache:
-    #         batched_layer_key.append(key)
-    #         batched_layer_value.append(value)
-    #         #batched_layer_index.append(index)
-    #         batched_layer_index.append(
-    #             np.zeros((config.max_target_positions,), np.int32))
-
-    #     key_flatten = np.concatenate(batched_layer_key, axis=0)
-    #     value_flatten = np.concatenate(batched_layer_value, axis=0)
-    #     index_flatten = np.concatenate(batched_layer_index, axis=0)
-    #     cache_1d_flatten.append((key_flatten, value_flatten, index_flatten))
-
-    # logits, cache_1d_updated = inference_step_1d(
-    #     params_1d, {
-    #         "input_ids": input_ids_flatten,
-    #         "position_ids": position_ids_flatten,
-    #         "batch_idxs": batch_idxs,
-    #         "cache": cache_1d_flatten,
-    #     })
-    # print("logits shape:", logits.shape, flush=True)
-    # assert_allclose(logistic_ref, logits)
-
-    # # Recover the cache.
-    # # The output cache only includes the new values of the current generated token,
-    # # so we perform dynamic slice update on the original cache.
-    # for layer_idx, (key_flatten, value_flatten) in enumerate(cache_1d_updated):
-    #     update_start = 0
-    #     key_flatten = key_flatten.squeeze()
-    #     value_flatten = value_flatten.squeeze()
-    #     for batch_idx in range(batch_size):
-    #         updated_length = len(input_pool[batch_idx])
-    #         update_end = update_start + updated_length
-    #         curr_index = cache_1ds[batch_idx][layer_idx][2][0]
-    #         new_index = curr_index + updated_length
-    #         cache_1ds[batch_idx][layer_idx][0][curr_index:new_index][:][:] = \
-    #             key_flatten[update_start:update_end]
-    #         cache_1ds[batch_idx][layer_idx][1][curr_index:new_index][:][:] = \
-    #             value_flatten[update_start:update_end]
-    #         cache_1ds[batch_idx][layer_idx][2][0] = new_index
-    #         update_start = update_end
-
-    # # Compare cache values
-    # for cache_2d, cache_1d in zip(cache_refs, cache_1ds):
-    #     # Batch
-    #     assert len(cache_2d) == len(cache_1d), \
-    #         "Layer length mismatch: %d vs. %d" % (len(cache_2d), len(cache_1d))
-
-    #     for layer_2d, layer_1d in zip(cache_2d, cache_1d):
-    #         # Layer
-    #         assert len(layer_2d) == len(layer_1d), \
-    #             "KVI length mismatch: %d vs. %d" % (len(layer_2d), len(layer_1d))
-
-    #         # Note that cache index formats are not the same, so we skip the comparison.
-    #         key_2d, value_2d, _ = layer_2d
-    #         key_1d, value_1d, _ = layer_1d
-    #         assert_allclose(key_2d.reshape(key_1d.shape), key_1d)
-    #         assert_allclose(value_2d.reshape(value_1d.shape), value_1d)
 
 
 if __name__ == "__main__":

--- a/examples/opt_serving/model/test_1d.py
+++ b/examples/opt_serving/model/test_1d.py
@@ -1,0 +1,133 @@
+"""Test the correctness of cache implementation."""
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from alpa.testing import assert_allclose
+from opt_serving.model import opt_model
+from opt_serving.model import opt_model_1d
+
+
+def print_params(params, prefix=""):
+    for key, value in params.items():
+        if isinstance(value, dict):
+            print_params(value, prefix=prefix + key + ".")
+        else:
+            print(prefix + key, value.shape)
+
+
+def inference_step_with_cache(model):
+
+    @jax.jit
+    def wrapper(params, batch):
+        output = model.apply(params,
+                             batch["input_ids"],
+                             batch["position_ids"],
+                             attention_cache=batch["cache"])
+        return output.logits, output.attention_cache
+
+    return wrapper
+
+
+def test_opt_125M():
+    name = "125M"
+    np_weights_folder = f"/home/ubuntu/opt_weights/{name}_np"
+
+    input_id_list = [
+        [45942, 2866, 16, 5, 892, 9, 44042, 8],
+        # [100, 261, 23888, 2426, 16, 10, 21624, 12, 4310, 3034, 9744, 25526, 11],
+        # [133, 589, 9, 886, 6, 10817, 16, 10, 285],
+        # [5625, 16, 10, 205, 183, 8, 38, 236, 7],
+        # [2264, 16, 5, 7440, 9, 16673, 873, 24214, 116],
+    ]
+    batch_size = len(input_id_list)
+
+    # Init 2D model
+    print("Running 2D OPT model", flush=True)
+    config = opt_model.get_opt_config(name, dtype=jnp.float32)
+    model_2d, params_2d = opt_model.init_model_aval(config)
+    params_2d = opt_model.load_params_np(params_2d, np_weights_folder, config)
+    params_2d = jax.tree_map(jnp.array, params_2d)
+    cache_2d = opt_model.init_cache_np(config, 1)
+
+    # Get expected results
+    @jax.jit
+    def inference_step_2d(params, batch):
+        output = model_2d.apply(params,
+                                batch["input_ids"],
+                                batch["position_ids"],
+                                attention_cache=batch["cache"])
+        return output.logits, output.attention_cache
+
+    # Run each prompt individually because their lengths are different
+    logits_ref = []
+    for input_ids in input_id_list:
+        input_ids = np.array([input_ids], dtype=np.int32)
+        position_ids = opt_model.build_position_ids(input_ids, config.pad)
+
+        # Note: do not override the cache
+        logits, temp = inference_step_2d(
+            params_2d, {
+                "input_ids": input_ids,
+                "position_ids": position_ids,
+                "cache": cache_2d,
+            })
+        # The logits are in shape (1, seq_len, vocab_size), so we squeeze the batch dimension
+        # and concat them together to mimic the output of the 1D model.
+        logits_ref.append(logits.squeeze())
+    logits_ref = np.concatenate(logits_ref, axis=0)
+    print("logits_ref shape:", logits_ref.shape, flush=True)
+    for i, t in enumerate(temp):
+        jnp.save("temp_2d_%d.npy" % i, t)
+
+    # Init 1D model
+    print("Running 1D OPT model", flush=True)
+    model_1d, params_1d = opt_model_1d.init_model_aval(config, batch_size)
+    params_1d = opt_model_1d.load_params_np(params_1d, np_weights_folder,
+                                            config)
+    params_1d = jax.tree_map(jnp.array, params_1d)
+    cache_1d = opt_model_1d.init_cache_np(config, batch_size)
+
+    @jax.jit
+    def inference_step_1d(params, batch):
+        output = model_1d.apply(params,
+                                batch["input_ids"],
+                                batch["position_ids"],
+                                batch["batch_idxs"],
+                                attention_cache=batch["cache"])
+        return output.logits, output.attention_cache
+
+    # Concat promopts together
+    input_ids_flatten = []
+    position_ids_flatten = []
+    batch_idxs = []
+    for idx, input_ids in enumerate(input_id_list):
+        # fused_mmha kernel requires batch_idxs to be in shape sum(input_ids). Each element
+        # in batch_idxs is the ID of the corresponding input sequence (starting from 1).
+        batch_idxs += np.full(shape=(len(input_ids),),
+                              fill_value=idx + 1,
+                              dtype=np.int32).tolist()
+        input_ids_flatten += input_ids
+        position_ids = opt_model_1d.build_position_ids(
+            np.array(input_ids, dtype=np.int32), config.pad).tolist()
+        position_ids_flatten += position_ids
+    input_ids_flatten = np.array(input_ids_flatten, dtype=np.int32)
+    position_ids_flatten = np.array(position_ids_flatten, dtype=np.int32)
+    batch_idxs = np.array(batch_idxs, dtype=np.int32)
+
+    logits, temp = inference_step_1d(
+        params_1d, {
+            "input_ids": input_ids_flatten,
+            "position_ids": position_ids_flatten,
+            "batch_idxs": batch_idxs,
+            "cache": cache_1d,
+        })
+    print("logits shape:", logits.shape, flush=True)
+    for i, t in enumerate(temp):
+        jnp.save("temp_1d_%d.npy" % i, t)
+
+    assert_allclose(logits_ref, logits)
+
+
+if __name__ == "__main__":
+    test_opt_125M()

--- a/examples/opt_serving/model/test_1d.py
+++ b/examples/opt_serving/model/test_1d.py
@@ -4,51 +4,21 @@ import jax.numpy as jnp
 import numpy as np
 
 from alpa.testing import assert_allclose
-from opt_serving.model import opt_model
-from opt_serving.model import opt_model_1d
+from opt_serving.model import opt_model, opt_model_1d
 
 
-def print_params(params, prefix=""):
-    for key, value in params.items():
-        if isinstance(value, dict):
-            print_params(value, prefix=prefix + key + ".")
-        else:
-            print(prefix + key, value.shape)
-
-
-def inference_step_with_cache(model):
-
-    @jax.jit
-    def wrapper(params, batch):
-        output = model.apply(params,
-                             batch["input_ids"],
-                             batch["position_ids"],
-                             attention_cache=batch["cache"])
-        return output.logits, output.attention_cache
-
-    return wrapper
-
-
-def test_opt_125M():
-    name = "125M"
-    np_weights_folder = f"/home/ubuntu/opt_weights/{name}_np"
-
-    input_id_list = [
-        [45942, 2866, 16, 5, 892, 9, 44042, 8],
-        # [100, 261, 23888, 2426, 16, 10, 21624, 12, 4310, 3034, 9744, 25526, 11],
-        # [133, 589, 9, 886, 6, 10817, 16, 10, 285],
-        # [5625, 16, 10, 205, 183, 8, 38, 236, 7],
-        # [2264, 16, 5, 7440, 9, 16673, 873, 24214, 116],
-    ]
-    batch_size = len(input_id_list)
-
+def run_2d_model_ref(name, np_weights_folder, input_id_list):
     # Init 2D model
     print("Running 2D OPT model", flush=True)
     config = opt_model.get_opt_config(name, dtype=jnp.float32)
     model_2d, params_2d = opt_model.init_model_aval(config)
     params_2d = opt_model.load_params_np(params_2d, np_weights_folder, config)
     params_2d = jax.tree_map(jnp.array, params_2d)
-    cache_2d = opt_model.init_cache_np(config, 1)
+
+    # Make cache for each input
+    cache_2ds = [
+        opt_model.init_cache_np(config, 1) for _ in range(len(input_id_list))
+    ]
 
     # Get expected results
     @jax.jit
@@ -60,33 +30,51 @@ def test_opt_125M():
         return output.logits, output.attention_cache
 
     # Run each prompt individually because their lengths are different
-    logits_ref = []
-    for input_ids in input_id_list:
+    logits_all = []
+    for idx, input_ids in enumerate(input_id_list):
         input_ids = np.array([input_ids], dtype=np.int32)
         position_ids = opt_model.build_position_ids(input_ids, config.pad)
 
-        # Note: do not override the cache
-        logits, temp = inference_step_2d(
+        logits, cache_2ds[idx] = inference_step_2d(
             params_2d, {
                 "input_ids": input_ids,
                 "position_ids": position_ids,
-                "cache": cache_2d,
+                "cache": cache_2ds[idx],
             })
         # The logits are in shape (1, seq_len, vocab_size), so we squeeze the batch dimension
         # and concat them together to mimic the output of the 1D model.
-        logits_ref.append(logits.squeeze())
-    logits_ref = np.concatenate(logits_ref, axis=0)
-    print("logits_ref shape:", logits_ref.shape, flush=True)
-    for i, t in enumerate(temp):
-        jnp.save("temp_2d_%d.npy" % i, t)
+        logits_all.append(logits.squeeze())
+    logits_all = np.concatenate(logits_all, axis=0)
+    print("prompt logits shape:", logits_all.shape, flush=True)
+    return logits_all, cache_2ds
+
+
+def test_opt_125M():
+    name = "125M"
+    np_weights_folder = f"/home/ubuntu/opt_weights/{name}_np"
+
+    input_id_list = [
+        [45942, 2866, 16, 5, 892, 9, 44042, 8],
+        [100, 261, 23888, 2426, 16, 10, 21624, 12, 4310, 3034, 9744, 25526, 11],
+        [133, 589, 9, 886, 6, 10817, 16, 10, 285],
+        [5625, 16, 10, 205, 183, 8, 38, 236, 7],
+        [2264, 16, 5, 7440, 9, 16673, 873, 24214, 116],
+    ]
+    batch_size = len(input_id_list)
+
+    logistic_ref, cache_refs = run_2d_model_ref(name, np_weights_folder,
+                                                input_id_list)
 
     # Init 1D model
     print("Running 1D OPT model", flush=True)
+    config = opt_model.get_opt_config(name, dtype=jnp.float32)
     model_1d, params_1d = opt_model_1d.init_model_aval(config, batch_size)
     params_1d = opt_model_1d.load_params_np(params_1d, np_weights_folder,
                                             config)
     params_1d = jax.tree_map(jnp.array, params_1d)
-    cache_1d = opt_model_1d.init_cache_np(config, batch_size)
+    cache_1ds = [
+        opt_model_1d.init_cache_np(config) for _ in range(len(input_id_list))
+    ]
 
     @jax.jit
     def inference_step_1d(params, batch):
@@ -115,18 +103,63 @@ def test_opt_125M():
     position_ids_flatten = np.array(position_ids_flatten, dtype=np.int32)
     batch_idxs = np.array(batch_idxs, dtype=np.int32)
 
-    logits, temp = inference_step_1d(
+    # Concate per-input cache together
+    cache_1d_flatten = []
+    for batched_layer_cache in zip(*cache_1ds):
+        batched_layer_key = []
+        batched_layer_value = []
+        batched_layer_index = []
+        for key, value, index in batched_layer_cache:
+            batched_layer_key.append(key)
+            batched_layer_value.append(value)
+            batched_layer_index.append(index)
+
+        key_flatten = np.concatenate(batched_layer_key, axis=0)
+        value_flatten = np.concatenate(batched_layer_value, axis=0)
+        index_flatten = np.concatenate(batched_layer_index, axis=0)
+        cache_1d_flatten.append((key_flatten, value_flatten, index_flatten))
+
+    logits, cache_1d_temp = inference_step_1d(
         params_1d, {
             "input_ids": input_ids_flatten,
             "position_ids": position_ids_flatten,
             "batch_idxs": batch_idxs,
-            "cache": cache_1d,
+            "cache": cache_1d_flatten,
         })
     print("logits shape:", logits.shape, flush=True)
-    for i, t in enumerate(temp):
-        jnp.save("temp_1d_%d.npy" % i, t)
+    assert_allclose(logistic_ref, logits)
 
-    assert_allclose(logits_ref, logits)
+    # Recover the cache
+    # TODO: Update cache_index
+    # Note that assuming the length of 3 input prompts are L1, L2, L3, and the maximum
+    # length is L2, then the values of updated cache_index are organized as follows:
+    # [<1 x L1>, <0 x (L2-L1)>, <1 x L2>, <1 x L3>, <0 x (L2-L3)>..., 0, ...]
+    cache_1ds = [[] for _ in range(batch_size)]
+    for key_flatten, value_flatten, index_flatten in cache_1d_temp:
+        start = 0
+        for batch_idx in range(batch_size):
+            end = start + config.max_target_positions
+            cache_1ds[batch_idx].append(
+                (key_flatten[start:end], value_flatten[start:end],
+                 index_flatten[start:end]))
+            start = end
+
+    # Compare cache values
+    for cache_2d, cache_1d in zip(cache_refs, cache_1ds):
+        # Batch
+        assert len(cache_2d) == len(cache_1d), \
+            "Layer length mismatch: %d vs. %d" % (len(cache_2d), len(cache_1d))
+
+        for layer_2d, layer_1d in zip(cache_2d, cache_1d):
+            # Layer
+            assert len(layer_2d) == len(layer_1d), \
+                "KVI length mismatch: %d vs. %d" % (len(layer_2d), len(layer_1d))
+
+            # Note that cache index formats are not the same, so we skip the comparison.
+            key_2d, value_2d, _ = layer_2d
+            key_1d, value_1d, _ = layer_1d
+            assert_allclose(key_2d.reshape(key_1d.shape), key_1d)
+            assert_allclose(value_2d.reshape(value_1d.shape), value_1d)
 
 
 if __name__ == "__main__":

--- a/examples/opt_serving/model/test_1d.py
+++ b/examples/opt_serving/model/test_1d.py
@@ -6,21 +6,28 @@ import numpy as np
 from alpa.testing import assert_allclose
 from opt_serving.model import opt_model, opt_model_1d
 
+from transformers import AutoTokenizer
 
-def run_2d_model_ref(name, np_weights_folder, input_id_list):
+input_id_list = [
+    [45942, 2866, 16, 5, 892, 9, 44042, 8],
+    [100, 261, 23888, 2426, 16, 10, 21624, 12, 4310, 3034, 9744, 25526, 11],
+    [133, 589, 9, 886, 6, 10817, 16, 10, 285],
+    [5625, 16, 10, 205, 183, 8, 38, 236, 7],
+    [2264, 16, 5, 7440, 9, 16673, 873, 24214, 116],
+]
+
+
+def init_2d_model(name, np_weights_folder, input_id_list):
     # Init 2D model
-    print("Running 2D OPT model", flush=True)
     config = opt_model.get_opt_config(name, dtype=jnp.float32)
     model_2d, params_2d = opt_model.init_model_aval(config)
     params_2d = opt_model.load_params_np(params_2d, np_weights_folder, config)
     params_2d = jax.tree_map(jnp.array, params_2d)
 
     # Make cache for each input
-    cache_2ds = [
-        opt_model.init_cache_np(config, 1) for _ in range(len(input_id_list))
-    ]
+    input_pool_2d = [(input_id, opt_model.init_cache_np(config, 1))
+                     for input_id in input_id_list]
 
-    # Get expected results
     @jax.jit
     def inference_step_2d(params, batch):
         output = model_2d.apply(params,
@@ -29,52 +36,51 @@ def run_2d_model_ref(name, np_weights_folder, input_id_list):
                                 attention_cache=batch["cache"])
         return output.logits, output.attention_cache
 
-    # Run each prompt individually because their lengths are different
-    logits_all = []
-    for idx, input_ids in enumerate(input_id_list):
-        input_ids = np.array([input_ids], dtype=np.int32)
-        position_ids = opt_model.build_position_ids(input_ids, config.pad)
+    def runner(input_pool):
+        # Run each sequence individually because their lengths are different
+        logits_all = []
+        for idx, (_input_ids, cache) in enumerate(input_pool):
+            input_ids = np.array([_input_ids], dtype=np.int32)
+            position_ids = opt_model.build_position_ids(input_ids, config.pad)
+            if cache[0][2][0] > 0:
+                # Auto-regressive
+                input_ids = input_ids[:][-1]
+                position_ids = position_ids[:][-1:]
 
-        logits, cache_2ds[idx] = inference_step_2d(
-            params_2d, {
-                "input_ids": input_ids,
-                "position_ids": position_ids,
-                "cache": cache_2ds[idx],
-            })
-        # The logits are in shape (1, seq_len, vocab_size), so we squeeze the batch dimension
-        # and concat them together to mimic the output of the 1D model.
-        logits_all.append(logits.squeeze())
-    logits_all = np.concatenate(logits_all, axis=0)
-    print("prompt logits shape:", logits_all.shape, flush=True)
-    return logits_all, cache_2ds
+            logits, updated_cache = inference_step_2d(
+                params_2d, {
+                    "input_ids": input_ids,
+                    "position_ids": position_ids,
+                    "cache": cache,
+                })
+            logits = logits.reshape(logits.shape[1:])
+            next_token = np.argmax(logits, axis=-1)[-1]
+
+            # Append the generated token and updated cache.
+            input_pool[idx] = (_input_ids + [next_token.tolist()],
+                               updated_cache)
+
+            # The logits are in shape (1, seq_len, vocab_size), so we squeeze the batch dimension
+            # and concat them together for verification.
+            logits_all.append(logits)
+        logits_all = np.concatenate(logits_all, axis=0)
+        return input_pool
+
+    return runner, input_pool_2d
 
 
-def test_opt_125M():
-    name = "125M"
-    np_weights_folder = f"/home/ubuntu/opt_weights/{name}_np"
-
-    input_id_list = [
-        [45942, 2866, 16, 5, 892, 9, 44042, 8],
-        [100, 261, 23888, 2426, 16, 10, 21624, 12, 4310, 3034, 9744, 25526, 11],
-        [133, 589, 9, 886, 6, 10817, 16, 10, 285],
-        [5625, 16, 10, 205, 183, 8, 38, 236, 7],
-        [2264, 16, 5, 7440, 9, 16673, 873, 24214, 116],
-    ]
-    batch_size = len(input_id_list)
-
-    logistic_ref, cache_refs = run_2d_model_ref(name, np_weights_folder,
-                                                input_id_list)
-
+def init_1d_model(name, np_weights_folder, input_id_list):
     # Init 1D model
-    print("Running 1D OPT model", flush=True)
+    max_batch_size = len(input_id_list)
     config = opt_model.get_opt_config(name, dtype=jnp.float32)
-    model_1d, params_1d = opt_model_1d.init_model_aval(config, batch_size)
+    model_1d, params_1d = opt_model_1d.init_model_aval(config, max_batch_size)
     params_1d = opt_model_1d.load_params_np(params_1d, np_weights_folder,
                                             config)
     params_1d = jax.tree_map(jnp.array, params_1d)
-    cache_1ds = [
-        opt_model_1d.init_cache_np(config) for _ in range(len(input_id_list))
-    ]
+
+    # Make cache for each input
+    input_pool_1d = [(input_id, opt_model_1d.init_cache_np(config))
+                     for input_id in input_id_list]
 
     @jax.jit
     def inference_step_1d(params, batch):
@@ -85,81 +91,312 @@ def test_opt_125M():
                                 attention_cache=batch["cache"])
         return output.logits, output.attention_cache
 
-    # Concat promopts together
-    input_ids_flatten = []
-    position_ids_flatten = []
-    batch_idxs = []
-    for idx, input_ids in enumerate(input_id_list):
-        # fused_mmha kernel requires batch_idxs to be in shape sum(input_ids). Each element
-        # in batch_idxs is the ID of the corresponding input sequence (starting from 1).
-        batch_idxs += np.full(shape=(len(input_ids),),
-                              fill_value=idx + 1,
-                              dtype=np.int32).tolist()
-        input_ids_flatten += input_ids
-        position_ids = opt_model_1d.build_position_ids(
-            np.array(input_ids, dtype=np.int32), config.pad).tolist()
-        position_ids_flatten += position_ids
-    input_ids_flatten = np.array(input_ids_flatten, dtype=np.int32)
-    position_ids_flatten = np.array(position_ids_flatten, dtype=np.int32)
-    batch_idxs = np.array(batch_idxs, dtype=np.int32)
+    def runner(input_pool):
+        batch_size = len(input_pool)
 
-    # Concate per-input cache together
-    cache_1d_flatten = []
-    for batched_layer_cache in zip(*cache_1ds):
-        batched_layer_key = []
-        batched_layer_value = []
-        batched_layer_index = []
-        for key, value, index in batched_layer_cache:
-            batched_layer_key.append(key)
-            batched_layer_value.append(value)
-            batched_layer_index.append(index)
+        # Concat promopts together
+        input_ids_flatten = []
+        position_ids_flatten = []
+        batch_idxs = []
+        for idx, (input_ids, _) in enumerate(input_pool):
+            # fused_mmha kernel requires batch_idxs to be in shape sum(input_ids). Each element
+            # in batch_idxs is the ID of the corresponding input sequence (starting from 1).
+            batch_idxs += np.full(shape=(len(input_ids),),
+                                  fill_value=idx + 1,
+                                  dtype=np.int32).tolist()
+            input_ids_flatten += input_ids
+            position_ids = opt_model_1d.build_position_ids(
+                np.array(input_ids, dtype=np.int32), config.pad).tolist()
+            position_ids_flatten += position_ids
+        input_ids_flatten = np.array(input_ids_flatten, dtype=np.int32)
+        position_ids_flatten = np.array(position_ids_flatten, dtype=np.int32)
+        batch_idxs = np.array(batch_idxs, dtype=np.int32)
 
-        key_flatten = np.concatenate(batched_layer_key, axis=0)
-        value_flatten = np.concatenate(batched_layer_value, axis=0)
-        index_flatten = np.concatenate(batched_layer_index, axis=0)
-        cache_1d_flatten.append((key_flatten, value_flatten, index_flatten))
+        # Concate per-input cache together and generate cache index.
+        # Note that assuming the length of 3 input prompts are L1, L2, L3, and the maximum
+        # length is L2, then the values of updated cache_index are organized as follows:
+        # [<1 x L1>, <0 x (L2-L1)>, <1 x L2>, <1 x L3>, <0 x (L2-L3)>..., 0, ...]
+        max_len_in_pool = max(
+            [len(ids) - cache[0][2][0] for ids, cache in input_pool])
+        cache_1d_flatten = []
+        for batched_layer_cache in zip(*[cache for _, cache in input_pool]):
+            batched_layer_key = []
+            batched_layer_value = []
+            batched_layer_index = []
+            for bidx, (key, value, index) in enumerate(batched_layer_cache):
+                batched_layer_key.append(key)
+                batched_layer_value.append(value)
 
-    logits, cache_1d_temp = inference_step_1d(
-        params_1d, {
-            "input_ids": input_ids_flatten,
-            "position_ids": position_ids_flatten,
-            "batch_idxs": batch_idxs,
-            "cache": cache_1d_flatten,
-        })
-    print("logits shape:", logits.shape, flush=True)
-    assert_allclose(logistic_ref, logits)
+                seq_ids = np.full(
+                    (index[0],),  # Valid cache length
+                    bidx + 1,  # Sequence ID starting from 1
+                    dtype=np.int32)
+                batched_layer_index.append(
+                    np.concatenate([
+                        seq_ids,
+                        np.zeros((config.max_target_positions - index[0],), dtype=np.int32)
+                    ]))                
 
-    # Recover the cache
-    # TODO: Update cache_index
-    # Note that assuming the length of 3 input prompts are L1, L2, L3, and the maximum
-    # length is L2, then the values of updated cache_index are organized as follows:
-    # [<1 x L1>, <0 x (L2-L1)>, <1 x L2>, <1 x L3>, <0 x (L2-L3)>..., 0, ...]
-    cache_1ds = [[] for _ in range(batch_size)]
-    for key_flatten, value_flatten, index_flatten in cache_1d_temp:
-        start = 0
-        for batch_idx in range(batch_size):
-            end = start + config.max_target_positions
-            cache_1ds[batch_idx].append(
-                (key_flatten[start:end], value_flatten[start:end],
-                 index_flatten[start:end]))
-            start = end
+                # The index for each cache is organized as the following format:
+                # <SeqID x L1>, <0 x (Lmax-L1)>, where Lmax is the maximum length
+                # in the CURRENT pool.
+                # seq_ids = np.full(
+                #     (index[0],),  # Valid cache length
+                #     bidx + 1,  # Sequence ID starting from 1
+                #     dtype=np.int32)
+                # batched_layer_index.append(
+                #     np.concatenate([
+                #         seq_ids,
+                #         np.zeros((max_len_in_pool - index[0],), dtype=np.int32)
+                #     ]))
 
-    # Compare cache values
-    for cache_2d, cache_1d in zip(cache_refs, cache_1ds):
-        # Batch
-        assert len(cache_2d) == len(cache_1d), \
-            "Layer length mismatch: %d vs. %d" % (len(cache_2d), len(cache_1d))
+            key_flatten = np.concatenate(batched_layer_key, axis=0)
+            value_flatten = np.concatenate(batched_layer_value, axis=0)
+            index_flatten = np.concatenate(batched_layer_index, axis=0)
 
+            # Pad 0s to fixed length: batch_size * max_target_positions
+            # padding = np.zeros(
+            #     (batch_size * config.max_target_positions - index_flatten.shape[0],),
+            #     dtype=np.int32)
+            # index_flatten = np.concatenate([index_flatten, padding], axis=0)
+            cache_1d_flatten.append((key_flatten, value_flatten, index_flatten))
+
+        logits, cache_1d_updated = inference_step_1d(
+            params_1d, {
+                "input_ids": input_ids_flatten,
+                "position_ids": position_ids_flatten,
+                "batch_idxs": batch_idxs,
+                "cache": cache_1d_flatten,
+            })
+
+        # Recover and update the cache.
+        # The output cache only includes the new values of the current generated token,
+        # so we perform dynamic slice update on the original cache.
+        for lidx, (key_flatten, value_flatten) in enumerate(cache_1d_updated):
+            update_start = 0
+            key_flatten = key_flatten.squeeze()
+            value_flatten = value_flatten.squeeze()
+            for bidx in range(batch_size):
+                cache = input_pool[bidx][1]
+                curr_index = cache[lidx][2][0]
+
+                # Determine the length of updated cache.
+                updated_length = len(input_pool[bidx][0]) - curr_index
+                update_end = update_start + updated_length
+                new_index = curr_index + updated_length
+
+                # Slice update.
+                cache[lidx][0][curr_index:new_index][:][:] = \
+                    key_flatten[update_start:update_end]
+                cache[lidx][1][curr_index:new_index][:][:] = \
+                    value_flatten[update_start:update_end]
+                cache[lidx][2][0] = new_index
+                input_pool[bidx] = (input_pool[bidx][0], cache)
+
+                update_start = update_end
+
+        # Append the generated token.
+        update_start = 0
+        for bidx, (_input_ids, cache) in enumerate(input_pool):
+            updated_length = len(_input_ids)  # FIXME
+            update_end = update_start + updated_length
+            next_token = np.argmax(logits[update_start:update_end], axis=-1)[-1]
+            input_pool[bidx] = (_input_ids + [next_token.tolist()], cache)
+            update_start = update_end
+
+        # Recover the cache.
+        # The output cache only includes the new values of the current generated token,
+        # so we perform dynamic slice update on the original cache.
+        # for layer_idx, (key_flatten, value_flatten) in enumerate(cache_1d_updated):
+        #     update_start = 0
+        #     key_flatten = key_flatten.squeeze()
+        #     value_flatten = value_flatten.squeeze()
+        #     for batch_idx in range(batch_size):
+        #         updated_length = len(input_pool[batch_idx])
+        #         update_end = update_start + updated_length
+        #         curr_index = cache_1ds[batch_idx][layer_idx][2][0]
+        #         new_index = curr_index + updated_length
+        #         cache_1ds[batch_idx][layer_idx][0][curr_index:new_index][:][:] = \
+        #             key_flatten[update_start:update_end]
+        #         cache_1ds[batch_idx][layer_idx][1][curr_index:new_index][:][:] = \
+        #             value_flatten[update_start:update_end]
+        #         cache_1ds[batch_idx][layer_idx][2][0] = new_index
+        #         update_start = update_end
+        return input_pool
+
+    return runner, input_pool_1d
+
+
+def verify_status(result_1d, result_2d):
+    """Verify the current sequence and cache values."""
+    print("Verifying results", flush=True)
+    for (seq_1d, cache_1d), (seq_2d, cache_2d) in zip(result_1d, result_2d):
+        # Verify sequence.
+        assert_allclose(seq_1d, seq_2d)
+
+        # Verify cache.
         for layer_2d, layer_1d in zip(cache_2d, cache_1d):
             # Layer
             assert len(layer_2d) == len(layer_1d), \
                 "KVI length mismatch: %d vs. %d" % (len(layer_2d), len(layer_1d))
 
-            # Note that cache index formats are not the same, so we skip the comparison.
             key_2d, value_2d, _ = layer_2d
             key_1d, value_1d, _ = layer_1d
             assert_allclose(key_2d.reshape(key_1d.shape), key_1d)
             assert_allclose(value_2d.reshape(value_1d.shape), value_1d)
+
+
+def simulate_serving(runner_n_pool, ref_runner_n_pool=None):
+    """Simulate model serviing."""
+    runner, input_pool = runner_n_pool
+
+    ref_runner = None
+    ref_input_pool = None
+    if ref_runner_n_pool is not None:
+        ref_runner, ref_input_pool = ref_runner_n_pool
+
+    # 1. Run the model with the first 3 prompts
+    updated_input_pool = runner(input_pool[:3])
+    print("Batch 1 done", flush=True)
+    if ref_runner_n_pool is not None:
+        ref_updated_input_pool = ref_runner(ref_input_pool[:3])
+        verify_status(updated_input_pool, ref_updated_input_pool)
+
+    # 2. Run the model with first 3 (auto-regressive) and rest 2 (prompt)
+    updated_input_pool = runner(updated_input_pool + input_pool[3:])
+    print("Batch 2 done", flush=True)
+    if ref_runner_n_pool is not None:
+        ref_updated_input_pool = ref_runner(ref_updated_input_pool +
+                                            ref_input_pool[3:])
+        verify_status(updated_input_pool, ref_updated_input_pool)
+
+    # # 3. Run the model with all 5 (auto-regessive)
+    # updated_input_pool = runner(updated_input_pool[:1])
+    # print("Batch 3 done", flush=True)
+
+
+def test_opt_125M():
+    name = "125M"
+    np_weights_folder = f"/home/ubuntu/opt_weights/{name}_np"
+
+    runner_2d, input_pool_2d = init_2d_model(name, np_weights_folder,
+                                             input_id_list)
+    runner_1d, input_pool_1d = init_1d_model(name, np_weights_folder,
+                                             input_id_list)
+    simulate_serving((runner_1d, input_pool_1d), (runner_2d, input_pool_2d))
+
+    # tokenizer = AutoTokenizer.from_pretrained("facebook/opt-30b",
+    #                                           use_fast=False)
+    # print(tokenizer.decode(result_2d[0][0]))
+
+    # batch_size = len(input_pool)
+    # logistic_ref, cache_refs = run_2d_model_ref(name, np_weights_folder,
+    #                                             input_pool)
+
+    # # Init 1D model
+    # print("Running 1D OPT model", flush=True)
+    # config = opt_model.get_opt_config(name, dtype=jnp.float32)
+    # model_1d, params_1d = opt_model_1d.init_model_aval(config, batch_size)
+    # params_1d = opt_model_1d.load_params_np(params_1d, np_weights_folder,
+    #                                         config)
+    # params_1d = jax.tree_map(jnp.array, params_1d)
+    # cache_1ds = [
+    #     opt_model_1d.init_cache_np(config) for _ in range(len(input_pool))
+    # ]
+
+    # @jax.jit
+    # def inference_step_1d(params, batch):
+    #     output = model_1d.apply(params,
+    #                             batch["input_ids"],
+    #                             batch["position_ids"],
+    #                             batch["batch_idxs"],
+    #                             attention_cache=batch["cache"])
+    #     return output.logits, output.attention_cache
+
+    # # Concat promopts together
+    # input_ids_flatten = []
+    # position_ids_flatten = []
+    # batch_idxs = []
+    # for idx, input_ids in enumerate(input_pool):
+    #     # fused_mmha kernel requires batch_idxs to be in shape sum(input_ids). Each element
+    #     # in batch_idxs is the ID of the corresponding input sequence (starting from 1).
+    #     batch_idxs += np.full(shape=(len(input_ids),),
+    #                           fill_value=idx + 1,
+    #                           dtype=np.int32).tolist()
+    #     input_ids_flatten += input_ids
+    #     position_ids = opt_model_1d.build_position_ids(
+    #         np.array(input_ids, dtype=np.int32), config.pad).tolist()
+    #     position_ids_flatten += position_ids
+    # input_ids_flatten = np.array(input_ids_flatten, dtype=np.int32)
+    # position_ids_flatten = np.array(position_ids_flatten, dtype=np.int32)
+    # batch_idxs = np.array(batch_idxs, dtype=np.int32)
+
+    # # Concate per-input cache together and generate cache index.
+    # # Note that assuming the length of 3 input prompts are L1, L2, L3, and the maximum
+    # # length is L2, then the values of updated cache_index are organized as follows:
+    # # [<1 x L1>, <0 x (L2-L1)>, <1 x L2>, <1 x L3>, <0 x (L2-L3)>..., 0, ...]
+    # cache_1d_flatten = []
+    # for batched_layer_cache in zip(*cache_1ds):
+    #     batched_layer_key = []
+    #     batched_layer_value = []
+    #     batched_layer_index = []
+    #     for key, value, index in batched_layer_cache:
+    #         batched_layer_key.append(key)
+    #         batched_layer_value.append(value)
+    #         #batched_layer_index.append(index)
+    #         batched_layer_index.append(
+    #             np.zeros((config.max_target_positions,), np.int32))
+
+    #     key_flatten = np.concatenate(batched_layer_key, axis=0)
+    #     value_flatten = np.concatenate(batched_layer_value, axis=0)
+    #     index_flatten = np.concatenate(batched_layer_index, axis=0)
+    #     cache_1d_flatten.append((key_flatten, value_flatten, index_flatten))
+
+    # logits, cache_1d_updated = inference_step_1d(
+    #     params_1d, {
+    #         "input_ids": input_ids_flatten,
+    #         "position_ids": position_ids_flatten,
+    #         "batch_idxs": batch_idxs,
+    #         "cache": cache_1d_flatten,
+    #     })
+    # print("logits shape:", logits.shape, flush=True)
+    # assert_allclose(logistic_ref, logits)
+
+    # # Recover the cache.
+    # # The output cache only includes the new values of the current generated token,
+    # # so we perform dynamic slice update on the original cache.
+    # for layer_idx, (key_flatten, value_flatten) in enumerate(cache_1d_updated):
+    #     update_start = 0
+    #     key_flatten = key_flatten.squeeze()
+    #     value_flatten = value_flatten.squeeze()
+    #     for batch_idx in range(batch_size):
+    #         updated_length = len(input_pool[batch_idx])
+    #         update_end = update_start + updated_length
+    #         curr_index = cache_1ds[batch_idx][layer_idx][2][0]
+    #         new_index = curr_index + updated_length
+    #         cache_1ds[batch_idx][layer_idx][0][curr_index:new_index][:][:] = \
+    #             key_flatten[update_start:update_end]
+    #         cache_1ds[batch_idx][layer_idx][1][curr_index:new_index][:][:] = \
+    #             value_flatten[update_start:update_end]
+    #         cache_1ds[batch_idx][layer_idx][2][0] = new_index
+    #         update_start = update_end
+
+    # # Compare cache values
+    # for cache_2d, cache_1d in zip(cache_refs, cache_1ds):
+    #     # Batch
+    #     assert len(cache_2d) == len(cache_1d), \
+    #         "Layer length mismatch: %d vs. %d" % (len(cache_2d), len(cache_1d))
+
+    #     for layer_2d, layer_1d in zip(cache_2d, cache_1d):
+    #         # Layer
+    #         assert len(layer_2d) == len(layer_1d), \
+    #             "KVI length mismatch: %d vs. %d" % (len(layer_2d), len(layer_1d))
+
+    #         # Note that cache index formats are not the same, so we skip the comparison.
+    #         key_2d, value_2d, _ = layer_2d
+    #         key_1d, value_1d, _ = layer_1d
+    #         assert_allclose(key_2d.reshape(key_1d.shape), key_1d)
+    #         assert_allclose(value_2d.reshape(value_1d.shape), value_1d)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds an 1-D OPT model implementation. See `test_1d.py` for model inputs and output.

Some highlights:
1. The model uses the fused kernel from `ft_mha`. The corresponding repo should be included in alpa-project, but it's not publicly available now.
2. With the fused MHA kernel, we still have to update the attention cache. I haven't implemented it because I haven't figured out how.
3. Currently I verified that the output of a batch of prompts from both 1D and 2D model are identical, so does the cache shape. However, based on 2, I commented out the cache value checking.
