### PR TITLE
Use relative path to access completions URL

### DIFF
--- a/examples/opt_serving/service/index.html
+++ b/examples/opt_serving/service/index.html
@@ -146,7 +146,7 @@
         var submitData = getFormData($("form"));
         console.log(JSON.stringify(submitData));
         $.ajax({
-            url: "/completions",
+            url: "completions",
             type: "POST",
             processData: true,
             contentType: "application/json",


### PR DESCRIPTION
We ran into some trouble hosting the OPT demo behind a reverse proxy like NGINX that adds a prefix to the OPT serving URLs. This PR changes the completions request to use a relative URL so the OPT service can work under and reverse proxy.