### PR TITLE
[FEATURE] Add FollowParallel

### DIFF
--- a/alpa/__init__.py
+++ b/alpa/__init__.py
@@ -12,7 +12,7 @@ from alpa.global_env import global_config
 from alpa.mesh_profiling import ProfilingResultDatabase
 from alpa.parallel_method import (ShardParallel, PipeshardParallel,
                                   DataParallel, Zero2Parallel, Zero3Parallel,
-                                  CreateStateParallel)
+                                  CreateStateParallel, FollowParallel)
 from alpa.parallel_plan import plan_to_method
 from alpa.pipeline_parallel.primitive_def import mark_pipeline_boundary
 from alpa.pipeline_parallel.layer_construction import (manual_remat,
@@ -33,6 +33,7 @@ from . import create_state_parallel
 from . import device_mesh
 from . import data_loader
 from . import global_env
+from . import follow_parallel
 from . import mesh_profiling
 from . import monkey_patch
 from . import parallel_method

--- a/alpa/create_state_parallel.py
+++ b/alpa/create_state_parallel.py
@@ -124,10 +124,10 @@ def compile_create_state_executable(fun, in_tree, out_tree_thunk,
         num_meshes = len(executable.mesh_group)
 
         propagate_mesh_assignment(jaxpr, var2mesh, eqn2mesh)
-        sliced_eqns = slice_jaxpr_with_mesh_assignment(
-            jaxpr, eqn2mesh, num_meshes)
-        new_jaxpr = add_pipeline_marks_for_sliced_eqns(
-            closed_jaxpr, sliced_eqns)
+        sliced_eqns = slice_jaxpr_with_mesh_assignment(jaxpr, eqn2mesh,
+                                                       num_meshes)
+        new_jaxpr = add_pipeline_marks_for_sliced_eqns(closed_jaxpr,
+                                                       sliced_eqns)
 
         # Compile a pipeshard executable with predefined output shardings
         pipeshard_config = compile_pipeshard_executable_internal(

--- a/alpa/create_state_parallel.py
+++ b/alpa/create_state_parallel.py
@@ -2,7 +2,7 @@
 from collections import defaultdict, deque
 from typing import Sequence, Optional
 
-from jax._src.lib import xla_bridge as xb, xla_extension as xe
+from jax._src.lib import xla_extension as xe
 from jax.core import ClosedJaxpr, Var
 from jax.interpreters import partial_eval as pe, pxla
 from jax.tree_util import tree_flatten, tree_unflatten, PyTreeDef
@@ -76,15 +76,13 @@ def compile_create_state_executable(fun, in_tree, out_tree_thunk,
     # Trace to get jaxpr and HloModule
     jaxpr, out_avals, consts = pe.trace_to_jaxpr_final(fun, avals)
     closed_jaxpr = ClosedJaxpr(jaxpr, consts)
-    out_tree = out_tree_thunk()
-    state_aval = tree_unflatten(out_tree, out_avals)
 
     name = f"{fun.__name__}_create_state_parallel"
-    backend = xb.get_backend("gpu")
-    hlo_module = jaxpr_to_hlo_module(name, closed_jaxpr, donated_invars,
-                                     backend)
+    hlo_module = jaxpr_to_hlo_module(name, closed_jaxpr, donated_invars)
 
     # Compile train_step to get the placement specs.
+    out_tree = out_tree_thunk()
+    state_aval = tree_unflatten(out_tree, out_avals)
     executable = train_step.get_executable(state_aval, other_args)
     placement_specs = executable.get_input_placement_specs()[0]
     placement_specs, _ = tree_flatten(placement_specs)
@@ -126,15 +124,17 @@ def compile_create_state_executable(fun, in_tree, out_tree_thunk,
         num_meshes = len(executable.mesh_group)
 
         propagate_mesh_assignment(jaxpr, var2mesh, eqn2mesh)
-        eqns = slice_jaxpr_with_mesh_assignment(jaxpr, eqn2mesh, num_meshes)
-        new_jaxpr = add_pipeline_marks_for_sliced_eqns(closed_jaxpr, eqns)
+        sliced_eqns = slice_jaxpr_with_mesh_assignment(
+            jaxpr, eqn2mesh, num_meshes)
+        new_jaxpr = add_pipeline_marks_for_sliced_eqns(
+            closed_jaxpr, sliced_eqns)
 
         # Compile a pipeshard executable with predefined output shardings
         pipeshard_config = compile_pipeshard_executable_internal(
             new_jaxpr, None, 1, [False] * len(avals), [False] * len(avals),
             executable.mesh_group.parent, 1, "inference",
             AutoShardingOption(enable_auto_sharding=False),
-            UniformStageOption(), name, output_shardings, None)
+            UniformStageOption(), name, None, output_shardings, None)
 
         return CreateStateExecutable(mesh_group=executable.mesh_group,
                                      pipeshard_config=pipeshard_config,
@@ -145,6 +145,16 @@ def compile_create_state_executable(fun, in_tree, out_tree_thunk,
 
 
 def propagate_mesh_assignment(jaxpr, var2mesh, eqn2mesh):
+    """Propagate mesh assignment for all variables and equations.
+
+    Note that this is different from the propagation in apply_grad.
+    create_state_parallel: always assign one equation to one mesh.
+      If one equation is used by multiple meshes, use send/recv to
+      pass the value.
+    apply_grad: can assign one equation to multiple meshes.
+      If one equation is used by multiple meshes, replicate the
+      computation on all meshes.
+    """
     def_eqn = {}  # Dict[var -> eqn_idx]
 
     for idx, eqn in enumerate(jaxpr.eqns):
@@ -162,6 +172,8 @@ def propagate_mesh_assignment(jaxpr, var2mesh, eqn2mesh):
         for var in mesh2vars[mesh_idx]:
             eqn_idx = def_eqn[var]
             if eqn_idx not in eqn2mesh:
+                # Propagate from the definition equation to
+                # all related equations
                 queue = deque((eqn_idx,))
 
                 while queue:
@@ -176,10 +188,10 @@ def propagate_mesh_assignment(jaxpr, var2mesh, eqn2mesh):
 
 
 def slice_jaxpr_with_mesh_assignment(jaxpr, eqn2mesh, num_meshes):
-    eqns = [[] for _ in range(num_meshes)]
+    sliced_eqns = [[] for _ in range(num_meshes)]
 
     for idx, eqn in enumerate(jaxpr.eqns):
         if idx in eqn2mesh:
-            eqns[eqn2mesh[idx]].append(eqn)
+            sliced_eqns[eqn2mesh[idx]].append(eqn)
 
-    return eqns
+    return sliced_eqns

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -791,6 +791,8 @@ class LocalPhysicalDeviceMesh(PhysicalDeviceMesh):
         self.device_strs = []
         self.operation_executables = {}
 
+        self.backend = xb.get_backend("gpu")
+
         self.set_runtime_random_seed(global_config.runtime_random_seed)
 
     ##### Executable Related Functions #####

--- a/alpa/follow_parallel.py
+++ b/alpa/follow_parallel.py
@@ -1,0 +1,147 @@
+"""Follow the parallelization strategy of another function."""
+import logging
+
+from jax._src.lib import xla_bridge as xb, xla_extension as xe, xla_client as xc
+from jax.core import ClosedJaxpr, Var
+from jax.interpreters import partial_eval as pe
+from jax.tree_util import tree_leaves
+
+from alpa.mesh_executable import (NormalMeshDriverExecutable,
+                                  GradAccMeshDriverExecutable,
+                                  PlacementSpec)
+from alpa.shard_parallel.auto_sharding import (run_auto_sharding_pass,
+                                               AutoShardingOption)
+from alpa.util import (jaxpr_to_hlo_module, trace_jaxpr_with_micro_batch,
+                       undefined_sharding_spec_proto)
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+def compile_follow_parallel_executable(fun, in_tree, out_tree_thunk,
+                                       static_argnums, donated_invars,
+                                       batch_invars, src_func,
+                                       num_micro_batches, input_placement_specs,
+                                       pipeline_schedule, layer_option, *avals):
+    executable = src_func.get_last_executable()
+    is_leave = lambda x: isinstance(x, PlacementSpec) or x is None
+    placement_specs = tree_leaves(input_placement_specs, is_leave)
+
+    if isinstance(executable,
+                  (NormalMeshDriverExecutable, GradAccMeshDriverExecutable)):
+        if num_micro_batches != 1 and num_micro_batches is not None:
+            logger.warning("num_micro_batches is ignored in FollowParallel")
+
+        # Trace to get jaxpr and HloModule
+        jaxpr, out_avals, consts = pe.trace_to_jaxpr_final(fun, avals)
+        closed_jaxpr = ClosedJaxpr(jaxpr, consts)
+        out_tree = out_tree_thunk()
+
+        name = f"{fun.__name__}_follow_parallel"
+        hlo_module = jaxpr_to_hlo_module(name, closed_jaxpr, donated_invars)
+
+        # Get input sharding specs
+        sharding_protos = []
+        for spec in placement_specs:
+            if spec is None:
+                sharding_protos.append(undefined_sharding_spec_proto())
+            else:
+                assert len(spec.mesh_ids) == 1
+                sharding_protos.append(spec.sharding_specs[0].sharding_proto())
+
+        # Run sharding propagation
+        physical_mesh = executable.physical_mesh
+        xe.set_hlo_module_input_shardings(hlo_module, sharding_protos)
+        hlo_module, stage_plan = run_auto_sharding_pass(
+            hlo_module, physical_mesh.get_logical_mesh(), "single", 1,
+            AutoShardingOption(enable_auto_sharding=False))
+
+        return NormalMeshDriverExecutable(physical_mesh, hlo_module, stage_plan,
+                                          avals, out_avals,
+                                          [False] * len(avals), static_argnums,
+                                          in_tree, out_tree)
+    else:
+        num_micro_batches = num_micro_batches or 1
+
+        if layer_option == "manual":
+            layer_option = ManualLayerOption()
+        elif layer_option == "auto":
+            layer_option = FollowLayerOption(placement_specs)
+        else:
+            raise ValueError(f"Invalid layer option: {layer_option}")
+
+        return compile_pipeshard_executable(
+            fun, in_tree, out_tree_thunk, static_argnums, donated_invars,
+            batch_invars, mesh, num_micro_batches, pipeline_schedule,
+            AutoShardingOption(enable_auto_sharding=False),
+            layer_option, UniformStageOption(),
+            input_shardings, None, *avals)
+
+#def slice_jaxpr_with_var_assignment(jaxpr, var2mesh):
+#        # Trace to get jaxpr and HloModule
+#        closed_jaxpr, batch_size = trace_jaxpr_with_micro_batch(
+#            fun, batch_invars, num_micro_batches, avals)
+#
+#        if num_microbatch > 1:
+#            # Trace again with a full batch
+#            for store in fun.stores:
+#                if store:
+#                    store.reset()
+#            full_batch_closed_jaxpr, _ = trace_jaxpr_with_micro_batch(
+#                fun, batch_invars, 1, avals)
+#        else:
+#            full_batch_closed_jaxpr = None
+#
+#        # Construct a new pipelined jaxpr
+#        invars = closed_jaxpr.jaxpr.invars
+#
+#        var2mesh = {}  # Dict[var -> mesh_id]
+#
+#        input_shardings = []
+#        for var, spec in zip(invars, placement_specs):
+#            if spec is None:
+#                # Assign input vars to mesh 0 by default
+#                if isinstance(var, Var):
+#                    var2mesh[var] = 0
+#            else:
+#                if isinstance(var, Var):
+#                    var2mesh[var] = spec.mesh_ids[0]
+#                input_shardings.append(spec.sharding_specs[0])
+#
+#        num_meshes = len(executable.mesh_group)
+#        sliced_eqns = slice_jaxpr_with_var_assignment(
+#            closed_jaxpr.jaxpr, var2mesh)
+#        new_jaxpr = add_pipeline_marks_for_sliced_eqns(
+#            closed_jaxpr, sliced_eqns)
+#
+#
+#
+#    mesh_must_eqns = defaultdict(list)   # Dict[mesh_idx -> List[eqn_idx]]
+#
+#    # All direct users of an input var much be on the same mesh of the input var.
+#    for idx, eqn in enumerate(jaxpr.eqns):
+#        if eqn.primitive is pipeline_p:
+#            raise ValueError("FollowParallel is not compatible with manual "
+#                             "pipeline marker. Please do not insert manual "
+#                             "pipeline marker in the function.")
+#        for var in eqn.invars:
+#            if var in var2mesh:
+#                mesh_must_eqns[var2mesh[var]].append(idx)
+#
+#    cost_criteria = "flops"
+#    costs = get_layer_construction_costs(jaxpr, cost_criteria=cost_criteria)
+#    non_trivial, input_sizes, compute_costs = costs
+#
+#    max_cost = np.sum(compute_costs) * 10
+#    for mesh_idx, eqn_indices in mesh_must_eqns:
+#        tmp_cost = max_cost / len(eqn_indices)
+#        for eqn_idx in eqn_indices:
+#            compute_costs[eqn_idx] = tmp_cost
+#
+#    sliced_eqns, _ = cluster_jaxpr_by_cost(jaxpr,
+#					   layer_num=len(mesh_must_eqns),
+#					   eps=0.1,
+#					   costs,
+#					   cost_criteria=cost_criteria)
+#    return sliced_eqns
+#

--- a/alpa/parallel_method.py
+++ b/alpa/parallel_method.py
@@ -315,7 +315,7 @@ class FollowParallel(ParallelMethod):
                  num_micro_batches: Optional[int] = None,
                  get_input_placement_specs: Callable = None,
                  pipeline_schedule: str = "inference",
-                 layer_option: str = "auto"):
+                 layer_option: str = "follow"):
         self.src_func = src_func
         self.num_micro_batches = num_micro_batches
 

--- a/alpa/parallel_method.py
+++ b/alpa/parallel_method.py
@@ -18,7 +18,7 @@ from typing import Callable, Optional, Sequence, Union, Any
 from jax import linear_util as lu
 from jax.core import AbstractValue
 from jax.interpreters import pxla
-from jax.tree_util import PyTreeDef, tree_map
+from jax.tree_util import PyTreeDef
 import numpy as np
 
 from alpa.create_state_parallel import compile_create_state_executable
@@ -229,8 +229,8 @@ class PipeshardParallel(ParallelMethod):
         return compile_pipeshard_executable(
             fun, in_tree, out_tree_thunk, static_argnums, donated_invars,
             batch_invars, mesh, self.num_micro_batches, self.pipeline_schedule,
-            self.as_option, self.layer_option, self.stage_option,
-            None, self.stage_input_shardings, *avals)
+            self.as_option, self.layer_option, self.stage_option, None,
+            self.stage_input_shardings, *avals)
 
 
 class LocalPipelineParallel(ParallelMethod):
@@ -344,12 +344,8 @@ class FollowParallel(ParallelMethod):
         *avals: Sequence[AbstractValue],
     ):
         input_placement_specs = self.get_input_placement_specs()
-        return compile_follow_parallel_executable(fun, in_tree, out_tree_thunk,
-                                                  static_argnums,
-                                                  donated_invars, batch_invars,
-                                                  self.src_func,
-                                                  self.num_micro_batches,
-                                                  input_placement_specs,
-                                                  self.pipeline_schedule,
-                                                  self.layer_option,
-                                                  *avals)
+        return compile_follow_parallel_executable(
+            fun, in_tree, out_tree_thunk, static_argnums, donated_invars,
+            batch_invars, self.src_func, self.num_micro_batches,
+            input_placement_specs, self.pipeline_schedule, self.layer_option,
+            *avals)

--- a/alpa/parallel_method.py
+++ b/alpa/parallel_method.py
@@ -18,10 +18,11 @@ from typing import Callable, Optional, Sequence, Union, Any
 from jax import linear_util as lu
 from jax.core import AbstractValue
 from jax.interpreters import pxla
-from jax.tree_util import PyTreeDef
+from jax.tree_util import PyTreeDef, tree_map
 import numpy as np
 
 from alpa.create_state_parallel import compile_create_state_executable
+from alpa.follow_parallel import compile_follow_parallel_executable
 from alpa.device_mesh import (PhysicalDeviceMesh, VirtualPhysicalMesh,
                               LocalPhysicalDeviceMesh, get_global_physical_mesh,
                               get_global_virtual_physical_mesh)
@@ -107,7 +108,7 @@ class ShardParallel(ParallelMethod):
 class DataParallel(ShardParallel):
     """
     Use vanilla data parallelism.
-    This method syncs gradient by using all-reduce.
+    This method syncs gradients by using all-reduce.
     """
 
     def __init__(self,
@@ -229,7 +230,7 @@ class PipeshardParallel(ParallelMethod):
             fun, in_tree, out_tree_thunk, static_argnums, donated_invars,
             batch_invars, mesh, self.num_micro_batches, self.pipeline_schedule,
             self.as_option, self.layer_option, self.stage_option,
-            self.stage_input_shardings, *avals)
+            None, self.stage_input_shardings, *avals)
 
 
 class LocalPipelineParallel(ParallelMethod):
@@ -264,7 +265,7 @@ class CreateStateParallel(ParallelMethod):
         To use thie parallel method, the function being parallelized should
         return a single output `state`. Then train_step should take `state`
         as the first argument and `other_args` as successive arguments.
-        See tests/test_create_state.py for example usages.
+        See `tests/test_create_state.py` for example usages.
     """
 
     def __init__(self, train_step: "ParallelizedFunc",
@@ -293,3 +294,62 @@ class CreateStateParallel(ParallelMethod):
                                                static_argnums, donated_invars,
                                                self.train_step, self.other_args,
                                                *avals)
+
+
+class FollowParallel(ParallelMethod):
+    """
+    Parallelize a function given its input placement specs.
+
+    Args:
+        num_micro_batches: The number of micro batches.
+        get_input_placement_specs: A callaback function that returns
+          the input placement specs.
+        pipeline_schedule: The pipeline schedule.
+          Possible choices: {"1f1b", "gpipe", "inference"}
+        layer_option: Options of grouping basic operators to layers.
+          Possible choices: {"auto", "manual"}.
+    """
+
+    def __init__(self,
+                 src_func: "ParallelizedFunc",
+                 num_micro_batches: Optional[int] = None,
+                 get_input_placement_specs: Callable = None,
+                 pipeline_schedule: str = "inference",
+                 layer_option: str = "auto"):
+        self.src_func = src_func
+        self.num_micro_batches = num_micro_batches
+
+        if get_input_placement_specs is None:
+
+            def default_get():
+                executable = src_func.get_last_executable()
+                input_placement_specs = executable.get_input_placement_specs()
+                train_state, batch = input_placement_specs
+                return train_state.params, batch
+
+            get_input_placement_specs = default_get
+
+        self.get_input_placement_specs = get_input_placement_specs
+        self.pipeline_schedule = pipeline_schedule
+        self.layer_option = layer_option
+
+    def compile_executable(
+        self,
+        fun: lu.WrappedFun,
+        in_tree: PyTreeDef,
+        out_tree_thunk: Callable[[], PyTreeDef],
+        static_argnums: Sequence[int],
+        donated_invars: Sequence[bool],
+        batch_invars: Sequence[bool],
+        *avals: Sequence[AbstractValue],
+    ):
+        input_placement_specs = self.get_input_placement_specs()
+        return compile_follow_parallel_executable(fun, in_tree, out_tree_thunk,
+                                                  static_argnums,
+                                                  donated_invars, batch_invars,
+                                                  self.src_func,
+                                                  self.num_micro_batches,
+                                                  input_placement_specs,
+                                                  self.pipeline_schedule,
+                                                  self.layer_option,
+                                                  *avals)

--- a/alpa/pipeline_parallel/compile_executable.py
+++ b/alpa/pipeline_parallel/compile_executable.py
@@ -228,7 +228,8 @@ def compile_pipeshard_executable_internal(
         input_sharding_dict = {}
     if global_output_shardings:
         assert len(global_output_shardings) == len(global_outvars)
-        output_sharding_dict = dict(zip(global_outvars, global_output_shardings))
+        output_sharding_dict = dict(zip(global_outvars,
+                                        global_output_shardings))
     else:
         output_sharding_dict = {}
 
@@ -273,8 +274,8 @@ def shard_each_stage(jax_all_stages, virtual_meshes, schedule, n_stages,
                      acc_grad_outvars, donate_invars_dict, num_microbatch,
                      logical_mesh_shapes, autosharding_option_dicts,
                      default_as_option, input_sharding_dict,
-                     output_sharding_dict, stage_input_shardings,
-                     name_base, gensym_func):
+                     output_sharding_dict, stage_input_shardings, name_base,
+                     gensym_func):
     """Run intra-op parallelism compilation for a stage."""
     # Initialize donation mapping
     stage_dict = [[] for _ in range(num_meshes)]
@@ -330,8 +331,8 @@ def shard_each_stage(jax_all_stages, virtual_meshes, schedule, n_stages,
         if distributed_compile:
             module, flops = (generate_sharded_xla_computations_arguments(
                 f"{name_base}_mesh_{mesh_idx}", stage_dict[mesh_idx],
-                stage_donate_invars, input_sharding_dict,
-                output_sharding_dict, stage_input_sharding))
+                stage_donate_invars, input_sharding_dict, output_sharding_dict,
+                stage_input_sharding))
             other_kwargs = {
                 "logical_mesh": logical_mesh,
                 "return_mode": "stages",
@@ -348,8 +349,7 @@ def shard_each_stage(jax_all_stages, virtual_meshes, schedule, n_stages,
                 f"{name_base}_mesh_{mesh_idx}", stage_dict[mesh_idx],
                 stage_donate_invars, donatable_dict[mesh_idx], acc_grad_outvars,
                 num_microbatch, logical_mesh, autosharding_option,
-                input_sharding_dict, output_sharding_dict,
-                stage_input_sharding)
+                input_sharding_dict, output_sharding_dict, stage_input_sharding)
             total_flops += flops
             for i, xla_stage in zip(stage_id_dict[mesh_idx],
                                     sharded_xla_stages):

--- a/alpa/pipeline_parallel/compile_executable.py
+++ b/alpa/pipeline_parallel/compile_executable.py
@@ -46,11 +46,19 @@ def compile_pipeshard_executable(
         virtual_mesh: VirtualPhysicalMesh, num_microbatch: int,
         pipeline_schedule: str, default_as_option: AutoShardingOption,
         layer_option: LayerOption, stage_option: StageOption,
+        global_input_shardings: Optional[Sequence[pxla.ShardingSpec]],
         stage_input_shardings: Optional[Sequence[Sequence[pxla.ShardingSpec]]],
         *avals: Sequence[AbstractValue]):
     """
     Compile a callable for pipeshard parallel which combines
     pipeline parallelism and 2d shard parallelsim.
+
+    Args:
+        fun: The function to be parallelized.
+        global_input_shardings: Forcibly set sharding specs of global
+          input vars.
+        stage_input_shardings: Forcibly set sharding specs of input vars of
+          each stage.
     """
     debug_compilation_time(None)
     name_base = f"{fun.__name__}_pipeshard_parallel"
@@ -58,26 +66,30 @@ def compile_pipeshard_executable(
     if pipeline_schedule == "inference":
         fun.f = layer_option.transform(fun.f)
 
+    # Trace the function wit a micro batch to get the jaxpr.
+    # Apply layer construction to add pipeline markers.
     with GradFuncTransformContext(layer_option.transform):
-        # Trace the function wit a micro batch to get the jaxpr
         closed_jaxpr, micro_batch_size = trace_jaxpr_with_micro_batch(
             fun, batch_invars, num_microbatch, avals)
 
-        if num_microbatch > 1:
-            # Trace again with a full batch
-            for store in fun.stores:
-                if store:
-                    store.reset()
-            full_batch_closed_jaxpr, _ = trace_jaxpr_with_micro_batch(
-                fun, batch_invars, 1, avals)
-        else:
-            full_batch_closed_jaxpr = None
+    # Trace again with a full batch.
+    # The full batch is used to derive the reduction operator across
+    # micro batches (e.g., addition, concatenation).
+    if num_microbatch > 1:
+        for store in fun.stores:
+            if store:
+                store.reset()
+        full_batch_closed_jaxpr, _ = trace_jaxpr_with_micro_batch(
+            fun, batch_invars, 1, avals)
+    else:
+        full_batch_closed_jaxpr = None
     debug_compilation_time("trace")
 
     pipeshard_config = compile_pipeshard_executable_internal(
         closed_jaxpr, full_batch_closed_jaxpr, micro_batch_size, donated_invars,
         batch_invars, virtual_mesh, num_microbatch, pipeline_schedule,
-        default_as_option, stage_option, name_base, None, stage_input_shardings)
+        default_as_option, stage_option, name_base, global_input_shardings,
+        None, stage_input_shardings)
 
     executable = PipeshardDriverExecutable(
         mesh_group=virtual_mesh.launched_physical_mesh_group,
@@ -98,8 +110,19 @@ def compile_pipeshard_executable_internal(
         virtual_mesh: VirtualPhysicalMesh, num_microbatch: int,
         pipeline_schedule: str, default_as_option: AutoShardingOption,
         stage_option: StageOption, name_base: str,
-        output_shardings: Optional[Sequence[pxla.ShardingSpec]],
+        global_input_shardings: Optional[Sequence[pxla.ShardingSpec]],
+        global_output_shardings: Optional[Sequence[pxla.ShardingSpec]],
         stage_input_shardings: Optional[Sequence[Sequence[pxla.ShardingSpec]]]):
+    """
+    Args:
+        fun: The function to be parallelized.
+        global_input_shardings: Forcibly set sharding specs of global
+          input vars.
+        global_output_shardings: Forcibly set sharding specs of global
+          output vars.
+        stage_input_shardings: Forcibly set sharding specs of input vars of
+          each stage.
+    """
     global_invars = closed_jaxpr.jaxpr.invars
     global_outvars = closed_jaxpr.jaxpr.outvars
     gensym_func = gensym([closed_jaxpr.jaxpr])
@@ -193,21 +216,26 @@ def compile_pipeshard_executable_internal(
     else:
         raise ValueError(f"Invalid schedule: {pipeline_schedule}")
 
-    # Call auto-sharding pass to shard each stage
-    if output_shardings:
-        # Forcibly set the sharding specs of global outvars.
-        assert len(output_shardings) == len(global_outvars)
-        output_sharding_dict = dict(zip(global_outvars, output_shardings))
+    # Forcibly set the sharding specs of global invars and outvars.
+    if global_input_shardings:
+        assert len(global_input_shardings) == len(global_outvars)
+        input_sharding_dict = dict(zip(global_outvars, global_input_shardings))
+    else:
+        input_sharding_dict = {}
+    if global_output_shardings:
+        assert len(global_output_shardings) == len(global_outvars)
+        output_sharding_dict = dict(zip(global_outvars, global_output_shardings))
     else:
         output_sharding_dict = {}
 
+    # Call auto-sharding pass to shard each stage
     xla_stages, total_flops = shard_each_stage(
         jax_all_stages, sliced_virtual_meshes, schedule, n_stages, num_meshes,
         grad_in_to_out, global_invars, acc_grad_outvars, donate_invars_dict,
         num_microbatch, manual_stage_option.submesh_logical_shapes,
         manual_stage_option.submesh_autosharding_option_dicts,
-        default_as_option, output_sharding_dict, stage_input_shardings,
-        name_base, gensym_func)
+        default_as_option, input_sharding_dict, output_sharding_dict,
+        stage_input_shardings, name_base, gensym_func)
     total_flops *= num_microbatch
     debug_compilation_time("shard stages")
 
@@ -240,8 +268,9 @@ def shard_each_stage(jax_all_stages, virtual_meshes, schedule, n_stages,
                      num_meshes, grad_in_to_out, global_invars,
                      acc_grad_outvars, donate_invars_dict, num_microbatch,
                      logical_mesh_shapes, autosharding_option_dicts,
-                     default_as_option, output_sharding_dict,
-                     stage_input_shardings, name_base, gensym_func):
+                     default_as_option, input_sharding_dict,
+                     output_sharding_dict, stage_input_shardings,
+                     name_base, gensym_func):
     """Run intra-op parallelism compilation for a stage."""
     # Initialize donation mapping
     stage_dict = [[] for _ in range(num_meshes)]
@@ -297,8 +326,8 @@ def shard_each_stage(jax_all_stages, virtual_meshes, schedule, n_stages,
         if distributed_compile:
             module, flops = (generate_sharded_xla_computations_arguments(
                 f"{name_base}_mesh_{mesh_idx}", stage_dict[mesh_idx],
-                stage_donate_invars, output_sharding_dict,
-                stage_input_sharding))
+                stage_donate_invars, input_sharding_dict,
+                output_sharding_dict, stage_input_sharding))
             other_kwargs = {
                 "logical_mesh": logical_mesh,
                 "return_mode": "stages",
@@ -315,7 +344,8 @@ def shard_each_stage(jax_all_stages, virtual_meshes, schedule, n_stages,
                 f"{name_base}_mesh_{mesh_idx}", stage_dict[mesh_idx],
                 stage_donate_invars, donatable_dict[mesh_idx], acc_grad_outvars,
                 num_microbatch, logical_mesh, autosharding_option,
-                output_sharding_dict, stage_input_sharding)
+                input_sharding_dict, output_sharding_dict,
+                stage_input_sharding)
             total_flops += flops
             for i, xla_stage in zip(stage_id_dict[mesh_idx],
                                     sharded_xla_stages):

--- a/alpa/pipeline_parallel/computation.py
+++ b/alpa/pipeline_parallel/computation.py
@@ -865,12 +865,14 @@ def generate_sharded_xla_computations_arguments(
 
     if input_sharding_dict:
         sharding_protos = []
+        sharding_specs = []
         for x in invars:
-            spec = input_sharding_dict[x]
+            spec = input_sharding_dict.get(x, None)
             if spec is None:
                 sharding_protos.append(undefined_sharding_spec_proto())
             else:
                 sharding_protos.append(spec.sharding_proto())
+            sharding_specs.append(spec)
         xe.set_hlo_module_input_shardings(hlo_module, sharding_protos)
 
     if output_sharding_dict:

--- a/alpa/pipeline_parallel/computation.py
+++ b/alpa/pipeline_parallel/computation.py
@@ -905,8 +905,8 @@ def generate_sharded_xla_computations(
     them together to get a sharding strategy config.
     """
     hlo_module, flops = generate_sharded_xla_computations_arguments(
-        name, jax_computations, computation_donate_invars,
-        input_sharding_dict, output_sharding_dict, stage_input_sharding)
+        name, jax_computations, computation_donate_invars, input_sharding_dict,
+        output_sharding_dict, stage_input_sharding)
 
     #  pylint: disable=unbalanced-tuple-unpacking
     (computation_names, computation_modules,

--- a/alpa/pipeline_parallel/computation.py
+++ b/alpa/pipeline_parallel/computation.py
@@ -29,7 +29,8 @@ from alpa.shard_parallel.auto_sharding import (run_auto_sharding_pass,
 from alpa.global_env import global_config
 from alpa.util import (OrderedSet, clone_jaxpr, get_compile_options,
                        jaxpr_to_hlo_module, setup_computation_alias,
-                       compile_dummy_zero_constant, get_var_mapping)
+                       compile_dummy_zero_constant, get_var_mapping,
+                       undefined_sharding_spec_proto)
 
 # pylint: disable=redefined-builtin
 unsafe_map, map = map, safe_map  # type: ignore
@@ -143,9 +144,8 @@ class XlaPipelineComputation(PipelineComputation):
               JaxPipelineComputation.
         """
         closed_jaxpr = jax_pipeline_computation.closed_jaxpr()
-        backend = xb.get_backend("gpu")
         name = f"pipeline_computation_{jax_pipeline_computation.name}"
-        hlo_module = jaxpr_to_hlo_module(name, closed_jaxpr, None, backend)
+        hlo_module = jaxpr_to_hlo_module(name, closed_jaxpr, None)
 
         return cls(
             name=jax_pipeline_computation.name,
@@ -159,8 +159,7 @@ class XlaPipelineComputation(PipelineComputation):
         out_avals = [var.aval for var in self.outvars]
         tuple_args = len(
             self.invars) > 100  # pass long arg lists as tuple for TPU
-        backend = "gpu"
-        backend = xb.get_backend(backend)
+        backend = xb.get_backend("gpu")
         device = backend.get_default_device_assignment(1)[0]
         options = get_compile_options(
             num_replicas=1,
@@ -212,12 +211,10 @@ class XlaShardedPipelineComputation(PipelineComputation):
     @classmethod
     def dummy_computation(cls, name, logical_mesh_shape, gensym_func):
         """Create a dummy computation."""
-        backend_name = "gpu"
-        backend = xb.get_backend(backend_name)
         stage_plan = StagePlan(global_config.compile_random_seed,
                                logical_mesh_shape, 1, 1, AutoShardingOption(),
                                None, 0)
-        compiled = compile_dummy_zero_constant(backend,
+        compiled = compile_dummy_zero_constant(xb.get_backend("gpu"),
                                                np.prod(logical_mesh_shape))
         sharding_annotated_module = compiled.hlo_modules()[0]
         outvar = gensym_func(ShapedArray((), np.dtype(np.int32)))
@@ -827,6 +824,7 @@ def generate_computations_from_modules(jax_computations, computation_names,
 def generate_sharded_xla_computations_arguments(
         name: str, jax_computations: Sequence[JaxPipelineComputation],
         computation_donate_invars: Sequence[bool],
+        input_sharding_dict: Dict[Var, pxla.ShardingSpec],
         output_sharding_dict: Dict[Var, pxla.ShardingSpec],
         stage_input_sharding: Optional[Sequence[pxla.ShardingSpec]]):
     """
@@ -863,10 +861,17 @@ def generate_sharded_xla_computations_arguments(
     dummy_donated_invars = (True,) * donation_num + (False,) * (len(invars) -
                                                                 donation_num)
     closed_jaxpr = ClosedJaxpr(jaxpr, consts_dir.values())
-    backend_name = "gpu"
-    backend = xb.get_backend(backend_name)
-    hlo_module = jaxpr_to_hlo_module(name, closed_jaxpr, dummy_donated_invars,
-                                     backend)
+    hlo_module = jaxpr_to_hlo_module(name, closed_jaxpr, dummy_donated_invars)
+
+    if input_sharding_dict:
+        sharding_protos = []
+        for x in invars:
+            spec = input_sharding_dict[x]
+            if spec is None:
+                sharding_protos.append(undefined_sharding_spec_proto())
+            else:
+                sharding_protos.append(spec.sharding_proto())
+        xe.set_hlo_module_input_shardings(hlo_module, sharding_protos)
 
     if output_sharding_dict:
         sharding_protos = [
@@ -889,7 +894,7 @@ def generate_sharded_xla_computations(
         name: str, jax_computations: Sequence[JaxPipelineComputation],
         computation_donate_invars, donatable_lists, acc_grad_outvars,
         num_micro_batches, logical_mesh, autosharding_option,
-        output_sharding_dict, stage_input_sharding):
+        input_sharding_dict, output_sharding_dict, stage_input_sharding):
     """
     Generate sharded XLA computations.
 
@@ -898,8 +903,8 @@ def generate_sharded_xla_computations(
     them together to get a sharding strategy config.
     """
     hlo_module, flops = generate_sharded_xla_computations_arguments(
-        name, jax_computations, computation_donate_invars, output_sharding_dict,
-        stage_input_sharding)
+        name, jax_computations, computation_donate_invars,
+        input_sharding_dict, output_sharding_dict, stage_input_sharding)
 
     #  pylint: disable=unbalanced-tuple-unpacking
     (computation_names, computation_modules,

--- a/alpa/pipeline_parallel/layer_construction.py
+++ b/alpa/pipeline_parallel/layer_construction.py
@@ -1,7 +1,8 @@
 """Group small ops into layers and rematerialize at layer boundary."""
 from abc import ABC, abstractmethod
-import logging
+from collections import defaultdict
 from functools import partial, wraps
+import logging
 from typing import Callable, Union, Sequence
 
 import numpy as np
@@ -14,6 +15,7 @@ from jax.core import (Var, Jaxpr, ClosedJaxpr, DropVar, Literal, jaxpr_as_fun,
 from jax.interpreters.partial_eval import remat_call_p
 
 from alpa.global_env import global_config
+from alpa.parallel_plan import PlacementSpec
 from alpa.pipeline_parallel.layer_stats import (global_invar_size,
                                                 is_nontrivial, eqn_flops,
                                                 heavy_count,
@@ -42,14 +44,23 @@ class ManualLayerOption(LayerOption):
     """
     Manually specifying the boundaries of layers by using
     alpa.mark_pipeline_boundary()
+
+    Args:
+      remat_layer: Whether to use gradient rematerialization for each layer.
+      static_argnums: The indices of static arguments of the
+        forward function.
     """
 
-    def __init__(self, remat_layer=False):
+    def __init__(self, remat_layer: bool = False,
+                 static_argnums: Sequence[int] = ()):
         self.remat_layer = remat_layer
+        self.static_argnums = static_argnums
         super().__init__()
 
     def transform(self, func):
-        return manual_layer_construction(func, remat_layer=self.remat_layer)
+        return manual_layer_construction(func,
+                                         static_argnums=self.static_argnums,
+                                         remat_layer=self.remat_layer)
 
 
 class AutoLayerOption(LayerOption):
@@ -59,17 +70,50 @@ class AutoLayerOption(LayerOption):
     resulting layers. You can try a few values for this parameters.
     The best choice of this value depends on the number of nodes in your
     cluster and the number of repetitive blocks in your model.
+
+    Args:
+      layer_num: The number of layers to construct.
+      remat_layer: Whether to use gradient rematerialization for each layer.
+      static_argnums: The indices of static arguments of the
+        forward function.
     """
 
-    def __init__(self, layer_num: int, remat_layer=False):
+    def __init__(self, layer_num: int, remat_layer: bool = False,
+                 static_argnums: Sequence[int] = ()):
         super().__init__()
         self.layer_num = layer_num
         self.remat_layer = remat_layer
+        self.static_argnums = static_argnums
 
     def transform(self, func):
         return automatic_layer_construction(func,
+                                            static_argnums=self.static_argnums,
                                             layer_num=self.layer_num,
                                             remat_layer=self.remat_layer)
+
+
+class FollowLayerOption(LayerOption):
+    """Follow given input placement specs to construct the layer.
+    
+    Args:
+      input_placement_specs: The flatten placement specs of inputs.
+      static_argnums: The indices of static arguments of the
+        forward function.
+    """
+
+    def __init__(self,
+                 input_placement_specs: Sequence[PlacementSpec],
+                 num_meshes: int,
+                 static_argnums: Sequence[int] = ()):
+        self.placement_specs = input_placement_specs
+        self.num_meshes = num_meshes
+        self.static_argnums = static_argnums
+
+    def transform(self, func):
+        return follow_layer_construction(func, 
+                                         self.static_argnums,
+                                         self.placement_specs,
+                                         self.num_meshes)
 
 
 LAYER_HEAVY_OP_LOWER_BOUND = 3
@@ -623,3 +667,81 @@ def automatic_layer_construction(fun: Callable = None,
     else:
         _check_callable(fun)
         return decorate_fun(fun)
+
+
+def follow_layer_construction(fun, static_argnums, input_placement_specs, num_meshes):
+    """Follow given input placement specs to construct layers."""
+    _check_callable(fun)
+
+    @wraps(fun)
+    def wrapped(*args):
+        jaxpr, out_shape_tree = make_jaxpr(fun,
+                                           static_argnums=static_argnums,
+                                           return_shape=True)(*args)
+
+        var2mesh = {}  # Dict[var -> mesh_idx]
+
+        for var, spec in zip(jaxpr.jaxpr.invars, input_placement_specs):
+            if spec is None:
+                # Assign input vars to mesh 0 by default
+                if isinstance(var, Var):
+                    var2mesh[var] = 0
+            else:
+                if isinstance(var, Var):
+                    var2mesh[var] = spec.mesh_ids[0]
+
+        sliced_eqns = slice_jaxpr_with_var_assignment(jaxpr, var2mesh, num_meshes)
+        jaxpr = add_pipeline_marks_for_sliced_eqns(jaxpr, sliced_eqns)
+
+        flatten_args, _ = tree_flatten(args)
+        ans = jaxpr_as_fun(jaxpr)(*flatten_args)  # pylint: disable=not-callable
+        _, out_tree = tree_flatten(out_shape_tree)
+        return tree_unflatten(out_tree, ans)
+
+    return wrapped
+
+
+def slice_jaxpr_with_var_assignment(jaxpr, var2mesh, num_meshes):
+    mesh_begin = [None] * num_meshes
+    mesh_end = [None] * num_meshes
+
+    # Run a linear scan to find the begin and end equations of each mesh.
+    cur_mesh = 0
+    for idx, eqn in enumerate(jaxpr.eqns):
+        if eqn.primitive is pipeline_p:
+            raise ValueError("FollowParallel is not compatible with manual "
+                             "pipeline marker. Please do not insert manual "
+                             "pipeline marker in the function.")
+        for var in eqn.invars:
+            if isinstance(var, Var) and var in var2mesh:
+                mesh_idx = var2mesh[var]
+
+                if mesh_idx > cur_mesh:
+                    cur_mesh = mesh_idx
+
+                if mesh_begin[cur_mesh] is None:
+                    mesh_begin[cur_mesh] = idx
+                mesh_end[cur_mesh] = idx
+
+    # Some boundary equations are not within the ranges detected above.
+    # Use DP algorithm to refine the boundary, so we can minimize the communication
+    # costs.
+    cost_criteria = "flops"
+    costs = get_layer_construction_costs(jaxpr, cost_criteria=cost_criteria)
+    non_trivial, input_sizes, compute_costs = costs
+
+    # To make the solution of DP algorithm respect our begin/end constraint.
+    # We assign begin, end equations a very large cost and run DP
+    # with a small eps.
+    max_cost = np.sum(compute_costs) * 10
+    for i in range(num_meshes):
+        assert mesh_begin[i] is not None and mesh_end[i] is not None
+        compute_costs[mesh_begin[i]] += max_cost
+        compute_costs[mesh_end[i]] += max_cost
+
+    sliced_eqns, _ = cluster_jaxpr_by_cost(jaxpr,
+                                           layer_num=num_meshes,
+                                           eps=0.1,
+                                           costs=costs,
+                                           cost_criteria=cost_criteria)
+    return sliced_eqns

--- a/alpa/pipeline_parallel/runtime_emitter.py
+++ b/alpa/pipeline_parallel/runtime_emitter.py
@@ -686,7 +686,7 @@ class PipelineInstEmitter:
                                                         batch_dim, num_batch)
                 input_shard_indices.append(
                     pxla.spec_to_indices(new_shape, new_spec))
-                input_shard_specs.append(new_spec)
+                input_shard_specs.append(var_to_spec[var])
             else:
                 input_shard_indices.append(
                     pxla.spec_to_indices(var.aval.shape, var_to_spec[var]))

--- a/alpa/pipeline_parallel/stage_profiling.py
+++ b/alpa/pipeline_parallel/stage_profiling.py
@@ -619,8 +619,6 @@ def generate_stage_info(all_layers, selected_indices, donation_mapping,
                         global_outvars, name, insert_hook_after,
                         apply_grad_layers, apply_grad_info):
     """Combine selected layers together for profiling."""
-    backend = xb.get_backend("gpu")
-
     # TODO(yonghao): clean up code here
     (selected_donation_mapping, used_outside,
      layers) = split_global_use_and_donate(all_layers, selected_indices,
@@ -679,7 +677,7 @@ def generate_stage_info(all_layers, selected_indices, donation_mapping,
                                                       new_outvars,
                                                       selected_donation_mapping)
 
-    hlo_module = jaxpr_to_hlo_module(name, merged, is_donated, backend)
+    hlo_module = jaxpr_to_hlo_module(name, merged, is_donated)
     proto = hlo_module.as_serialized_hlo_module_proto()
     compile_config = CompileConfig(proto, output_acc_grad_indices)
     stage_config = StageConfig(compile_config, profile_config, apply_info)

--- a/alpa/util.py
+++ b/alpa/util.py
@@ -334,12 +334,16 @@ def get_compile_options(num_replicas: int, num_partitions: int,
     return compile_options
 
 
-def jaxpr_to_hlo_module(name: str, closed_jaxpr: ClosedJaxpr,
-                        donated_invars: Sequence[bool], backend):
+def jaxpr_to_hlo_module(name: str,
+                        closed_jaxpr: ClosedJaxpr,
+                        donated_invars: Sequence[bool],
+                        backend=None):
     """Convert a jaxpr to an XLA HloModule.
 
     Reference code: jax/jax/_src/dispatch.py::lower_xla_callable
     """
+    if backend is None:
+        backend = xb.get_backend("gpu")
     backend_name = backend.platform
     in_avals = [var.aval for var in closed_jaxpr.jaxpr.invars]
     consts = closed_jaxpr.consts
@@ -666,6 +670,14 @@ class XlaPassContext:
     def __exit__(self, exc_type, exc_value, exc_traceback):
         XlaPassContext.current = None
         xe.clear_pass_context()
+
+
+def undefined_sharding_spec_proto():
+    """Return a proto of ShardingSpec which represents an undefined spec."""
+    # We reuse "Manual" to represent "Undefined"
+    proto = xc.OpSharding()
+    proto.type = xc.OpSharding.Type.MANUAL
+    return proto
 
 
 ########################################

--- a/tests/runtime/test_follow_parallel.py
+++ b/tests/runtime/test_follow_parallel.py
@@ -82,16 +82,13 @@ class FollowParallelTest(unittest.TestCase):
         state = train_step(state, train_batch)
         out = eval_step(state.params, eval_batch)
 
-        if isinstance(method, ShardParallel):
-            actual = jax.tree_flatten(
-                eval_step.get_last_executable().get_input_placement_specs()
-                [0])[0]
-            expected = jax.tree_flatten(
-                train_step.get_last_executable().get_input_placement_specs()
-                [0].params)[0]
-            assert actual == expected
-        elif isinstance(method, PipeshardParallel):
-            raise NotImplementedError
+        actual = jax.tree_flatten(
+            eval_step.get_last_executable().get_input_placement_specs()
+            [0])[0]
+        expected = jax.tree_flatten(
+            train_step.get_last_executable().get_input_placement_specs()
+            [0].params)[0]
+        assert actual == expected
 
     def test_shard_parallel(self):
         method = ShardParallel(num_micro_batches=None)
@@ -109,8 +106,8 @@ class FollowParallelTest(unittest.TestCase):
 
 def suite():
     suite = unittest.TestSuite()
-    #suite.addTest(FollowParallelTest("test_shard_parallel"))
-    #suite.addTest(FollowParallelTest("test_shard_parallel_grad_acc"))
+    suite.addTest(FollowParallelTest("test_shard_parallel"))
+    suite.addTest(FollowParallelTest("test_shard_parallel_grad_acc"))
     suite.addTest(FollowParallelTest("test_pipeshard_parallel"))
     return suite
 

--- a/tests/runtime/test_follow_parallel.py
+++ b/tests/runtime/test_follow_parallel.py
@@ -83,8 +83,7 @@ class FollowParallelTest(unittest.TestCase):
         out = eval_step(state.params, eval_batch)
 
         actual = jax.tree_flatten(
-            eval_step.get_last_executable().get_input_placement_specs()
-            [0])[0]
+            eval_step.get_last_executable().get_input_placement_specs()[0])[0]
         expected = jax.tree_flatten(
             train_step.get_last_executable().get_input_placement_specs()
             [0].params)[0]
@@ -99,8 +98,8 @@ class FollowParallelTest(unittest.TestCase):
         self.run_test(method)
 
     def test_pipeshard_parallel(self):
-        method = PipeshardParallel(num_micro_batches=2,
-                                   layer_option=alpa.AutoLayerOption(layer_num=2))
+        method = PipeshardParallel(
+            num_micro_batches=2, layer_option=alpa.AutoLayerOption(layer_num=2))
         self.run_test(method)
 
 

--- a/tests/runtime/test_follow_parallel.py
+++ b/tests/runtime/test_follow_parallel.py
@@ -1,0 +1,120 @@
+"""Test following another parallel strategy."""
+import unittest
+
+from flax import linen as nn
+from flax.training.train_state import TrainState
+import jax
+from jax._src.api import make_jaxpr
+import jax.numpy as jnp
+import optax
+
+import alpa
+from alpa import (init, shutdown, parallelize, ShardParallel, PipeshardParallel,
+                  CreateStateParallel)
+
+
+class FollowParallelTest(unittest.TestCase):
+
+    def setUp(self):
+        init(cluster="ray")
+
+    def tearDown(self):
+        shutdown()
+
+    def run_test(self, method):
+        use_bias = True
+        batch_size = 32
+        input_dim = output_dim = hidden_dim = 8
+
+        class Model(nn.Module):
+
+            @nn.compact
+            def __call__(self, x):
+                x = nn.Dense(features=hidden_dim, use_bias=use_bias)(x)
+                x = nn.Dense(features=hidden_dim, use_bias=use_bias)(x)
+                x = nn.Dense(features=hidden_dim, use_bias=use_bias)(x)
+                x = nn.Dense(features=output_dim, use_bias=use_bias)(x)
+                return x
+
+        def train_step(state, batch):
+
+            def loss_func(params):
+                out = state.apply_fn(params, batch["x"])
+                return jnp.mean((out - batch["y"])**2)
+
+            grads = alpa.grad(loss_func)(state.params)
+            new_state = state.apply_gradients(grads=grads)
+            return new_state
+
+        def eval_step(params, batch):
+            out = state.apply_fn(params, batch["x"])
+            return jnp.mean((out - batch["y"])**2)
+
+        def create_state():
+            model = Model()
+            rngkey = jax.random.PRNGKey(0)
+            params = model.init(rngkey, jnp.ones((1, input_dim)))
+            tx = optax.adam(learning_rate=1e-2)
+            return TrainState.create(apply_fn=model.apply, params=params, tx=tx)
+
+        train_batch = {
+            "x": jnp.ones((batch_size, input_dim)),
+            "y": jnp.ones((batch_size, output_dim)),
+        }
+        eval_batch = {
+            "x": jnp.ones((batch_size * 2, input_dim)),
+            "y": jnp.ones((batch_size * 2, output_dim)),
+        }
+
+        if isinstance(method, ShardParallel):
+            num_micro_batches = None
+        else:
+            num_micro_batches = 2
+
+        state = create_state()
+
+        train_step = parallelize(train_step, method=method)
+        eval_step = parallelize(eval_step,
+                                method=alpa.FollowParallel(
+                                    train_step,
+                                    num_micro_batches=num_micro_batches))
+
+        state = train_step(state, train_batch)
+        out = eval_step(state.params, eval_batch)
+
+        if isinstance(method, ShardParallel):
+            actual = jax.tree_flatten(
+                eval_step.get_last_executable().get_input_placement_specs()
+                [0])[0]
+            expected = jax.tree_flatten(
+                train_step.get_last_executable().get_input_placement_specs()
+                [0].params)[0]
+            assert actual == expected
+        elif isinstance(method, PipeshardParallel):
+            raise NotImplementedError
+
+    def test_shard_parallel(self):
+        method = ShardParallel(num_micro_batches=None)
+        self.run_test(method)
+
+    def test_shard_parallel_grad_acc(self):
+        method = ShardParallel(num_micro_batches=2)
+        self.run_test(method)
+
+    def test_pipeshard_parallel(self):
+        method = PipeshardParallel(num_micro_batches=2,
+                                   layer_option=alpa.AutoLayerOption(layer_num=2))
+        self.run_test(method)
+
+
+def suite():
+    suite = unittest.TestSuite()
+    #suite.addTest(FollowParallelTest("test_shard_parallel"))
+    #suite.addTest(FollowParallelTest("test_shard_parallel_grad_acc"))
+    suite.addTest(FollowParallelTest("test_pipeshard_parallel"))
+    return suite
+
+
+if __name__ == "__main__":
+    runner = unittest.TextTestRunner()
+    runner.run(suite())


### PR DESCRIPTION
We can use `method=FollowParallel()` to let a function follow the parallelization strategy of another function. For example, let eval_step follow the train_step.

```python
train_step = parallelize(train_step, method=method)
eval_step = parallelize(eval_step,
                        method=alpa.FollowParallel(
                            train_step,
                            num_micro_batches=num_micro_batches))
```

This works for both ShardParallel and PipeshardParallel.