### PR TITLE
add logprobs endpoint with caching past key values

### DIFF
--- a/examples/opt_serving/service/constants.py
+++ b/examples/opt_serving/service/constants.py
@@ -9,3 +9,7 @@ MAX_BS = 8
 # Generation-related params
 NUM_BEAMS = 1
 NUM_RETURN_SEQ = 1
+
+# Logprobs endpoint cache-related params
+LOGPROBS_PAST_CACHE_TIMEOUT = 60 * 10 # 10 minutes
+LOGPROBS_PAST_CACHE_SIZE_LIMIT = 20 # max sets of past_key_values to keep at a time in cache


### PR DESCRIPTION
Hi, 

I'd like to be able to modify the logits before sampling at each step of generation, so I implemented a logprobs endpoint which returns logprobs based on top-p and top-k and also caches past_key_values. To avoid mixing work items with the existing completions endpoint, I made a separate queue for the new endpoint. The past_key_values cache removes old items after 10 minutes or after it gets too full. 

I was hoping to integrate the new endpoint more with the existing completions endpoint which calls huggingface's generate() method, but it seems like this might not be possible at the moment due to generate() not supporting returning past key values pending this PR https://github.com/huggingface/transformers/pull/17574. 

Also, the new endpoint does everything with batch size 1 to avoid needing to mix past_key_values from different calls, but then pads up to batch size MAX_BS=16 anyway since that's what the model interface seems to expect. Not sure if this would be a problem down the line. 

Please let me know if there's something implemented in a problematic way and I can try to fix it. Would really like to be able to run controlled generation approaches with these larger models. 