### PR TITLE
[Alpa Runtime] update the alpa api for resources awareness

### DIFF
--- a/alpa/api.py
+++ b/alpa/api.py
@@ -21,7 +21,9 @@ traceback_util.register_exclusion(__file__)
 is_initialized = False
 
 
-def init(cluster: str = "ray"):
+def init(cluster: str = "ray",
+         devices_per_node: int = None,
+         num_nodes: int = None):
     """Initialize the global environment.
 
     Args:
@@ -36,7 +38,7 @@ def init(cluster: str = "ray"):
         return
     is_initialized = True
 
-    init_global_cluster(cluster)
+    init_global_cluster(cluster, devices_per_node, num_nodes)
 
 
 def shutdown():

--- a/alpa/api.py
+++ b/alpa/api.py
@@ -26,11 +26,20 @@ def init(cluster: str = "ray",
          num_nodes: int = None):
     """Initialize the global environment.
 
+    `devices_per_node, num_nodes` are used to specify the number of devices.
+    If not specified, the number of devices is determined automatically and
+    the whole cluster is used.
+
+    For simplicity, the resource specification is only supported for
+    ray cluster.
+
     Args:
       cluster: The distributed cluster.
         Possible choices: {"local", "ray"}.
         "local" means using all local devices on a single node.
         "ray" means using all devices in a ray cluster.
+      devices_per_node: The number of devices per node.
+      num_nodes: The number of nodes.
     """
     global is_initialized
 

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -2035,7 +2035,7 @@ class DeviceCluster:
             self.host_num_devices.append(int(number))
 
         # adjust the resource allocations
-        # if `num_nodes` is set, use it. 
+        # if `num_nodes` is set, use it.
         # otherwise, use the number of nodes in cluster
         if num_nodes:
             num_hosts = min(num_nodes, self.num_hosts)

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -1011,7 +1011,7 @@ class DistributedPhysicalDeviceMesh(PhysicalDeviceMesh):
             bundle_index = device_bundle_idx_list[i]
 
             # Launch the DaemonMoveWorker
-            cls = ray.remote(num_cpus=1e-4)(DaemonMoveWorker)
+            cls = ray.remote(num_cpus=0)(DaemonMoveWorker)
             move_worker = cls.options(
                 placement_group=placement_group,
                 placement_group_bundle_index=bundle_index).remote()

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -2059,7 +2059,7 @@ class DeviceCluster:
 
         # update the Device Cluster info
         if devices_per_node or num_nodes:
-            self._updte_cluster_resource_from_placement_group()
+            self._update_cluster_resource_from_placement_group()
 
     def _update_cluster_resource_from_placement_group(self):
         """Update the cluster resource from the placement group."""

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -1011,7 +1011,7 @@ class DistributedPhysicalDeviceMesh(PhysicalDeviceMesh):
             bundle_index = device_bundle_idx_list[i]
 
             # Launch the DaemonMoveWorker
-            cls = ray.remote(num_cpus=0)(DaemonMoveWorker)
+            cls = ray.remote(num_cpus=1e-4)(DaemonMoveWorker)
             move_worker = cls.options(
                 placement_group=placement_group,
                 placement_group_bundle_index=bundle_index).remote()

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -55,7 +55,7 @@ from alpa.timer import timers
 from alpa.util import (benchmark_func, list_gpu_info, OrderedSet,
                        update_jax_platform, is_ray_node_resource,
                        try_import_ray_worker, create_placement_group,
-                       get_bundle_idx, retrieve_placement_group)
+                       get_bundle_idx, retrieve_placement_group, get_bundle2ip)
 
 ray_worker = try_import_ray_worker()
 
@@ -2006,7 +2006,7 @@ class DeviceCluster:
     This is the top interface for alpa to interact with ray cluster's resources.
     """
 
-    def __init__(self):
+    def __init__(self, devices_per_node: int = None, num_nodes: int = None):
         # pylint: disable=import-outside-toplevel
         ray_global_node = ray_worker._global_node
         try:
@@ -2019,10 +2019,13 @@ class DeviceCluster:
 
         # Gather host ids
         self.host_info = []
+        self.host_ips = []
+
         for node in ray.nodes():
             for key in node["Resources"]:
                 if is_ray_node_resource(key):
                     self.host_info.append(node)
+                    self.host_ips.append(key.split("node:")[-1])
 
         # Gather device info
         self.host_num_devices = []
@@ -2031,9 +2034,49 @@ class DeviceCluster:
             assert number.is_integer()
             self.host_num_devices.append(int(number))
 
+        # adjust the resource allocations
+        if num_nodes:
+            num_hosts = min(num_nodes, self.num_hosts)
+        else:
+            num_hosts = self.num_hosts
+
+        if devices_per_node:
+            # verify that the number of devices per node is valid
+            num_valid = sum(num_device >= devices_per_node
+                            for num_device in self.host_num_devices)
+            if num_valid < num_nodes:
+                raise RuntimeError("The number of devices per node is invalid. "
+                                   f"There are only {num_valid} valid nodes.")
+            # NOTE: for simplicity, we assume `devices_per_node` are equal.
+            self.host_num_devices = [devices_per_node] * num_hosts
+
         # Create placement group
         self.placement_group = create_placement_group(self.num_hosts,
                                                       self.host_num_devices)
+
+        if devices_per_node or num_nodes:
+            self._updte_cluster_resource_from_placement_group()
+
+    def _update_cluster_resource_from_placement_group(self):
+
+        # map: host ip to host info
+        self.dict_host_ip2info = dict(zip(self.host_ips, self.host_info))
+
+        # get bundle's ip address
+        ips = get_bundle2ip(self.placement_group)
+        bundle_specs = self.placement_group.bundle_specs
+
+        # filter out the bundle index with device (GPUs)
+        device_bundle_idx_list = [
+            i for i, bundle_spec in enumerate(bundle_specs)
+            if bundle_spec.get("GPU", 0) > 0
+        ]
+        self.host_ips = [
+            ips[bundle_idx] for bundle_idx in device_bundle_idx_list
+        ]
+
+        # filter nodes according to the placment group
+        self.host_info = [self.dict_host_ip2info[ip] for ip in ips]
 
     def delete_placement_group(self):
         """remove the placement group for the current device cluster."""
@@ -2118,7 +2161,9 @@ global_physical_mesh: PhysicalDeviceMesh = None
 global_virtual_physical_mesh: VirtualPhysicalMesh = None
 
 
-def init_global_cluster(cluster: str):
+def init_global_cluster(cluster: str,
+                        devices_per_node: int = None,
+                        num_nodes: int = None):
     global global_cluster, global_physical_mesh, global_virtual_physical_mesh
 
     if cluster == "local":
@@ -2127,7 +2172,7 @@ def init_global_cluster(cluster: str):
         if not ray.is_initialized():
             ray.init(address="auto", ignore_reinit_error=True)
         update_jax_platform("cpu")
-        global_cluster = DeviceCluster()
+        global_cluster = DeviceCluster(devices_per_node, num_nodes)
         global_virtual_physical_mesh = (
             global_cluster.get_virtual_physical_mesh())
 

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -2035,11 +2035,14 @@ class DeviceCluster:
             self.host_num_devices.append(int(number))
 
         # adjust the resource allocations
+        # if `num_nodes` is set, use it. 
+        # otherwise, use the number of nodes in cluster
         if num_nodes:
             num_hosts = min(num_nodes, self.num_hosts)
         else:
             num_hosts = self.num_hosts
 
+        # if `devices_per_node` is set, use it.
         if devices_per_node:
             # verify that the number of devices per node is valid
             num_valid = sum(num_device >= devices_per_node
@@ -2054,11 +2057,12 @@ class DeviceCluster:
         self.placement_group = create_placement_group(self.num_hosts,
                                                       self.host_num_devices)
 
+        # update the Device Cluster info
         if devices_per_node or num_nodes:
             self._updte_cluster_resource_from_placement_group()
 
     def _update_cluster_resource_from_placement_group(self):
-
+        """Update the cluster resource from the placement group."""
         # map: host ip to host info
         self.dict_host_ip2info = dict(zip(self.host_ips, self.host_info))
 

--- a/tests/run_all.py
+++ b/tests/run_all.py
@@ -101,7 +101,6 @@ if __name__ == "__main__":
     args = arg_parser.parse_args()
 
     files = glob.glob("**/test_*.py", recursive=True)
-
     if args.order == "sorted":
         files.sort()
     elif args.order == "random":

--- a/tests/run_all.py
+++ b/tests/run_all.py
@@ -100,7 +100,9 @@ if __name__ == "__main__":
                             choices=["sorted", "random", "reverse_sorted"])
     args = arg_parser.parse_args()
 
-    files = glob.glob("**/test_*.py", recursive=True)
+    # files = glob.glob("**/test_*.py", recursive=True)
+    files = glob.glob("**/test_device_mesh.py", recursive=True)
+    
     if args.order == "sorted":
         files.sort()
     elif args.order == "random":

--- a/tests/run_all.py
+++ b/tests/run_all.py
@@ -102,7 +102,7 @@ if __name__ == "__main__":
 
     # files = glob.glob("**/test_*.py", recursive=True)
     files = glob.glob("**/test_device_mesh.py", recursive=True)
-    
+
     if args.order == "sorted":
         files.sort()
     elif args.order == "random":

--- a/tests/run_all.py
+++ b/tests/run_all.py
@@ -100,8 +100,7 @@ if __name__ == "__main__":
                             choices=["sorted", "random", "reverse_sorted"])
     args = arg_parser.parse_args()
 
-    # files = glob.glob("**/test_*.py", recursive=True)
-    files = glob.glob("**/test_device_mesh.py", recursive=True)
+    files = glob.glob("**/test_*.py", recursive=True)
 
     if args.order == "sorted":
         files.sort()

--- a/tests/runtime/test_device_mesh.py
+++ b/tests/runtime/test_device_mesh.py
@@ -62,11 +62,25 @@ class DeviceMeshTest(unittest.TestCase):
         assert isinstance(a, DistributedArray)
 
 
+class DeviceMesh_ResourceAwareness(unittest.TestCase):
+
+    def setUp(self):
+        init(cluster="ray", devices_per_node=2, num_nodes=1)
+
+    @unittest.skipIf(jax.local_device_count("gpu") < 8, "no enough device")
+    def test_resource_check(self):
+        cluster_devices = ray.cluster_resources().get("GPU", 0)
+        available_devices = ray.available_resources().get("GPU", 0)
+        assert available_devices + 2 == cluster_devices
+
+
 def suite():
     suite = unittest.TestSuite()
     suite.addTest(DeviceMeshTest("test_add_one"))
     suite.addTest(DeviceMeshTest("test_distributed_array"))
     suite.addTest(DeviceMeshTest("test_preshard_args"))
+    suite.addTest(DeviceMeshTest("test_preshard_args"))
+    suite.addTest(DeviceMesh_ResourceAwareness("test_resource_check"))
 
     return suite
 

--- a/tests/runtime/test_device_mesh.py
+++ b/tests/runtime/test_device_mesh.py
@@ -11,7 +11,7 @@ from jax.interpreters import pxla
 import numpy as np
 import ray
 
-from alpa import init, parallelize, DistributedArray
+from alpa import init, shutdown, parallelize, DistributedArray
 from alpa.device_mesh import get_global_physical_mesh
 from alpa.testing import assert_allclose
 
@@ -20,6 +20,9 @@ class DeviceMeshTest(unittest.TestCase):
 
     def setUp(self):
         init(cluster="ray")
+
+    def tearDown(self):
+        shutdown()
 
     def test_add_one(self):
 
@@ -66,6 +69,9 @@ class DeviceMesh_ResourceAwareness(unittest.TestCase):
 
     def setUp(self):
         init(cluster="ray", devices_per_node=2, num_nodes=1)
+
+    def tearDown(self):
+        shutdown()
 
     @unittest.skipIf(jax.local_device_count("gpu") < 8, "no enough device")
     def test_resource_check(self):

--- a/tests/runtime/test_device_mesh.py
+++ b/tests/runtime/test_device_mesh.py
@@ -71,6 +71,7 @@ class DeviceMesh_ResourceAwareness(unittest.TestCase):
     def test_resource_check(self):
         cluster_devices = ray.cluster_resources().get("GPU", 0)
         available_devices = ray.available_resources().get("GPU", 0)
+        print(cluster_devices, available_devices, ray.cluster_resources(), ray.available_resources())
         assert available_devices + 2 == cluster_devices
 
 

--- a/tests/runtime/test_device_mesh.py
+++ b/tests/runtime/test_device_mesh.py
@@ -71,7 +71,8 @@ class DeviceMesh_ResourceAwareness(unittest.TestCase):
     def test_resource_check(self):
         cluster_devices = ray.cluster_resources().get("GPU", 0)
         available_devices = ray.available_resources().get("GPU", 0)
-        print(cluster_devices, available_devices, ray.cluster_resources(), ray.available_resources())
+        print(cluster_devices, available_devices, ray.cluster_resources(),
+              ray.available_resources())
         assert available_devices + 2 == cluster_devices
 
 


### PR DESCRIPTION
> Hello! Sorry maybe a silly question, but is there a configuration for alpa to use only a subset of the # of gpus? (Ie. only run 2 cores when 8 cores are available) Do I have to create a device mesh for it? 


People prefer to set the configuration for the alpa instead of using the whole cluster. This PR is try to enrich the resources allocation with a easy-to-use api.

![image](https://user-images.githubusercontent.com/20907377/184989169-02928f36-452c-47ed-b2d7-1ceb8feba105.png)

@zhisbug @merrymercy 



- [x] adding the `cpu=1e-4` for the `daemonworker`. 