### PR TITLE
[OPT] Change the default torch device to CPU & Use multiple executables by default

### DIFF
--- a/examples/opt_finetune/README.md
+++ b/examples/opt_finetune/README.md
@@ -46,7 +46,7 @@ python3 run_clm_flax.py \
     --learning_rate="5e-4" --warmup_steps="2000" \
     --adam_beta1="0.9" --adam_beta2="0.98" --weight_decay="0.01" \
     --overwrite_output_dir \
-    --num_train_epochs="20" \
+    --num_train_epochs="8" \
     --logging_steps="16" \
     --save_steps="2500" \
     --eval_steps="2500"

--- a/examples/opt_serving/README.rst
+++ b/examples/opt_serving/README.rst
@@ -221,7 +221,16 @@ Launch the web server:
 
 Then open ``https://[IP-ADDRESS]:20001`` in your browser to try out the model!
 
-Code structure
+Improving Generation Speed
+==========================
+Here are some tips for improving the generation speed.
+1. Batching. Single sequence generation cannot fully utilize the GPU power. Applying batching can greatly boost the performace. See ``textgen_demo.py`` for the usage.
+2. Tune the ``encoder_chunk_sizes`` argument of ``get_model``. Alpa compiles multiple executables and uses these executables to encode a prompt chunk by chunk. This argument controls the possible chunk sizes. Depending on the length of your prompt, you can try different combinations. For example, if your prompt lengths are around 1000-1500, a good combination is ``[1, 256, 1024]``.
+3. Tune parallelization strategy. If you are familiar with alpa, you can tune the ``method`` argument of ``alpa.parallelize`` and try different parallelization methods.
+
+If you find the generation speed too slow and want to accelerate it, please join `Alpa slack <https://forms.gle/YEZTCrtZD6EAVNBQ7>`_ and tell us your use cases. We are acitvely working on improving the performance.
+
+Code Structure
 ==============
 
 * `examples/opt_serving/benchmark <https://github.com/alpa-projects/alpa/tree/main/examples/opt_serving/benchmark>`_: Benchmark scripts for generation in the command line.

--- a/examples/opt_serving/README.rst
+++ b/examples/opt_serving/README.rst
@@ -223,8 +223,11 @@ Then open ``https://[IP-ADDRESS]:20001`` in your browser to try out the model!
 Improving Generation Speed
 ==========================
 Here are some tips for improving the generation speed.
-1. Batching. Single sequence generation cannot fully utilize the GPU power. Applying batching can greatly boost the performace. See ``textgen_demo.py`` for the usage.
-2. Tune the ``encoder_chunk_sizes`` argument of ``get_model``. Alpa compiles multiple executables and uses these executables to encode a prompt chunk by chunk. This argument controls the possible chunk sizes. Depending on the length of your prompt, you can try different combinations. For example, if your prompt lengths are around 1000-1500, a good combination is ``[1, 256, 1024]``.
+
+1. Batching. Single sequence generation cannot fully utilize the GPU power.
+   Applying batching can greatly boost the performace. See ``textgen_demo.py`` for the usage.
+2. Tune the ``encoder_chunk_sizes`` argument of ``get_model``.
+   Alpa compiles multiple executables and uses these executables to encode a prompt chunk by chunk. This argument controls the possible chunk sizes. Depending on the length of your prompt, you can try different combinations. For example, if your prompt lengths are around 1000-1500, a good combination is ``[1, 256, 1024]``.
 3. Tune parallelization strategy. If you are familiar with alpa, you can tune the ``method`` argument of ``alpa.parallelize`` and try different parallelization methods.
 
 If you find the generation speed too slow and want to accelerate it, please join `Alpa slack <https://forms.gle/YEZTCrtZD6EAVNBQ7>`_ and tell us your use cases. We are acitvely working on improving the performance.

--- a/examples/opt_serving/README.rst
+++ b/examples/opt_serving/README.rst
@@ -49,13 +49,12 @@ Use huggingface/transformers interface and Alpa backend for distributed inferenc
 
   # Load the model
   model = get_model(model_name="alpa/opt-2.7b",
-                    device="cuda",
                     path="/home/ubuntu/opt_weights/")
 
   # Generate
   prompt = "Paris is the capital city of"
 
-  input_ids = tokenizer(prompt, return_tensors="pt").input_ids.to("cuda")
+  input_ids = tokenizer(prompt, return_tensors="pt").input_ids
   output = model.generate(input_ids=input_ids, max_length=256, do_sample=True)
   generated_string = tokenizer.batch_decode(output, skip_special_tokens=True)
 

--- a/examples/opt_serving/generator.py
+++ b/examples/opt_serving/generator.py
@@ -120,10 +120,11 @@ class GeneratorInterface:
     def load_model(self):
         """Load model and return the model wrapper."""
         tic = time.time()
-        self.model_wrapper = get_model(self.model_name, "cuda", self.path,
+        self.model_wrapper = get_model(self.model_name, self.path,
+                                       torch_device="cuda",
                                        autoregressive=True,
                                        batch_size=MAX_BS,
-                                       encoder_seq_lengths=[1, 64],
+                                       encoder_chunk_sizes=[1, 64],
                                        max_target_positions=MAX_SEQ_LEN)
         load_time = time.time() - tic
 

--- a/examples/opt_serving/model/wrapper.py
+++ b/examples/opt_serving/model/wrapper.py
@@ -473,7 +473,7 @@ def get_model(model_name: str,
                 past_key_values = output.attention_cache
                 i += step_input_ids.shape[1]
 
-        logits_step = torch.from_numpy(np.array(output.logits)).to(torch_device)
+        logits_step = torch.from_numpy(np.array(output.logits)).to(torch_device).float32()
         return InferenceFuncOutput(logits_step, output.attention_cache,
                                    output.hidden_states, output.attentions)
 

--- a/examples/opt_serving/model/wrapper.py
+++ b/examples/opt_serving/model/wrapper.py
@@ -372,6 +372,8 @@ def get_model(model_name: str,
                        attention_mask,
                        output_attentions,
                        output_hidden_states):
+        assert input_ids.shape[0] == expand_size, (
+            f"Expect batch size = {expand_size}, but got {input_ids.shape[0]}")
         input_ids = input_ids.cpu().numpy()
         attention_mask = attention_mask.cpu().numpy()
 

--- a/examples/opt_serving/model/wrapper.py
+++ b/examples/opt_serving/model/wrapper.py
@@ -473,7 +473,7 @@ def get_model(model_name: str,
                 past_key_values = output.attention_cache
                 i += step_input_ids.shape[1]
 
-        logits_step = torch.from_numpy(np.array(output.logits)).to(torch_device).float32()
+        logits_step = torch.from_numpy(np.array(output.logits)).to(torch_device).float()
         return InferenceFuncOutput(logits_step, output.attention_cache,
                                    output.hidden_states, output.attentions)
 

--- a/examples/opt_serving/model/wrapper.py
+++ b/examples/opt_serving/model/wrapper.py
@@ -2,7 +2,7 @@
 from collections import defaultdict
 import os
 import time
-from typing import Sequence, Any
+from typing import Sequence, Any, Optional
 
 import alpa
 from alpa.device_mesh import DistributedArray
@@ -219,18 +219,19 @@ def get_hf_opt_model(model_name, device, num_beams):
 
 
 def get_model(model_name: str,
-              device: str,
               # Weights
               path: str,
               dummy: bool = False,
-              # Model parameters
-              autoregressive: bool = True,
-              dtype=jnp.float16,
               # Batch size and seq length
               batch_size: int = 1,
               num_micro_batches: int = 1,
               max_target_positions: int = 2048,
-              encoder_seq_lengths: Sequence[int] = [1],
+              encoder_chunk_sizes: Sequence[int] = (1, 64),
+              num_pp_stages: Optional[int] = None,
+              # Model parameters
+              autoregressive: bool = True,
+              dtype=jnp.float16,
+              torch_device: str = "cpu",
               # Shared arguments with model.generate
               do_sample: bool = False,
               num_beams: int = 1,
@@ -242,12 +243,21 @@ def get_model(model_name: str,
 
     Args:
         model_name: "facebook/opt-", or "alpa/opt-".
-        device: "cpu" or "gpu". This only controls the device used
-          by pytorch. Alpa always runs on GPU.
         path: The path to opt weights.
         dummy: Use dummy weights for faster debugging.
-        encoder_seq_lengths: compile mutliple executables for multiple
-          encoder sequence lengths.
+        batch_size: The batch size.
+        num_micro_batches: The number of micro batch sizs in pipeline
+          parallelism.
+        max_target_positions: The max sequence length.
+        encoder_chunk_sizes: Compile mutliple executables with different
+          chunk sizes. These executables are used to encoding prompts
+          chunk by chunk.
+        num_pp_stages: The number of pipeline parallelism stages.
+        autoregressive: Whether to run the model for autoregressive generation.
+        dtype: The type of parameters.
+        torch_device: "cpu" or "gpu". This only controls the device used
+          by pytorch. Alpa always runs on GPU.
+        other parameters: shared with huggingface's model.generate API.
     """
     if not model_name.startswith("alpa") and not autoregressive:
         raise NotImplementedError(
@@ -257,14 +267,15 @@ def get_model(model_name: str,
             f"Cannot support num_micro_batches > 1 in autoregressive mode.")
 
     if "facebook/opt" in model_name:
-        return get_hf_opt_model(model_name, device, num_beams)
+        return get_hf_opt_model(model_name, torch_device, num_beams)
 
     assert ("jax/opt" in model_name or "alpa/opt" in model_name)
     assert return_dict_in_generate
 
-    if autoregressive and 1 not in encoder_seq_lengths:
-        encoder_seq_lengths += [1]
-    encoder_seq_lengths.sort()
+    if autoregressive and 1 not in encoder_chunk_sizes:
+        encoder_chunk_sizes += [1]
+    encoder_chunk_sizes = list(set(encoder_chunk_sizes))
+    encoder_chunk_sizes.sort()
 
     # weight path
     name = model_name.split("-")[1].upper()
@@ -296,7 +307,7 @@ def get_model(model_name: str,
             vocab_size=config.vocab_size)
 
         executables, params_aval = get_jax_executable(
-            config, encoder_seq_lengths,
+            config, encoder_chunk_sizes,
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states)
 
@@ -314,9 +325,10 @@ def get_model(model_name: str,
             f"Load model {model_name} ... (This can take several minutes for very large models)"
         )
 
-        num_pp_stages = max(2, alpa.get_global_cluster().num_hosts)
-        num_pp_stages = min(num_pp_stages,
-                            alpa.get_global_cluster().num_devices)
+        if num_pp_stages is None:
+            num_pp_stages = max(2, alpa.get_global_cluster().num_hosts)
+            num_pp_stages = min(num_pp_stages,
+                                alpa.get_global_cluster().num_devices)
         config = get_opt_config(name,
                                 num_pp_stages=num_pp_stages,
                                 dtype=dtype,
@@ -328,13 +340,13 @@ def get_model(model_name: str,
             seq_len=config.max_target_positions,
             vocab_size=config.vocab_size)
 
-        print(f" - Compile executables for encoder_seq_lengths={encoder_seq_lengths}. ", end="", flush=True)
+        print(f" - Compile executables for encoder_chunk_sizes={encoder_chunk_sizes}. ", end="", flush=True)
         tic = time.time()
         executables, params_aval = get_pipeshard_executable(
             config,
             batch_size=expand_size,
             num_micro_batches=num_micro_batches,
-            encoder_seq_lengths=encoder_seq_lengths,
+            encoder_chunk_sizes=encoder_chunk_sizes,
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             autoregressive=autoregressive)
@@ -353,9 +365,9 @@ def get_model(model_name: str,
                                                                dummy=dummy)
             set_skip_shard_args_check(init_cache)
 
-        print(f"elapsed: {time.time() - tic:.2f} second.")
         for executable in executables.values():
             executable.sync()
+        print(f"elapsed: {time.time() - tic:.2f} second.")
 
         # return executable directly if not autoregressive
         if not autoregressive:
@@ -435,7 +447,7 @@ def get_model(model_name: str,
             i = 0
             while i < seq_len:
                 remaining = seq_len - i
-                step_len = get_padded_step_len(remaining, encoder_seq_lengths)
+                step_len = get_padded_step_len(remaining, encoder_chunk_sizes)
 
                 step_input_ids = input_ids[:, i:i + step_len]
                 step_attention_mask = (
@@ -461,7 +473,7 @@ def get_model(model_name: str,
                 past_key_values = output.attention_cache
                 i += step_input_ids.shape[1]
 
-        logits_step = torch.from_numpy(np.array(output.logits)).to(device)
+        logits_step = torch.from_numpy(np.array(output.logits)).to(torch_device)
         return InferenceFuncOutput(logits_step, output.attention_cache,
                                    output.hidden_states, output.attentions)
 
@@ -472,13 +484,13 @@ def get_model(model_name: str,
                                 transformer_config)
 
 
-def get_padded_step_len(length, encoder_seq_lengths):
-    """For a given length, find the smallest value in encoder_seq_lengths that
+def get_padded_step_len(length, encoder_chunk_sizes):
+    """For a given length, find the smallest value in encoder_chunk_sizes that
     is greater than the given length."""
-    for i in range(len(encoder_seq_lengths)):
-        if encoder_seq_lengths[i] >= length:
+    for i in range(len(encoder_chunk_sizes)):
+        if encoder_chunk_sizes[i] >= length:
             break
-    return encoder_seq_lengths[i]
+    return encoder_chunk_sizes[i]
 
 
 def set_skip_shard_args_check(attention_cache):

--- a/examples/opt_serving/textgen_demo.py
+++ b/examples/opt_serving/textgen_demo.py
@@ -8,7 +8,7 @@ import numpy as np
 tokenizer = AutoTokenizer.from_pretrained("facebook/opt-30b", use_fast=False)
 tokenizer.add_bos_token = False
 
-generate_params = {"do_sample": False, "num_beams": 1, "num_return_sequences": 1}
+generate_params = {"do_sample": True, "num_beams": 1, "num_return_sequences": 1}
 
 # Load the model
 model = get_model(model_name="alpa/opt-125m",

--- a/examples/opt_serving/textgen_demo.py
+++ b/examples/opt_serving/textgen_demo.py
@@ -12,10 +12,8 @@ generate_params = {"do_sample": False, "num_beams": 1, "num_return_sequences": 1
 
 # Load the model
 model = get_model(model_name="alpa/opt-125m",
-                  device="cuda",
                   path="/home/ubuntu/opt_weights",
                   batch_size=4,
-                  max_target_positions=512,
                   **generate_params)
 
 # Generate
@@ -25,7 +23,7 @@ prompts = [
     "Computer Science studies the area of",
     "University of California Berkeley is a public university"
 ]
-input_ids = tokenizer(prompts, return_tensors="pt", padding="longest").input_ids.to("cuda")
+input_ids = tokenizer(prompts, return_tensors="pt", padding="longest").input_ids
 output_ids = model.generate(input_ids=input_ids,
                             max_length=64,
                             **generate_params)

--- a/examples/opt_serving/textgen_demo.py
+++ b/examples/opt_serving/textgen_demo.py
@@ -8,7 +8,7 @@ import numpy as np
 tokenizer = AutoTokenizer.from_pretrained("facebook/opt-30b", use_fast=False)
 tokenizer.add_bos_token = False
 
-generate_params = {"do_sample": True, "num_beams": 1, "num_return_sequences": 1}
+generate_params = {"do_sample": False, "num_beams": 1, "num_return_sequences": 1}
 
 # Load the model
 model = get_model(model_name="alpa/opt-125m",
@@ -19,22 +19,20 @@ model = get_model(model_name="alpa/opt-125m",
                   **generate_params)
 
 # Generate
-prompt = [
+prompts = [
     "Paris is the capital city of",
     "Today is a good day and I'd like to",
     "Computer Science studies the area of",
     "University of California Berkeley is a public university"
 ]
-input_ids = tokenizer(prompt, return_tensors="pt", padding="longest").input_ids.to("cuda")
-
-outputs = model.generate(input_ids=input_ids,
-                         pad_token_id=tokenizer.pad_token_id,
-                         max_length=64,
-                         **generate_params)
+input_ids = tokenizer(prompts, return_tensors="pt", padding="longest").input_ids.to("cuda")
+output_ids = model.generate(input_ids=input_ids,
+                            max_length=64,
+                            **generate_params)
+outputs = tokenizer.batch_decode(output_ids, skip_special_tokens=True)
 
 # Print results
-print("Output:\n" + 100 * '-')
+print("Outputs:\n" + 100 * '-')
 for i, output in enumerate(outputs):
-    print("{}: {}".format(i, tokenizer.decode(output,
-                                              skip_special_tokens=True)))
+    print(f"{i}: {output}")
     print(100 * '-')


### PR DESCRIPTION
- **API CHANGE**. Update the argument of `get_model` and improve the docstrings
   - `device` is renamed to `torch_device`.
   - `encoder_seq_lengths` is renamed to `encoder_chunk_sizes`
   -  Some order changes
- Change the default torch device to CPU to avoid memory conflicts
- Use multiple executables by default 
