### PR TITLE
[doc] adding the doc to describe the new api

### DIFF
--- a/docs/gallery/tutorials/pipeshard_parallelism.py
+++ b/docs/gallery/tutorials/pipeshard_parallelism.py
@@ -43,6 +43,12 @@ alpa.init(cluster="ray")
 # Alternatively, you can use the following command to connect to an existing
 # ray cluster.
 # ray.init(address="auto")
+#
+# Note: `alpa.init(cluster="ray")` uses the gpus resources of the whole ray
+# cluster. To configure Alpa to only use a subset of gpu resources, one can 
+# specific the number of nodes and number of gpus per node.
+# For example, only run 2 gpus when 8 gpus are available 
+# alpa.init('ray', devices_per_node=2, num_nodes=1)  
 
 ################################################################################
 # Train an MLP on a Single Device


### PR DESCRIPTION
this pr is to add the explanation of using the new api (https://github.com/alpa-projects/alpa/pull/657). 

Not sure this is the best place to add the description, but it will show in the [online tutorials](https://alpa.ai/tutorials/pipeshard_parallelism.html#connect-to-a-ray-cluster). 

@zhisbug 
