### PR TITLE
limited batching support for logprobs endpoint

### DIFF
--- a/examples/opt_serving/client.py
+++ b/examples/opt_serving/client.py
@@ -57,7 +57,6 @@ class Client(object):
         """TODO(yangkevin2)"""
         pload = {
             "prompt": prompt,
-            "top_p": top_p,
             "top_k": top_k,
             "redirect_logprobs": True
         }

--- a/examples/opt_serving/test_logprobs.py
+++ b/examples/opt_serving/test_logprobs.py
@@ -17,7 +17,8 @@ if __name__ == "__main__":
     tokenizer = AutoTokenizer.from_pretrained("facebook/opt-30b", use_fast=False)
     tokenizer.add_bos_token = False
 
-    prompt = [int(x) for x in tokenizer.encode("Paris is the capital city of")]
+    prompt = [[int(x) for x in tokenizer.encode("Paris is the capital city of France")], 
+              [int(x) for x in tokenizer.encode("Paris is the capital city of Germany")]]
     top_k = 50
 
     output = client.logprobs(prompt, top_k=top_k)
@@ -25,15 +26,16 @@ if __name__ == "__main__":
     tic = time.time()
     num_tokens = 40
     for i in range(num_tokens):
-        distribution = np.full((tokenizer.vocab_size + 10), -1e8, dtype=np.float32)
-        for idx, logprob in zip(output['indices'], output['logprobs']):
-            distribution[idx] = logprob
-        #distribution = softmax(distribution)
-        #token = np.random.choice(np.arange(len(distribution)), p=distribution)
-        token = distribution.argmax()
-        prompt.append(int(token))
-        print(tokenizer.decode(prompt))
-
+        print('\nStep', i)
+        for j in range(len(prompt)):
+            distribution = np.full((tokenizer.vocab_size + 10), -1e8, dtype=np.float32)
+            for idx, logprob in zip(output['indices'][j], output['logprobs'][j]):
+                distribution[idx] = logprob
+            # distribution = softmax(distribution)
+            # token = np.random.choice(np.arange(len(distribution)), p=distribution)
+            token = distribution.argmax()
+            prompt[j].append(int(token))
+            print(tokenizer.decode(prompt[j]))
         output = client.logprobs(prompt, top_k=top_k, cache_id=output["cache_id"])
     time_cost = time.time() - tic
     print(f"Generation throughput: {num_tokens/time_cost:.2f} token/s")


### PR DESCRIPTION
Hi, 

I implemented a limited version of batching for the logprobs endpoint. Specifically, the user can now send up to `MAX_BS` prompts together, each with the same number of tokens, and they'll be processed and cached together as one WorkItem. Then the user can update each of those prompts by one token and re-query with the same batch in the same order. I modified `test_logprobs.py` to show an example. 

This should be all that I need for my use case, but it currently doesn't support mixing prompts from different batches, or using prompts of different lengths in the same batch. The latter is checked via an assert; without the assert, it will run without crashing, but the result is incorrect even after I ensure the `input_ids` and `attention_mask` are correct, so I assume there's something going wrong with the `past_key_values` + padding in the presence of different-length prompts that I haven't yet looked into.

Is this fine to merge as initial batching support, and leave the rest for later?

(I also removed the top-p option, figuring the user can do their own manipulation given the logprobs, and just kept top-k in case they're network-limited). 