### PR TITLE
Fixed erroneous naming of ckpt-path argument in OPT-175b conversion documentation

### DIFF
--- a/examples/opt_serving/README.rst
+++ b/examples/opt_serving/README.rst
@@ -132,7 +132,7 @@ We provide detailed instructions below on how to convert the original OPT-175B w
 
     .. code:: shell
 
-      python3 step_3_convert_to_numpy_weights.py --ckpt_path PATH_TO_SAVE_CHECKPOINT --output-folder OUTPUT_PATH
+      python3 step_3_convert_to_numpy_weights.py --ckpt-path PATH_TO_SAVE_CHECKPOINT --output-folder OUTPUT_PATH
 
 
     The weights will be saved at the folder ``OUTPUT_PATH`` as specified in the command.


### PR DESCRIPTION
This PR contains a minor typo fix to the documentation of the opt-175b model conversion process. The `--ckpt-path` flag is hyphenated in `examples/opt_serving/scripts/step_3_convert_to_numpy_weights.py` but underscored in the documentation.