### PR TITLE
[PROFILE] Dump pipeline stage execution timeline into chrome tracing file in inference benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ build_jaxlib/dist
 
 # Examples build and tmp files
 examples/build/
+examples/imagenet/imagenet
 examples/llm_serving/dataset/*.so
 examples/llm_serving/dataset/*.c
 examples/llm_serving/dataset/*.cpp
@@ -45,6 +46,10 @@ alpa_debug_info
 *.prof
 *.tsv
 *.hlo
+*.pkl
+benchmark/alpa/tmp
+benchmark/alpa/chrome_trace
+*.log
 
 # Tests temp files
 tests/tmp
@@ -53,20 +58,14 @@ tests/tmp
 benchmark/deepspeed/data
 
 # plots
-benchmark/**.pdf
+benchmark/*.pdf
 
 # Numpy cache
 *.npy
-*.pkl
-benchmark/alpa/tmp
-*.log
 
 # Documentation website build
 docs/_build
 docs/tutorials
-
-# Example temp files
-examples/imagenet/imagenet
 
 # macOS temp files
 .DS_Store

--- a/alpa/pipeline_parallel/pipeshard_executable.py
+++ b/alpa/pipeline_parallel/pipeshard_executable.py
@@ -256,9 +256,9 @@ class PipeshardDriverExecutable:
     ##### Profiling and Debugging Related Functions #####
     def get_stage_execution_info(self):
         """Get the execution information of each request's each stage.
-            return a list, each element corresponds to a single stage, and is 
-            a list of (start, stop, node_ids, devices) tuple, each corresponds to 
-            a single request. 
+            return a list, each element corresponds to a single stage,
+            and is a list of (start, stop, node_ids, devices) tuple, 
+            each corresponds to a single request.
         """
         all_stages_info_list = []
         for mesh in self.mesh_group:

--- a/alpa/pipeline_parallel/pipeshard_executable.py
+++ b/alpa/pipeline_parallel/pipeshard_executable.py
@@ -254,6 +254,21 @@ class PipeshardDriverExecutable:
         return tree_unflatten(self.out_tree, out)
 
     ##### Profiling and Debugging Related Functions #####
+    def get_stage_execution_info(self):
+        """Get the execution information of each request's each stage.
+            return a list, each element corresponds to a single stage, and is 
+            a list of (start, stop, node_ids, devices) tuple, each corresponds to 
+            a single request. 
+        """
+        all_stages_info_list = []
+        for mesh in self.mesh_group:
+            timer = mesh.get_remote_timer("stage_timestamps")
+            per_stage_info_list = []
+            for s, e in zip(timer.start_times, timer.stop_times):
+                per_stage_info_list.append((s, e, mesh.host_ids, mesh.devices))
+            all_stages_info_list.append(per_stage_info_list)
+        return all_stages_info_list
+
     def get_execution_time_costs(self,
                                  timer_name="overall",
                                  return_all_costs=False):
@@ -498,11 +513,15 @@ class PipeshardMeshWorkerExecuable:
             #self.worker.sync()
 
             if instruction.opcode == PipelineInstType.RUN:
+                if "stage" in instruction.info:
+                    timers("stage_timestamps").start(sync_func=sync_func)
                 timers("compute").start()
                 self.worker.run_executable(instruction.task_uuid,
                                            instruction.input_uuids,
                                            instruction.output_uuids,
                                            **instruction.opaques["kwargs"])
+                if "stage" in instruction.info:
+                    timers("stage_timestamps").stop(sync_func=sync_func)
                 timers("compute").suspend()
             elif instruction.opcode == PipelineInstType.SEND:
                 timers("resharding_send").start()

--- a/alpa/pipeline_parallel/pipeshard_executable.py
+++ b/alpa/pipeline_parallel/pipeshard_executable.py
@@ -256,9 +256,9 @@ class PipeshardDriverExecutable:
     ##### Profiling and Debugging Related Functions #####
     def get_stage_execution_info(self):
         """Get the execution information of each request's each stage.
-            return a list, each element corresponds to a single stage,
-            and is a list of (start, stop, node_ids, devices) tuple,
-            each corresponds to a single request.
+           Return a list, where each element corresponds to a single stage.
+           Each element is a list of (start, stop, node_ids, devices) tuple,
+           where each tuple corresponds to a single request.
         """
         all_stages_info_list = []
         for mesh in self.mesh_group:

--- a/alpa/pipeline_parallel/pipeshard_executable.py
+++ b/alpa/pipeline_parallel/pipeshard_executable.py
@@ -257,7 +257,7 @@ class PipeshardDriverExecutable:
     def get_stage_execution_info(self):
         """Get the execution information of each request's each stage.
             return a list, each element corresponds to a single stage,
-            and is a list of (start, stop, node_ids, devices) tuple, 
+            and is a list of (start, stop, node_ids, devices) tuple,
             each corresponds to a single request.
         """
         all_stages_info_list = []

--- a/alpa/timer.py
+++ b/alpa/timer.py
@@ -19,7 +19,8 @@ class _Timer:
         self.accum_cost = 0.0
 
         # start-stop timestamp pairs
-        self.stopped = True # started=False does not mean stopped=True because it may be suspended
+        self.stopped = True  # started=False does not imply stopped=True 
+                             # because it may be suspended
         self.start_times = []
         self.stop_times = []
 

--- a/alpa/timer.py
+++ b/alpa/timer.py
@@ -19,8 +19,8 @@ class _Timer:
         self.accum_cost = 0.0
 
         # start-stop timestamp pairs
-        self.stopped = True  # started=False does not imply stopped=True 
-                             # because it may be suspended
+        self.stopped = True  # started=False does not imply stopped=True
+        # because it may be suspended
         self.start_times = []
         self.stop_times = []
 

--- a/alpa/timer.py
+++ b/alpa/timer.py
@@ -18,9 +18,6 @@ class _Timer:
         self.ever_suspended = False
         self.accum_cost = 0.0
 
-        # started=False does not imply stopped=True
-        # because it may be suspended
-        self.stopped = True
         # start-stop timestamp pairs
         self.start_times = []
         self.stop_times = []
@@ -31,9 +28,7 @@ class _Timer:
         if sync_func and do_sync:
             sync_func()
         self.start_time = time.time()
-        if self.stopped:
-            self.stopped = False
-            self.start_times.append(self.start_time)
+        self.start_times.append(self.start_time)
         self.started = True
 
     def suspend(self, sync_func: Callable = None):
@@ -64,7 +59,6 @@ class _Timer:
             cost = time.time() - self.start_time
             self.costs.append(cost)
         self.stop_times.append(time.time())
-        self.stopped = True
         self.started = False
 
     def reset(self):

--- a/alpa/timer.py
+++ b/alpa/timer.py
@@ -18,9 +18,10 @@ class _Timer:
         self.ever_suspended = False
         self.accum_cost = 0.0
 
-        # start-stop timestamp pairs
-        self.stopped = True  # started=False does not imply stopped=True
+        # started=False does not imply stopped=True
         # because it may be suspended
+        self.stopped = True
+        # start-stop timestamp pairs
         self.start_times = []
         self.stop_times = []
 

--- a/alpa/timer.py
+++ b/alpa/timer.py
@@ -18,12 +18,20 @@ class _Timer:
         self.ever_suspended = False
         self.accum_cost = 0.0
 
+        # start-stop timestamp pairs
+        self.stopped = True # started=False does not mean stopped=True because it may be suspended
+        self.start_times = []
+        self.stop_times = []
+
     def start(self, sync_func: Callable = None):
         """Start the timer."""
         assert not self.started, "timer has already been started"
         if sync_func and do_sync:
             sync_func()
         self.start_time = time.time()
+        if self.stopped:
+            self.stopped = False
+            self.start_times.append(self.start_time)
         self.started = True
 
     def suspend(self, sync_func: Callable = None):
@@ -53,6 +61,8 @@ class _Timer:
         else:
             cost = time.time() - self.start_time
             self.costs.append(cost)
+        self.stop_times.append(time.time())
+        self.stopped = True
         self.started = False
 
     def reset(self):

--- a/benchmark/alpa/README.md
+++ b/benchmark/alpa/README.md
@@ -124,6 +124,11 @@ Add `--profile-driver-time` to derive the latency from the driver. This flag wil
 python benchmark.py --suite gpt_inference.profile --profile-driver-time
 ```
 
+Add `--profile_stage_execution_time` to derive the stage execution timeline for each requests and dump into chrome tracing files in folder `$PWD/chrome_trace/`.
+```
+python benchmark.py --suite gpt_inference.profile --profile_stage_execution_time
+```
+
 We also include a convenient script `run_exp.py` to run multiple benchmarks with different cluster configurations. For example, to run all gpt search cases:
 ```
 python run_exp.py gpt

--- a/benchmark/alpa/README.md
+++ b/benchmark/alpa/README.md
@@ -126,7 +126,7 @@ python benchmark.py --suite gpt_inference.profile --profile-driver-time
 
 Add `--profile_stage_execution_time` to derive the stage execution timeline for each requests and dump into chrome tracing files in folder `$PWD/chrome_trace/`.
 ```
-python benchmark.py --suite gpt_inference.profile --profile_stage_execution_time
+python benchmark.py --suite gpt_inference.profile --profile-stage-execution-time
 ```
 
 We also include a convenient script `run_exp.py` to run multiple benchmarks with different cluster configurations. For example, to run all gpt search cases:

--- a/benchmark/alpa/benchmark.py
+++ b/benchmark/alpa/benchmark.py
@@ -73,17 +73,18 @@ def benchmark_suite(suite_name,
 
         # Run one case
         print("Working on case: {}".format(str(benchmark_case)))
-        result = benchmark_one_case(model_type,
-                                    benchmark_case,
-                                    niter,
-                                    num_hosts,
-                                    num_devices_per_host,
-                                    shard_only=shard_only,
-                                    local=local,
-                                    profile_driver_time=profile_driver_time,
-                                    profile_stage_execution_time=profile_stage_execution_time,
-                                    disable_tqdm=disable_tqdm,
-                                    use_separate_process=use_separate_process)
+        result = benchmark_one_case(
+            model_type,
+            benchmark_case,
+            niter,
+            num_hosts,
+            num_devices_per_host,
+            shard_only=shard_only,
+            local=local,
+            profile_driver_time=profile_driver_time,
+            profile_stage_execution_time=profile_stage_execution_time,
+            disable_tqdm=disable_tqdm,
+            use_separate_process=use_separate_process)
 
         (parameter_count, peak_mem, latencies, tflops, metadata) = result
 
@@ -127,10 +128,11 @@ if __name__ == "__main__":
                         action="store_true",
                         help="Profile the execution time on the driver instead "
                         "of the workers.")
-    parser.add_argument("--profile-stage-execution-time",
-                        action="store_true",
-                        help="Profile the execution timestamps of each pipeline "
-                        "stage")
+    parser.add_argument(
+        "--profile-stage-execution-time",
+        action="store_true",
+        help="Profile the execution timestamps of each pipeline "
+        "stage")
     parser.add_argument("--no-separate-process",
                         action="store_false",
                         help="Do not launch separate processes for benchmark. "
@@ -145,7 +147,5 @@ if __name__ == "__main__":
 
     benchmark_suite(args.suite, num_hosts, num_devices_per_host, args.exp_name,
                     args.niter, args.shard_only, args.local,
-                    args.profile_driver_time,
-                    args.profile_stage_execution_time,
-                    args.disable_tqdm,
-                    args.use_separate_process)
+                    args.profile_driver_time, args.profile_stage_execution_time,
+                    args.disable_tqdm, args.use_separate_process)

--- a/benchmark/alpa/benchmark.py
+++ b/benchmark/alpa/benchmark.py
@@ -46,6 +46,7 @@ def benchmark_suite(suite_name,
                     shard_only=False,
                     local=False,
                     profile_driver_time=False,
+                    profile_stage_execution_time=False,
                     disable_tqdm=False,
                     use_separate_process=True):
     num_gpus = num_hosts * num_devices_per_host
@@ -80,6 +81,7 @@ def benchmark_suite(suite_name,
                                     shard_only=shard_only,
                                     local=local,
                                     profile_driver_time=profile_driver_time,
+                                    profile_stage_execution_time=profile_stage_execution_time,
                                     disable_tqdm=disable_tqdm,
                                     use_separate_process=use_separate_process)
 
@@ -125,6 +127,10 @@ if __name__ == "__main__":
                         action="store_true",
                         help="Profile the execution time on the driver instead "
                         "of the workers.")
+    parser.add_argument("--profile-stage-execution-time",
+                        action="store_true",
+                        help="Profile the execution timestamps of each pipeline "
+                        "stage")
     parser.add_argument("--no-separate-process",
                         action="store_false",
                         help="Do not launch separate processes for benchmark. "
@@ -139,5 +145,7 @@ if __name__ == "__main__":
 
     benchmark_suite(args.suite, num_hosts, num_devices_per_host, args.exp_name,
                     args.niter, args.shard_only, args.local,
-                    args.profile_driver_time, args.disable_tqdm,
+                    args.profile_driver_time,
+                    args.profile_stage_execution_time,
+                    args.disable_tqdm,
                     args.use_separate_process)

--- a/benchmark/alpa/benchmark_one_case.py
+++ b/benchmark/alpa/benchmark_one_case.py
@@ -25,6 +25,7 @@ def benchmark_one_case_internal(model,
                                 num_hosts,
                                 num_devices_per_host,
                                 profile_driver_time=False,
+                                profile_stage_execution_time=False,
                                 shard_only=False,
                                 local=False,
                                 disable_tqdm=False):
@@ -110,7 +111,8 @@ def benchmark_one_case_internal(model,
                 niter,
                 num_hosts,
                 num_devices_per_host,
-                profile_driver_time=profile_driver_time)
+                profile_driver_time=profile_driver_time,
+                profile_stage_execution_time=profile_stage_execution_time)
         else:
             raise ValueError(f"Invalid model: {model}")
 

--- a/benchmark/alpa/benchmark_one_case_gpt_bert_inference.py
+++ b/benchmark/alpa/benchmark_one_case_gpt_bert_inference.py
@@ -11,7 +11,7 @@ from alpa.util import print_used_time
 
 from util import compute_gpt_parameter_count, compute_gpt_tflops
 from benchmark_parallel_utils import (
-    get_pipeshard_parallel_method,
+    get_pipeshard_parallel_method, dump_chrome_tracing,
     compile_and_benchmark_pipeshard_inference_executable)
 
 
@@ -140,7 +140,8 @@ def benchmark_gpt_inference_internal(model_type,
                                      niter,
                                      num_hosts,
                                      num_devices_per_host,
-                                     profile_driver_time=False):
+                                     profile_driver_time=False,
+                                     profile_stage_execution_time=False):
     # Connect to the cluster
     virtual_mesh = get_global_cluster().get_virtual_physical_mesh(
         host_ids=list(range(num_hosts)),
@@ -166,6 +167,10 @@ def benchmark_gpt_inference_internal(model_type,
          infer_step,
          params, (batch, rngkey),
          profile_driver_time=profile_driver_time)
+
+    if profile_stage_execution_time:
+        exec_info = executable.get_stage_execution_info()
+        dump_chrome_tracing(zip(*exec_info), f"./chrome_trace/bs={benchmark_case.batch_size},pp={num_manual_pipeline_stages}.json")
 
     # Compute statistics
     tflops, parameter_count = compute_gpt_inference_statistics(

--- a/benchmark/alpa/benchmark_one_case_gpt_bert_inference.py
+++ b/benchmark/alpa/benchmark_one_case_gpt_bert_inference.py
@@ -170,7 +170,10 @@ def benchmark_gpt_inference_internal(model_type,
 
     if profile_stage_execution_time:
         exec_info = executable.get_stage_execution_info()
-        dump_chrome_tracing(zip(*exec_info), f"./chrome_trace/bs={benchmark_case.batch_size},pp={num_manual_pipeline_stages}.json")
+        dump_chrome_tracing(
+            zip(*exec_info),
+            f"./chrome_trace/bs={benchmark_case.batch_size},pp={num_manual_pipeline_stages}.json"
+        )
 
     # Compute statistics
     tflops, parameter_count = compute_gpt_inference_statistics(

--- a/benchmark/alpa/benchmark_parallel_utils.py
+++ b/benchmark/alpa/benchmark_parallel_utils.py
@@ -1,7 +1,9 @@
 """Options of a benchmark case."""
-import time
-from typing import Optional, Dict, Any
 from collections import namedtuple
+import json
+import os
+import time
+from typing import Optional, Dict, Any, List
 
 import numpy as np
 import jax
@@ -418,3 +420,63 @@ def compile_and_benchmark_pipeshard_inference_executable(
     max_mem_allocated = executable.mesh_group.get_max_memory_allocated()
 
     return latencies, max_mem_allocated, compilation_times, executable
+
+
+def dump_chrome_tracing(timelines: List[tuple], dumpfile: str):
+    def get_color(i):
+        color_list = [
+            "thread_state_uninterruptible",
+            "thread_state_iowait",
+            "thread_state_running",
+            "thread_state_runnable",
+            "thread_state_unknown",
+            "background_memory_dump",
+            "light_memory_dump",
+            "detailed_memory_dump",
+            "vsync_highlight_color",
+            "generic_work",
+            "good",
+            "bad",
+            "terrible",
+            "yellow",
+            "olive",
+            "rail_response",
+            "rail_animation",
+            "rail_idle",
+            "rail_load",
+            "startup",
+            "heap_dump_stack_frame",
+            "heap_dump_object_type",
+            "heap_dump_child_node_arrow",
+            "cq_build_running",
+            "cq_build_passed",
+            "cq_build_failed",
+            "cq_build_attempt_runnig",
+            "cq_build_attempt_passed",
+            "cq_build_attempt_failed",
+        ]
+        return color_list[i % len(color_list)]
+    
+    slot_list = []
+    for request_id, request_timeline in enumerate(timelines):
+        sorted_timeline = sorted(request_timeline, key=lambda x: x[0])
+
+        for stage_num, (s, e, node_ids, devices) in enumerate(sorted_timeline):
+            for node_id, devices_per_node in zip(node_ids, devices):
+                for device_id in devices_per_node:
+                    slot = {"name": f"r{request_id}s{stage_num}",
+                            "cat": f"request {request_id}, stage {stage_num}",
+                            "ph": "X",
+                            "pid": node_id,
+                            "tid": device_id,
+                            "ts": float(s) * 1e6,
+                            "dur": float(e - s) * 1e6,
+                            "cname": get_color(request_id)}
+                    slot_list.append(slot)
+
+    os.makedirs(os.path.dirname(dumpfile), exist_ok=True)
+    with open(dumpfile, "w") as fout:
+        fout.write(json.dumps({
+            "traceEvents": slot_list,
+            "displayTimeUnit": "ms",
+        }))

--- a/benchmark/alpa/benchmark_parallel_utils.py
+++ b/benchmark/alpa/benchmark_parallel_utils.py
@@ -423,6 +423,7 @@ def compile_and_benchmark_pipeshard_inference_executable(
 
 
 def dump_chrome_tracing(timelines: List[tuple], dumpfile: str):
+
     def get_color(i):
         color_list = [
             "thread_state_uninterruptible",
@@ -456,7 +457,7 @@ def dump_chrome_tracing(timelines: List[tuple], dumpfile: str):
             "cq_build_attempt_failed",
         ]
         return color_list[i % len(color_list)]
-    
+
     slot_list = []
     for request_id, request_timeline in enumerate(timelines):
         sorted_timeline = sorted(request_timeline, key=lambda x: x[0])
@@ -464,19 +465,22 @@ def dump_chrome_tracing(timelines: List[tuple], dumpfile: str):
         for stage_num, (s, e, node_ids, devices) in enumerate(sorted_timeline):
             for node_id, devices_per_node in zip(node_ids, devices):
                 for device_id in devices_per_node:
-                    slot = {"name": f"r{request_id}s{stage_num}",
-                            "cat": f"request {request_id}, stage {stage_num}",
-                            "ph": "X",
-                            "pid": node_id,
-                            "tid": device_id,
-                            "ts": float(s) * 1e6,
-                            "dur": float(e - s) * 1e6,
-                            "cname": get_color(request_id)}
+                    slot = {
+                        "name": f"r{request_id}s{stage_num}",
+                        "cat": f"request {request_id}, stage {stage_num}",
+                        "ph": "X",
+                        "pid": node_id,
+                        "tid": device_id,
+                        "ts": float(s) * 1e6,
+                        "dur": float(e - s) * 1e6,
+                        "cname": get_color(request_id)
+                    }
                     slot_list.append(slot)
 
     os.makedirs(os.path.dirname(dumpfile), exist_ok=True)
     with open(dumpfile, "w") as fout:
-        fout.write(json.dumps({
-            "traceEvents": slot_list,
-            "displayTimeUnit": "ms",
-        }))
+        fout.write(
+            json.dumps({
+                "traceEvents": slot_list,
+                "displayTimeUnit": "ms",
+            }))


### PR DESCRIPTION
Usage: in `alpa/benchmark/alpa`, run
```
python benchmark.py --suite gpt_inference.profile --profile_stage_execution_time
```
the chrome tracing files will be saved under `./chrome_trace/`.