### PR TITLE
[BENCHMARK] Align the benchmark output format with the requirements of Alpa Serve

### DIFF
--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -2033,6 +2033,14 @@ class PhysicalDeviceMeshGroup:
                 calls.append(worker.get_max_memory_allocated.remote())
         return max(ray.get(calls))
 
+    def get_max_memory_allocated_per_stage(self):
+        """Get the maximal size of memory allocated for each stage so far."""
+        return [mesh.get_max_memory_allocated() for mesh in self.meshes]
+
+    def reset_memory_stats(self):
+        for mesh in self.meshes:
+            mesh.reset_memory_stats()
+
     def destroy_collective_groups(self):
         for i in range(len(self)):
             for j in range(len(self)):

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -2033,8 +2033,8 @@ class PhysicalDeviceMeshGroup:
                 calls.append(worker.get_max_memory_allocated.remote())
         return max(ray.get(calls))
 
-    def get_max_memory_allocated_per_stage(self):
-        """Get the maximal size of memory allocated for each stage so far."""
+    def get_max_memory_allocated_per_mesh(self):
+        """Get the maximal size of memory allocated for each mesh so far."""
         return [mesh.get_max_memory_allocated() for mesh in self.meshes]
 
     def reset_memory_stats(self):

--- a/benchmark/alpa/benchmark.py
+++ b/benchmark/alpa/benchmark.py
@@ -88,15 +88,16 @@ def benchmark_suite(suite_name,
         (parameter_count, peak_mem, latencies, tflops, metadata) = result
 
         heads = [
-            "ModelName", "BS", "#Microbatch", "DP", "OP", "PP", "#GPU", 
+            "ModelName", "BS", "#Microbatch", "DP", "OP", "PP", "#GPU",
             "MeanTime(s)", "StdTime(s)", "TFLOPs", "Weights(GB)", "PeakMem(GB)",
             "StageLatencies(s)"
         ]
         values = [
-            exp_name, benchmark_case.batch_size, num_micro_batches, parallel_args.dp, 
-            parallel_args.op, parallel_args.pp, num_gpus, f"{np.mean(latencies):.3f}",
-            f"{np.std(latencies):.3f}", f"{tflops:.2f}", f"{parameter_count/1e9:.3f}",
-            f"{peak_mem/GB:.3f}", metadata["avg_stage_latencies"]
+            exp_name, benchmark_case.batch_size, num_micro_batches,
+            parallel_args.dp, parallel_args.op, parallel_args.pp, num_gpus,
+            f"{np.mean(latencies):.3f}", f"{np.std(latencies):.3f}",
+            f"{tflops:.2f}", f"{parameter_count/1e9:.3f}", f"{peak_mem/GB:.3f}",
+            metadata["avg_stage_latencies"]
         ]
         write_tsv(heads, values, output_name)
 

--- a/benchmark/alpa/benchmark.py
+++ b/benchmark/alpa/benchmark.py
@@ -42,11 +42,11 @@ def benchmark_suite(suite_name,
                     num_hosts,
                     num_devices_per_host,
                     exp_name="default",
-                    niter=3,
+                    niter=10,
                     shard_only=False,
                     local=False,
                     profile_driver_time=False,
-                    profile_stage_execution_time=False,
+                    profile_stage_execution_time=True,
                     disable_tqdm=False,
                     use_separate_process=True):
     num_gpus = num_hosts * num_devices_per_host
@@ -88,16 +88,13 @@ def benchmark_suite(suite_name,
         (parameter_count, peak_mem, latencies, tflops, metadata) = result
 
         heads = [
-            "Type", "Model Config", "#Microbatch", "#GPU", "Parallel Config",
-            "Mean Time (s)", "Std Time (s)", "#Params (Billion)", "TFLOPs",
-            "Peak Mem (GB)", "Metadata"
+            "BS", "#Microbatch", "#GPU", "Mean Time (s)", "Std Time (s)", 
+            "#Params (Billion)", "TFLOPs", "Peak Mem (GB)"
         ]
         values = [
-            model_type, model_config, num_micro_batches, num_gpus,
-            parallel_args, f"{np.mean(latencies):.3f}",
-            f"{np.std(latencies):.3f}", f"{parameter_count/1e9:.3f}B",
+            benchmark_case.batch_size, num_micro_batches, num_gpus,
+            f"{np.mean(latencies):.3f}", f"{np.std(latencies):.3f}", f"{parameter_count/1e9:.3f}B",
             f"{tflops:.2f}", f"{peak_mem/GB:.3f}",
-            to_str_round(metadata, 2)
         ]
         write_tsv(heads, values, output_name)
 

--- a/benchmark/alpa/benchmark.py
+++ b/benchmark/alpa/benchmark.py
@@ -42,11 +42,11 @@ def benchmark_suite(suite_name,
                     num_hosts,
                     num_devices_per_host,
                     exp_name="default",
-                    niter=10,
+                    niter=3,
                     shard_only=False,
                     local=False,
                     profile_driver_time=False,
-                    profile_stage_execution_time=True,
+                    profile_stage_execution_time=False,
                     disable_tqdm=False,
                     use_separate_process=True):
     num_gpus = num_hosts * num_devices_per_host
@@ -88,16 +88,16 @@ def benchmark_suite(suite_name,
         (parameter_count, peak_mem, latencies, tflops, metadata) = result
 
         heads = [
-            "ModelName", "BS", "#Microbatch", "DP", "OP", "PP", "#GPU",
-            "MeanTime(s)", "StdTime(s)", "TFLOPs", "Weights(GB)", "PeakMem(GB)",
-            "StageLatencies(s)"
+            "Type", "Model Config", "#Microbatch", "#GPU", "Parallel Config",
+            "Mean Time (s)", "Std Time (s)", "#Params (Billion)", "TFLOPs",
+            "Peak Mem (GB)", "Metadata"
         ]
         values = [
-            exp_name, benchmark_case.batch_size, num_micro_batches,
-            parallel_args.dp, parallel_args.op, parallel_args.pp, num_gpus,
-            f"{np.mean(latencies):.3f}", f"{np.std(latencies):.3f}",
-            f"{tflops:.2f}", f"{parameter_count/1e9:.3f}", f"{peak_mem/GB:.3f}",
-            metadata["avg_stage_latencies"]
+            model_type, model_config, num_micro_batches, num_gpus,
+            parallel_args, f"{np.mean(latencies):.3f}",
+            f"{np.std(latencies):.3f}", f"{parameter_count/1e9:.3f}B",
+            f"{tflops:.2f}", f"{peak_mem/GB:.3f}",
+            to_str_round(metadata, 2)
         ]
         write_tsv(heads, values, output_name)
 

--- a/benchmark/alpa/benchmark.py
+++ b/benchmark/alpa/benchmark.py
@@ -88,13 +88,15 @@ def benchmark_suite(suite_name,
         (parameter_count, peak_mem, latencies, tflops, metadata) = result
 
         heads = [
-            "BS", "#Microbatch", "#GPU", "Mean Time (s)", "Std Time (s)", 
-            "#Params (Billion)", "TFLOPs", "Peak Mem (GB)"
+            "ModelName", "BS", "#Microbatch", "DP", "OP", "PP", "#GPU", 
+            "MeanTime(s)", "StdTime(s)", "TFLOPs", "Weights(GB)", "PeakMem(GB)",
+            "StageLatencies(s)"
         ]
         values = [
-            benchmark_case.batch_size, num_micro_batches, num_gpus,
-            f"{np.mean(latencies):.3f}", f"{np.std(latencies):.3f}", f"{parameter_count/1e9:.3f}B",
-            f"{tflops:.2f}", f"{peak_mem/GB:.3f}",
+            exp_name, benchmark_case.batch_size, num_micro_batches, parallel_args.dp, 
+            parallel_args.op, parallel_args.pp, num_gpus, f"{np.mean(latencies):.3f}",
+            f"{np.std(latencies):.3f}", f"{tflops:.2f}", f"{parameter_count/1e9:.3f}",
+            f"{peak_mem/GB:.3f}", metadata["avg_stage_latencies"]
         ]
         write_tsv(heads, values, output_name)
 

--- a/benchmark/alpa/benchmark_one_case_gpt_bert_inference.py
+++ b/benchmark/alpa/benchmark_one_case_gpt_bert_inference.py
@@ -201,7 +201,7 @@ def benchmark_gpt_inference_internal(model_type,
             model_name, benchmark_case.batch_size,
             benchmark_case.num_micro_batches, dp, op, pp, dp * op * pp,
             f"{np.mean(latencies):.3f}", f"{np.std(latencies):.3f}",
-            f"{tflops:.2f}", f"{np.array(per_stage_weight_mem)/1e9}",
+            f"{tflops:.2f}", f"{np.array(per_stage_weight_mem)/GB}",
             f"{np.array(per_stage_peak_mem)/GB}", avg_stage_latencies
         ]
         write_tsv(heads, values, f"{model_name}.tsv")

--- a/benchmark/alpa/benchmark_one_case_gpt_bert_inference.py
+++ b/benchmark/alpa/benchmark_one_case_gpt_bert_inference.py
@@ -13,7 +13,7 @@ from alpa.util import print_used_time, GB, write_tsv
 
 from util import compute_gpt_parameter_count, compute_gpt_tflops
 from benchmark_parallel_utils import (
-    get_pipeshard_parallel_method, dump_chrome_tracing,
+    get_pipeshard_parallel_method,
     compile_and_benchmark_pipeshard_inference_executable,
     compute_avg_stage_latencies)
 
@@ -178,14 +178,15 @@ def benchmark_gpt_inference_internal(model_type,
 
     # Log per-stage execution information if needed
     if profile_stage_execution_time:
+        # # dump chrome trace
+        # executable.dump_stage_execution_trace(
+        #     f"./chrome_trace/bs={benchmark_case.batch_size},op={benchmark_case.parallel_args.op},pp={benchmark_case.parallel_args.pp}.json"
+        # )
+        # compute and log per-stage latency/memory statistics
         exec_info = executable.get_stage_execution_info()
         timelines = list(zip(*exec_info))
         # drop warmup case
         timelines = timelines[1:]
-        dump_chrome_tracing(
-            timelines,
-            f"./chrome_trace/bs={benchmark_case.batch_size},op={benchmark_case.parallel_args.op},pp={benchmark_case.parallel_args.pp}.json"
-        )
         avg_stage_latencies = compute_avg_stage_latencies(timelines)
         assert len(avg_stage_latencies) == num_manual_pipeline_stages
         parallel_args = benchmark_case.parallel_args

--- a/benchmark/alpa/benchmark_one_case_gpt_bert_inference.py
+++ b/benchmark/alpa/benchmark_one_case_gpt_bert_inference.py
@@ -163,8 +163,9 @@ def benchmark_gpt_inference_internal(model_type,
 
     infer_step = get_infer_step(method, model, model_type)
 
-    (latencies, max_mem_allocated, compilation_times,
-     executable) = compile_and_benchmark_pipeshard_inference_executable(
+    (latencies, max_mem_allocated, compilation_times, executable,
+     per_stage_weight_mem,
+     per_stage_peak_mem) = compile_and_benchmark_pipeshard_inference_executable(
          benchmark_case.parallel_mode,
          niter,
          infer_step,
@@ -192,15 +193,15 @@ def benchmark_gpt_inference_internal(model_type,
         model_name = os.environ.get("MODEL_NAME", default="bert_model")
         heads = [
             "ModelName", "BS", "#Microbatch", "DP", "OP", "PP", "#GPU",
-            "MeanTime(s)", "StdTime(s)", "TFLOPs", "Weights(GB)", "PeakMem(GB)",
-            "StageLatencies(s)"
+            "MeanTime(s)", "StdTime(s)", "TFLOPs", "StageWeights(GB)",
+            "StagePeakMem(GB)", "StageLatencies(s)"
         ]
         values = [
             model_name, benchmark_case.batch_size,
             benchmark_case.num_micro_batches, dp, op, pp, dp * op * pp,
             f"{np.mean(latencies):.3f}", f"{np.std(latencies):.3f}",
-            f"{tflops:.2f}", f"{parameter_count/1e9:.3f}",
-            f"{max_mem_allocated/GB:.3f}", avg_stage_latencies
+            f"{tflops:.2f}", f"{np.array(per_stage_weight_mem)/1e9}",
+            f"{np.array(per_stage_peak_mem)/GB}", avg_stage_latencies
         ]
         write_tsv(heads, values, f"{model_name}.tsv")
 

--- a/benchmark/alpa/benchmark_one_case_gpt_bert_inference.py
+++ b/benchmark/alpa/benchmark_one_case_gpt_bert_inference.py
@@ -178,10 +178,10 @@ def benchmark_gpt_inference_internal(model_type,
 
     # Log per-stage execution information if needed
     if profile_stage_execution_time:
-        # # dump chrome trace
-        # executable.dump_stage_execution_trace(
-        #     f"./chrome_trace/bs={benchmark_case.batch_size},op={benchmark_case.parallel_args.op},pp={benchmark_case.parallel_args.pp}.json"
-        # )
+        # dump chrome trace
+        executable.dump_stage_execution_trace(
+            f"./chrome_trace/bs={benchmark_case.batch_size},op={benchmark_case.parallel_args.op},pp={benchmark_case.parallel_args.pp}.json"
+        )
         # compute and log per-stage latency/memory statistics
         exec_info = executable.get_stage_execution_info()
         timelines = list(zip(*exec_info))
@@ -207,7 +207,6 @@ def benchmark_gpt_inference_internal(model_type,
         write_tsv(heads, values, f"{model_name}.tsv")
 
     metadata = {
-        "latencies": latencies,
         "compilation_times": compilation_times,
     }
     return parameter_count, max_mem_allocated, latencies, tflops, metadata

--- a/benchmark/alpa/benchmark_one_case_gpt_bert_inference.py
+++ b/benchmark/alpa/benchmark_one_case_gpt_bert_inference.py
@@ -180,6 +180,8 @@ def benchmark_gpt_inference_internal(model_type,
         )
         avg_stage_latencies = compute_avg_stage_latencies(timelines)
         assert len(avg_stage_latencies) == num_manual_pipeline_stages
+    else:
+        avg_stage_latencies = None
 
     # Compute statistics
     tflops, parameter_count = compute_gpt_inference_statistics(
@@ -187,6 +189,6 @@ def benchmark_gpt_inference_internal(model_type,
     metadata = {
         "latencies": latencies,
         "compilation_times": compilation_times,
-        "avg_stage_latencies": avg_stage_latencies 
+        "avg_stage_latencies": avg_stage_latencies
     }
     return parameter_count, max_mem_allocated, latencies, tflops, metadata

--- a/benchmark/alpa/benchmark_parallel_utils.py
+++ b/benchmark/alpa/benchmark_parallel_utils.py
@@ -418,3 +418,90 @@ def compile_and_benchmark_pipeshard_inference_executable(
     max_mem_allocated = executable.mesh_group.get_max_memory_allocated()
 
     return latencies, max_mem_allocated, compilation_times, executable
+<<<<<<< HEAD
+=======
+
+
+def dump_chrome_tracing(timelines: List[tuple], dumpfile: str):
+
+    def get_color(i):
+        color_list = [
+            "thread_state_uninterruptible",
+            "thread_state_iowait",
+            "thread_state_running",
+            "thread_state_runnable",
+            "thread_state_unknown",
+            "background_memory_dump",
+            "light_memory_dump",
+            "detailed_memory_dump",
+            "vsync_highlight_color",
+            "generic_work",
+            "good",
+            "bad",
+            "terrible",
+            "yellow",
+            "olive",
+            "rail_response",
+            "rail_animation",
+            "rail_idle",
+            "rail_load",
+            "startup",
+            "heap_dump_stack_frame",
+            "heap_dump_object_type",
+            "heap_dump_child_node_arrow",
+            "cq_build_running",
+            "cq_build_passed",
+            "cq_build_failed",
+            "cq_build_attempt_runnig",
+            "cq_build_attempt_passed",
+            "cq_build_attempt_failed",
+        ]
+        return color_list[i % len(color_list)]
+
+    slot_list = []
+    stage_latencies = []
+    for request_id, request_timeline in enumerate(timelines):
+        sorted_timeline = sorted(request_timeline, key=lambda x: x[0])
+
+        stage_latency = []
+        for stage_num, (s, e, node_ids, devices) in enumerate(sorted_timeline):
+            stage_latency.append(e - s)
+            for node_id, devices_per_node in zip(node_ids, devices):
+                for device_id in devices_per_node:
+                    slot = {
+                        "name": f"r{request_id}s{stage_num}",
+                        "cat": f"request {request_id}, stage {stage_num}",
+                        "ph": "X",
+                        "pid": node_id,
+                        "tid": device_id,
+                        "ts": float(s) * 1e6,
+                        "dur": float(e - s) * 1e6,
+                        "cname": get_color(request_id)
+                    }
+                    slot_list.append(slot)
+        stage_latencies.append(stage_latency)
+    mean_stage_latencies = np.mean(stage_latencies, axis=0)
+    os.makedirs("./stage_latency/", exist_ok=True)
+    with open(f"./stage_latency/{os.path.basename(dumpfile)}", "w") as fout:
+        fout.write(json.dumps(mean_stage_latencies.tolist()))
+
+    os.makedirs(os.path.dirname(dumpfile), exist_ok=True)
+    with open(dumpfile, "w") as fout:
+        fout.write(
+            json.dumps({
+                "traceEvents": slot_list,
+                "displayTimeUnit": "ms",
+            }))
+
+
+def compute_avg_stage_latencies(timelines: List[tuple]):
+    stage_latencies = []
+    for request_timeline in timelines:
+        sorted_timeline = sorted(request_timeline, key=lambda x: x[0])
+        stage_borders = [sorted_timeline[0][0]]
+        for _, e, _, _ in sorted_timeline:
+            stage_borders.append(e)
+        stage_latency = [stage_borders[i + 1] - stage_borders[i] for i in range(len(stage_borders) - 1)]
+        stage_latencies.append(stage_latency)
+    return np.mean(stage_latencies, axis=0)
+>>>>>>> add stage latency to benchmark output

--- a/benchmark/alpa/benchmark_parallel_utils.py
+++ b/benchmark/alpa/benchmark_parallel_utils.py
@@ -408,7 +408,7 @@ def compile_and_benchmark_pipeshard_inference_executable(
         in_tree,
         executable.mesh_group.shard_args_to_arrays(flat_ps, flat_params))
     print_used_time("Preshard (driver)")
-    per_stage_weight_mem = executable.mesh_group.get_max_memory_allocated_per_stage(
+    per_stage_weight_mem = executable.mesh_group.get_max_memory_allocated_per_mesh(
     )
 
     latencies = benchmark_inference_executable(
@@ -419,7 +419,7 @@ def compile_and_benchmark_pipeshard_inference_executable(
         other_inference_step_inputs,
         profile_driver_time=profile_driver_time)
     max_mem_allocated = executable.mesh_group.get_max_memory_allocated()
-    per_stage_peak_mem = executable.mesh_group.get_max_memory_allocated_per_stage(
+    per_stage_peak_mem = executable.mesh_group.get_max_memory_allocated_per_mesh(
     )
 
     return latencies, max_mem_allocated, compilation_times, executable, per_stage_weight_mem, per_stage_peak_mem

--- a/benchmark/alpa/benchmark_parallel_utils.py
+++ b/benchmark/alpa/benchmark_parallel_utils.py
@@ -418,80 +418,6 @@ def compile_and_benchmark_pipeshard_inference_executable(
     max_mem_allocated = executable.mesh_group.get_max_memory_allocated()
 
     return latencies, max_mem_allocated, compilation_times, executable
-<<<<<<< HEAD
-=======
-
-
-def dump_chrome_tracing(timelines: List[tuple], dumpfile: str):
-
-    def get_color(i):
-        color_list = [
-            "thread_state_uninterruptible",
-            "thread_state_iowait",
-            "thread_state_running",
-            "thread_state_runnable",
-            "thread_state_unknown",
-            "background_memory_dump",
-            "light_memory_dump",
-            "detailed_memory_dump",
-            "vsync_highlight_color",
-            "generic_work",
-            "good",
-            "bad",
-            "terrible",
-            "yellow",
-            "olive",
-            "rail_response",
-            "rail_animation",
-            "rail_idle",
-            "rail_load",
-            "startup",
-            "heap_dump_stack_frame",
-            "heap_dump_object_type",
-            "heap_dump_child_node_arrow",
-            "cq_build_running",
-            "cq_build_passed",
-            "cq_build_failed",
-            "cq_build_attempt_runnig",
-            "cq_build_attempt_passed",
-            "cq_build_attempt_failed",
-        ]
-        return color_list[i % len(color_list)]
-
-    slot_list = []
-    stage_latencies = []
-    for request_id, request_timeline in enumerate(timelines):
-        sorted_timeline = sorted(request_timeline, key=lambda x: x[0])
-
-        stage_latency = []
-        for stage_num, (s, e, node_ids, devices) in enumerate(sorted_timeline):
-            stage_latency.append(e - s)
-            for node_id, devices_per_node in zip(node_ids, devices):
-                for device_id in devices_per_node:
-                    slot = {
-                        "name": f"r{request_id}s{stage_num}",
-                        "cat": f"request {request_id}, stage {stage_num}",
-                        "ph": "X",
-                        "pid": node_id,
-                        "tid": device_id,
-                        "ts": float(s) * 1e6,
-                        "dur": float(e - s) * 1e6,
-                        "cname": get_color(request_id)
-                    }
-                    slot_list.append(slot)
-        stage_latencies.append(stage_latency)
-    mean_stage_latencies = np.mean(stage_latencies, axis=0)
-    os.makedirs("./stage_latency/", exist_ok=True)
-    with open(f"./stage_latency/{os.path.basename(dumpfile)}", "w") as fout:
-        fout.write(json.dumps(mean_stage_latencies.tolist()))
-
-    os.makedirs(os.path.dirname(dumpfile), exist_ok=True)
-    with open(dumpfile, "w") as fout:
-        fout.write(
-            json.dumps({
-                "traceEvents": slot_list,
-                "displayTimeUnit": "ms",
-            }))
 
 
 def compute_avg_stage_latencies(timelines: List[tuple]):
@@ -501,7 +427,9 @@ def compute_avg_stage_latencies(timelines: List[tuple]):
         stage_borders = [sorted_timeline[0][0]]
         for _, e, _, _ in sorted_timeline:
             stage_borders.append(e)
-        stage_latency = [stage_borders[i + 1] - stage_borders[i] for i in range(len(stage_borders) - 1)]
+        stage_latency = [
+            stage_borders[i + 1] - stage_borders[i]
+            for i in range(len(stage_borders) - 1)
+        ]
         stage_latencies.append(stage_latency)
     return np.mean(stage_latencies, axis=0)
->>>>>>> add stage latency to benchmark output

--- a/benchmark/alpa/run_exp.py
+++ b/benchmark/alpa/run_exp.py
@@ -24,6 +24,7 @@ def run_exp(cluster_settings, suite_name, benchmark_settings=None):
         benchmark_suite(suite_name,
                         num_hosts,
                         num_devices_per_host,
+                        exp_name="bert-2.6b",
                         disable_tqdm=True,
                         **benchmark_settings)
 

--- a/benchmark/alpa/run_exp.py
+++ b/benchmark/alpa/run_exp.py
@@ -8,7 +8,7 @@ import sys
 from benchmark import benchmark_suite
 
 
-def run_exp(cluster_settings, suite_name, benchmark_settings=None):
+def run_exp(exp_name, cluster_settings, suite_name, benchmark_settings=None):
     os.environ["PYTHONUNBUFFERED"] = "1"
     now = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
 
@@ -21,10 +21,12 @@ def run_exp(cluster_settings, suite_name, benchmark_settings=None):
 
     for num_hosts, num_devices_per_host in cluster_settings:
         num_gpus = num_hosts * num_devices_per_host
+        if exp_name is None:
+            exp_name = f"{now}_{suite_name}_{num_gpus}_gpus"
         benchmark_suite(suite_name,
                         num_hosts,
                         num_devices_per_host,
-                        exp_name="bert-2.6b",
+                        exp_name=exp_name,
                         disable_tqdm=True,
                         **benchmark_settings)
 
@@ -41,9 +43,9 @@ model_search_suites = {
 }
 cluster_settings = [(4, 8), (3, 8), (2, 8), (1, 8), (1, 4), (1, 2), (1, 1)]
 
-
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("model", type=str, choices=model_search_suites.keys())
+    parser.add_argument("--exp-name", type=str, default=None)
     args = parser.parse_args()
-    run_exp(cluster_settings, *model_search_suites[args.model])
+    run_exp(args.exp_name, cluster_settings, *model_search_suites[args.model])

--- a/benchmark/alpa/run_exp.py
+++ b/benchmark/alpa/run_exp.py
@@ -24,7 +24,6 @@ def run_exp(cluster_settings, suite_name, benchmark_settings=None):
         benchmark_suite(suite_name,
                         num_hosts,
                         num_devices_per_host,
-                        exp_name=f"{now}_{suite_name}_{num_gpus}_gpus",
                         disable_tqdm=True,
                         **benchmark_settings)
 
@@ -39,7 +38,7 @@ model_search_suites = {
         "profile_driver_time": True
     }),
 }
-cluster_settings = [(8, 8), (4, 8), (2, 8), (1, 8), (1, 4), (1, 2), (1, 1)]
+cluster_settings = [(4, 8), (3, 8), (2, 8), (1, 8), (1, 4), (1, 2), (1, 1)]
 
 
 if __name__ == "__main__":

--- a/benchmark/alpa/run_exp.py
+++ b/benchmark/alpa/run_exp.py
@@ -35,7 +35,10 @@ model_search_suites = {
     "gpt": ("gpt.grid_search_auto", {}),
     "moe": ("moe.grid_search_auto", {}),
     "wresnet": ("wresnet.grid_search_auto", {}),
-    "gpt_inference": ("gpt_inference.profile", {}),
+    "gpt_inference": ("gpt_inference.profile", {
+        "niter": 10,
+        "profile_stage_execution_time": True
+    }),
     "gpt_no_embedding_inference": ("gpt_no_embedding_inference.profile", {}),
     "gpt_inference_streaming": ("gpt_inference.profile", {
         "profile_driver_time": True

--- a/benchmark/alpa/run_exp.py
+++ b/benchmark/alpa/run_exp.py
@@ -44,7 +44,8 @@ model_search_suites = {
         "profile_driver_time": True
     }),
 }
-cluster_settings = [(4, 8), (3, 8), (2, 8), (1, 8), (1, 4), (1, 2), (1, 1)]
+cluster_settings = [(8, 8), (4, 8), (3, 8), (2, 8), (1, 8), (1, 4), (1, 2),
+                    (1, 1)]
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()

--- a/benchmark/alpa/suite_inference_gpt.py
+++ b/benchmark/alpa/suite_inference_gpt.py
@@ -49,4 +49,4 @@ def get_config(model_config,
 #get_config(gpt_specs["6.7B"], [1, 2, 4, 8], [1], [1], [1], [1, 4, 16])
 #get_config(gpt_specs["15B"],  [1, 2, 4, 8], [1], [1], [1], [1, 4, 16])
 
-get_config(gpt_specs["350M"], [8], [1], [1], [4], [16])
+get_config(gpt_specs["2.6B"], [1, 2, 4, 8], [1], [1], [1], [1, 4, 16])


### PR DESCRIPTION
- Add per-stage latency to benchmark output.
- To benchmark `bert-1.3b`, run `MODEL_NAME="bert-1.3b" python run_exp.py gpt_inference` under `benchmark/alpa/`, the output will be in `bert-1.3b.tsv` under the same folder.