### PR TITLE
[Feature] Support TPU backend for ShardParallel

### DIFF
--- a/alpa/__init__.py
+++ b/alpa/__init__.py
@@ -1,4 +1,12 @@
 """Alpa is a system for training large-scale neural networks."""
+from . import global_env
+
+from alpa.global_env import global_config
+try:
+    import cupy
+    global_config.has_cuda = True
+except ImportError:
+    global_config.has_cuda = False
 
 # Import all public packages
 from . import api

--- a/alpa/__init__.py
+++ b/alpa/__init__.py
@@ -1,7 +1,7 @@
 """Alpa is a system for training large-scale neural networks."""
 from . import global_env
 
-from alpa.global_env import global_config
+from .global_env import global_config
 try:
     import cupy
     global_config.has_cuda = True
@@ -15,7 +15,6 @@ from . import create_state_parallel
 from . import data_loader
 from . import device_mesh
 from . import follow_parallel
-from . import global_env
 from . import mesh_executable
 from . import mesh_profiling
 from . import monkey_patch

--- a/alpa/__init__.py
+++ b/alpa/__init__.py
@@ -1,13 +1,4 @@
 """Alpa is a system for training large-scale neural networks."""
-from . import global_env
-
-from .global_env import global_config
-try:
-    import cupy
-    global_config.has_cuda = True
-except ImportError:
-    global_config.has_cuda = False
-
 # Import all public packages
 from . import api
 from . import collective
@@ -15,6 +6,7 @@ from . import create_state_parallel
 from . import data_loader
 from . import device_mesh
 from . import follow_parallel
+from . import global_env
 from . import mesh_executable
 from . import mesh_profiling
 from . import monkey_patch

--- a/alpa/collective/collective_group/nccl_util.py
+++ b/alpa/collective/collective_group/nccl_util.py
@@ -1,6 +1,8 @@
 """Code to wrap some NCCL API calls."""
 import numpy
 
+from alpa.collective.collective import nccl_available
+from alpa.collective.types import ReduceOp, torch_available
 from alpa.global_env import global_config
 
 if global_config.has_cuda:
@@ -18,8 +20,6 @@ if global_config.has_cuda:
         raise ImportError(
             "Please install nccl library following the above instructions")
 
-from alpa.collective.types import ReduceOp, torch_available
-if global_config.has_cuda:
     NCCL_REDUCE_OP_MAP = {
         ReduceOp.SUM: nccl.NCCL_SUM,
         ReduceOp.PRODUCT: nccl.NCCL_PROD,
@@ -51,7 +51,6 @@ if torch_available():
     import torch
     import torch.utils.dlpack
 
-    from alpa.collective.collective import nccl_available
     if nccl_available():
         TORCH_NCCL_DTYPE_MAP = {
             # INT types

--- a/alpa/collective/collective_group/nccl_util.py
+++ b/alpa/collective/collective_group/nccl_util.py
@@ -1,67 +1,74 @@
 """Code to wrap some NCCL API calls."""
 import numpy
-try:
-    import cupy
-    from cupy.cuda import nccl
-    from cupy.cuda import Device  # pylint: disable=unused-import
-    from cupy.cuda.nccl import get_version
-    from cupy.cuda.nccl import get_build_version
-    from cupy.cuda.nccl import NcclCommunicator
-    from cupy.cuda.nccl import groupStart  # pylint: disable=unused-import
-    from cupy.cuda.nccl import groupEnd  # pylint: disable=unused-import
-except ImportError as error:
-    # pylint: disable=raise-missing-from
-    raise ImportError(
-        "Please install nccl library following the above instructions")
+
+from alpa.global_env import global_config
+
+if global_config.has_cuda:
+    try:
+        import cupy
+        from cupy.cuda import nccl
+        from cupy.cuda import Device  # pylint: disable=unused-import
+        from cupy.cuda.nccl import get_version
+        from cupy.cuda.nccl import get_build_version
+        from cupy.cuda.nccl import NcclCommunicator
+        from cupy.cuda.nccl import groupStart  # pylint: disable=unused-import
+        from cupy.cuda.nccl import groupEnd  # pylint: disable=unused-import
+    except ImportError:
+        # pylint: disable=raise-missing-from
+        raise ImportError(
+            "Please install nccl library following the above instructions")
 
 from alpa.collective.types import ReduceOp, torch_available
+if global_config.has_cuda:
+    NCCL_REDUCE_OP_MAP = {
+        ReduceOp.SUM: nccl.NCCL_SUM,
+        ReduceOp.PRODUCT: nccl.NCCL_PROD,
+        ReduceOp.MIN: nccl.NCCL_MIN,
+        ReduceOp.MAX: nccl.NCCL_MAX,
+    }
 
-NCCL_REDUCE_OP_MAP = {
-    ReduceOp.SUM: nccl.NCCL_SUM,
-    ReduceOp.PRODUCT: nccl.NCCL_PROD,
-    ReduceOp.MIN: nccl.NCCL_MIN,
-    ReduceOp.MAX: nccl.NCCL_MAX,
-}
-
-# cupy types are the same with numpy types
-NUMPY_NCCL_DTYPE_MAP = {
-    # INT types
-    numpy.int: nccl.NCCL_INT64,
-    numpy.uint8: nccl.NCCL_UINT8,
-    numpy.uint32: nccl.NCCL_UINT32,
-    numpy.uint64: nccl.NCCL_UINT64,
-    numpy.int8: nccl.NCCL_INT8,
-    numpy.int32: nccl.NCCL_INT32,
-    numpy.int64: nccl.NCCL_INT64,
-    # FLOAT types
-    numpy.half: nccl.NCCL_HALF,
-    # note that numpy.float is float64.
-    numpy.float: nccl.NCCL_FLOAT64,
-    numpy.float16: nccl.NCCL_FLOAT16,
-    numpy.float32: nccl.NCCL_FLOAT32,
-    numpy.float64: nccl.NCCL_FLOAT64,
-    numpy.double: nccl.NCCL_DOUBLE
-}
+    # cupy types are the same with numpy types
+    NUMPY_NCCL_DTYPE_MAP = {
+        # INT types
+        numpy.int: nccl.NCCL_INT64,
+        numpy.uint8: nccl.NCCL_UINT8,
+        numpy.uint32: nccl.NCCL_UINT32,
+        numpy.uint64: nccl.NCCL_UINT64,
+        numpy.int8: nccl.NCCL_INT8,
+        numpy.int32: nccl.NCCL_INT32,
+        numpy.int64: nccl.NCCL_INT64,
+        # FLOAT types
+        numpy.half: nccl.NCCL_HALF,
+        # note that numpy.float is float64.
+        numpy.float: nccl.NCCL_FLOAT64,
+        numpy.float16: nccl.NCCL_FLOAT16,
+        numpy.float32: nccl.NCCL_FLOAT32,
+        numpy.float64: nccl.NCCL_FLOAT64,
+        numpy.double: nccl.NCCL_DOUBLE
+    }
 
 if torch_available():
     import torch
     import torch.utils.dlpack
-    TORCH_NCCL_DTYPE_MAP = {
-        # INT types
-        torch.int: nccl.NCCL_INT,
-        torch.uint8: nccl.NCCL_UINT8,
-        torch.int8: nccl.NCCL_INT8,
-        torch.int32: nccl.NCCL_INT32,
-        torch.int64: nccl.NCCL_INT64,
-        torch.long: nccl.NCCL_INT64,
-        # FLOAT types
-        torch.half: nccl.NCCL_HALF,
-        torch.float: nccl.NCCL_FLOAT,
-        torch.float16: nccl.NCCL_FLOAT16,
-        torch.float32: nccl.NCCL_FLOAT32,
-        torch.float64: nccl.NCCL_FLOAT64,
-        torch.double: nccl.NCCL_DOUBLE,
-    }
+
+    from alpa.collective.collective import nccl_available
+    if nccl_available():
+        TORCH_NCCL_DTYPE_MAP = {
+            # INT types
+            torch.int: nccl.NCCL_INT,
+            torch.uint8: nccl.NCCL_UINT8,
+            torch.int8: nccl.NCCL_INT8,
+            torch.int32: nccl.NCCL_INT32,
+            torch.int64: nccl.NCCL_INT64,
+            torch.long: nccl.NCCL_INT64,
+            # FLOAT types
+            torch.half: nccl.NCCL_HALF,
+            torch.float: nccl.NCCL_FLOAT,
+            torch.float16: nccl.NCCL_FLOAT16,
+            torch.float32: nccl.NCCL_FLOAT32,
+            torch.float64: nccl.NCCL_FLOAT64,
+            torch.double: nccl.NCCL_DOUBLE,
+        }
 
     TORCH_NUMPY_DTYPE_MAP = {
         # INT types

--- a/alpa/collective/collective_group/nccl_util.py
+++ b/alpa/collective/collective_group/nccl_util.py
@@ -1,7 +1,6 @@
 """Code to wrap some NCCL API calls."""
 import numpy
 
-from alpa.collective.collective import nccl_available
 from alpa.collective.types import ReduceOp, torch_available
 from alpa.global_env import global_config
 
@@ -51,7 +50,7 @@ if torch_available():
     import torch
     import torch.utils.dlpack
 
-    if nccl_available():
+    if global_config.has_cuda:
         TORCH_NCCL_DTYPE_MAP = {
             # INT types
             torch.int: nccl.NCCL_INT,

--- a/alpa/create_state_parallel.py
+++ b/alpa/create_state_parallel.py
@@ -7,8 +7,8 @@ from jax.interpreters import pxla
 from jax.tree_util import tree_flatten, tree_unflatten, PyTreeDef
 import numpy as np
 
-from alpa import global_config
 from alpa.device_mesh import ReplicatedDistributedArray, PhysicalDeviceMeshGroup
+from alpa.global_env import global_config
 from alpa.mesh_executable import (NormalMeshDriverExecutable,
                                   GradAccMeshDriverExecutable)
 from alpa.parallel_plan import PlacementSpec

--- a/alpa/create_state_parallel.py
+++ b/alpa/create_state_parallel.py
@@ -7,6 +7,7 @@ from jax.interpreters import pxla
 from jax.tree_util import tree_flatten, tree_unflatten, PyTreeDef
 import numpy as np
 
+from alpa import global_config
 from alpa.device_mesh import ReplicatedDistributedArray, PhysicalDeviceMeshGroup
 from alpa.mesh_executable import (NormalMeshDriverExecutable,
                                   GradAccMeshDriverExecutable)
@@ -88,6 +89,9 @@ def compile_create_state_executable(fun, in_tree, out_tree_thunk,
     placement_specs = executable.get_input_placement_specs()[0]
     placement_specs, _ = tree_flatten(placement_specs)
 
+    if (not isinstance(executable, NormalMeshDriverExecutable) and
+            global_config.backend == "tpu"):
+        raise NotImplementedError(f"{type(executable)} is not supported in tpu")
     if isinstance(executable,
                   (NormalMeshDriverExecutable, GradAccMeshDriverExecutable)):
         sharding_protos = []

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -59,11 +59,12 @@ from alpa.util import (benchmark_func, list_gpu_info, OrderedSet,
 
 ray_worker = try_import_ray_worker()
 
-if global_config.nccl_mode == "cupy":
-    import alpa.collective.worker_nccl_util_cupy as worker_nccl_util
-else:
-    assert global_config.nccl_mode == "xla_extension"
-    import alpa.collective.worker_nccl_util_xla as worker_nccl_util
+if global_config.backend == "gpu":
+    if global_config.nccl_mode == "cupy":
+        import alpa.collective.worker_nccl_util_cupy as worker_nccl_util
+    else:
+        assert global_config.nccl_mode == "xla_extension"
+        import alpa.collective.worker_nccl_util_xla as worker_nccl_util
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -126,8 +127,12 @@ class MeshHostWorker:
         self.distributed_client.connect()
         logger.debug(
             f"{host_id}: Success to connect to xla runtime at {server_address}")
-        self.backend = xla_client.make_gpu_client(self.distributed_client,
-                                                  node_id=host_id)
+        if global_config.backend == "gpu":
+            self.backend = xla_client.make_gpu_client(self.distributed_client,
+                                                      node_id=host_id)
+        else:
+            raise NotImplementedError(
+                f"backend {global_config.backend} is not supported")
         # Monkey patch the backend
         set_override_backend(self.backend)
         self.local_devices = self.backend.local_devices()
@@ -807,7 +812,7 @@ class LocalPhysicalDeviceMesh(PhysicalDeviceMesh):
         self.device_strs = []
         self.operation_executables = {}
 
-        self.backend = xb.get_backend("gpu")
+        self.backend = xb.get_backend(global_config.backend)
 
         self.set_runtime_random_seed(global_config.runtime_random_seed)
 
@@ -2118,7 +2123,7 @@ class DeviceCluster:
         # Gather device info
         self.host_num_devices = []
         for host_info in self.host_info:
-            number = host_info["Resources"]["GPU"]
+            number = host_info["Resources"][global_config.ray_accelerator_name]
             assert number.is_integer()
             self.host_num_devices.append(int(number))
 

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -59,7 +59,7 @@ from alpa.util import (benchmark_func, list_gpu_info, OrderedSet,
 
 ray_worker = try_import_ray_worker()
 
-if global_config.backend == "gpu":
+if global_config.backend == "gpu" and global_config.has_cuda:
     if global_config.nccl_mode == "cupy":
         import alpa.collective.worker_nccl_util_cupy as worker_nccl_util
     else:

--- a/alpa/follow_parallel.py
+++ b/alpa/follow_parallel.py
@@ -5,7 +5,7 @@ from jax.core import ClosedJaxpr
 from jax.interpreters import partial_eval as pe
 from jax.tree_util import tree_leaves
 
-from alpa import global_config
+from alpa.global_env import global_config
 from alpa.mesh_executable import (NormalMeshDriverExecutable,
                                   GradAccMeshDriverExecutable)
 from alpa.parallel_plan import PlacementSpec

--- a/alpa/follow_parallel.py
+++ b/alpa/follow_parallel.py
@@ -5,6 +5,7 @@ from jax.core import ClosedJaxpr
 from jax.interpreters import partial_eval as pe
 from jax.tree_util import tree_leaves
 
+from alpa import global_config
 from alpa.mesh_executable import (NormalMeshDriverExecutable,
                                   GradAccMeshDriverExecutable)
 from alpa.parallel_plan import PlacementSpec
@@ -33,6 +34,9 @@ def compile_follow_parallel_executable(fun, in_tree, out_tree_thunk,
     input_placement_specs = tree_leaves(input_placement_specs, is_leave)
 
     executable = src_func.get_last_executable()
+    if (not isinstance(executable, NormalMeshDriverExecutable) and
+            global_config.backend == "tpu"):
+        raise NotImplementedError(f"{type(executable)} is not supported in tpu")
     if isinstance(executable,
                   (NormalMeshDriverExecutable, GradAccMeshDriverExecutable)):
         if num_micro_batches != 1 and num_micro_batches is not None:

--- a/alpa/global_env.py
+++ b/alpa/global_env.py
@@ -9,7 +9,7 @@ class GlobalConfig:
         ########## Options of device mesh ##########
         self.backend = "gpu"
         # See https://jax.readthedocs.io/en/latest/gpu_memory_allocation.html
-        self.has_cuda = False
+        self.has_cuda = os.system("nvidia-smi > /dev/null 2>&1") == 0
         self.xla_client_mem_fraction = float(
             os.environ.get("XLA_PYTHON_CLIENT_MEM_FRACTION", 0.9))
         self.xla_gpu_autotune_level = 4

--- a/alpa/global_env.py
+++ b/alpa/global_env.py
@@ -7,7 +7,9 @@ class GlobalConfig:
 
     def __init__(self):
         ########## Options of device mesh ##########
+        self.backend = "tpu"
         # See https://jax.readthedocs.io/en/latest/gpu_memory_allocation.html
+        self.has_cuda = False
         self.xla_client_mem_fraction = float(
             os.environ.get("XLA_PYTHON_CLIENT_MEM_FRACTION", 0.9))
         self.xla_gpu_autotune_level = 4

--- a/alpa/global_env.py
+++ b/alpa/global_env.py
@@ -7,7 +7,7 @@ class GlobalConfig:
 
     def __init__(self):
         ########## Options of device mesh ##########
-        self.backend = "tpu"
+        self.backend = "gpu"
         # See https://jax.readthedocs.io/en/latest/gpu_memory_allocation.html
         self.has_cuda = False
         self.xla_client_mem_fraction = float(

--- a/alpa/global_env.py
+++ b/alpa/global_env.py
@@ -83,6 +83,11 @@ class GlobalConfig:
         # Whether to collect activity trace
         self.collect_trace = False
 
+    @property
+    def ray_accelerator_name(self):
+        backend_to_ray = {"gpu": "GPU"}
+        return backend_to_ray[self.backend]
+
 
 global_config = GlobalConfig()
 

--- a/alpa/global_env.py
+++ b/alpa/global_env.py
@@ -9,7 +9,7 @@ class GlobalConfig:
         ########## Options of device mesh ##########
         self.backend = "gpu"
         # See https://jax.readthedocs.io/en/latest/gpu_memory_allocation.html
-        self.has_cuda = os.system("nvidia-smi > /dev/null 2>&1") == 0
+        self.has_cuda = True
         self.xla_client_mem_fraction = float(
             os.environ.get("XLA_PYTHON_CLIENT_MEM_FRACTION", 0.9))
         self.xla_gpu_autotune_level = 4

--- a/alpa/global_env.py
+++ b/alpa/global_env.py
@@ -9,7 +9,7 @@ class GlobalConfig:
         ########## Options of device mesh ##########
         self.backend = "gpu"
         # See https://jax.readthedocs.io/en/latest/gpu_memory_allocation.html
-        self.has_cuda = True
+        self.has_cuda = os.system("nvidia-smi > /dev/null 2>&1") == 0
         self.xla_client_mem_fraction = float(
             os.environ.get("XLA_PYTHON_CLIENT_MEM_FRACTION", 0.9))
         self.xla_gpu_autotune_level = 4

--- a/alpa/mesh_executable.py
+++ b/alpa/mesh_executable.py
@@ -215,7 +215,8 @@ class NormalMeshDriverExecutable(MeshDriverExecutable):
         self.exec_uuid = next_mesh_executable_uuid()
         self._set_executable(physical_mesh, hlo, stage_plan)
 
-        hlo = run_spmd_partitioner_pass(hlo, physical_mesh.num_devices)
+        if hlo.is_sharding_annotated():
+            hlo = run_spmd_partitioner_pass(hlo, physical_mesh.num_devices)
         # Read sharding specs
         self.input_sharding_specs, self.output_sharding_specs = (
             get_input_output_sharding_specs(hlo.get_module(), avals, out_avals,

--- a/alpa/mesh_executable.py
+++ b/alpa/mesh_executable.py
@@ -210,6 +210,12 @@ class NormalMeshDriverExecutable(MeshDriverExecutable):
         self.auto_sharding_option = stage_plan.auto_sharding_option
         self.auto_sharding_objective = stage_plan.auto_sharding_objective
 
+        # Send the executable to workers
+        self.fully_optimized_hlo_text = None
+        self.exec_uuid = next_mesh_executable_uuid()
+        self._set_executable(physical_mesh, hlo, stage_plan)
+
+        hlo = run_spmd_partitioner_pass(hlo, physical_mesh.num_devices)
         # Read sharding specs
         self.input_sharding_specs, self.output_sharding_specs = (
             get_input_output_sharding_specs(hlo.get_module(), avals, out_avals,
@@ -223,11 +229,6 @@ class NormalMeshDriverExecutable(MeshDriverExecutable):
         ]
         self.outs_handler = physical_mesh.get_outputs_handler(
             out_avals, self.output_sharding_specs)
-
-        # Send the executable to workers
-        self.fully_optimized_hlo_text = None
-        self.exec_uuid = next_mesh_executable_uuid()
-        self._set_executable(physical_mesh, hlo, stage_plan)
 
         # Set up timers
         self.exec_timer_name = get_execution_timer_name(self.exec_uuid)

--- a/alpa/pipeline_parallel/compile_executable.py
+++ b/alpa/pipeline_parallel/compile_executable.py
@@ -59,6 +59,8 @@ def compile_pipeshard_executable(
         stage_input_shardings: Forcibly set sharding specs of input vars of
           each stage.
     """
+    if global_config.backend == "tpu":
+        raise NotImplementedError("Pipeshard Parallel for tpu is not supported")
     debug_compilation_time(None)
     name_base = f"{fun.__name__}_pipeshard_parallel"
 

--- a/alpa/pipeline_parallel/computation.py
+++ b/alpa/pipeline_parallel/computation.py
@@ -157,8 +157,9 @@ class XlaPipelineComputation(PipelineComputation):
     def get_runnable(self, mesh=None):
         """Return a callable of the pipeline computation."""
         out_avals = [var.aval for var in self.outvars]
-        tuple_args = False
-        backend = xb.get_backend("gpu")
+        tuple_args = len(
+            self.invars) > 100  # pass long arg lists as tuple for TPU
+        backend = xb.get_backend(global_config.backend)
         device = backend.get_default_device_assignment(1)[0]
         options = get_compile_options(
             num_replicas=1,
@@ -216,6 +217,7 @@ class XlaShardedPipelineComputation(PipelineComputation):
     @classmethod
     def dummy_computation(cls, name, logical_mesh_shape, gensym_func):
         """Create a dummy computation."""
+        backend = xb.get_backend(global_config.backend)
         stage_plan = StagePlan(global_config.compile_random_seed,
                                logical_mesh_shape, 1, 1, AutoShardingOption(),
                                None, 0)

--- a/alpa/pipeline_parallel/computation.py
+++ b/alpa/pipeline_parallel/computation.py
@@ -157,8 +157,7 @@ class XlaPipelineComputation(PipelineComputation):
     def get_runnable(self, mesh=None):
         """Return a callable of the pipeline computation."""
         out_avals = [var.aval for var in self.outvars]
-        tuple_args = len(
-            self.invars) > 100  # pass long arg lists as tuple for TPU
+        tuple_args = len(self.invars) > 100 and global_config.backend == "tpu"
         backend = xb.get_backend(global_config.backend)
         device = backend.get_default_device_assignment(1)[0]
         options = get_compile_options(

--- a/alpa/pipeline_parallel/computation.py
+++ b/alpa/pipeline_parallel/computation.py
@@ -217,7 +217,6 @@ class XlaShardedPipelineComputation(PipelineComputation):
     @classmethod
     def dummy_computation(cls, name, logical_mesh_shape, gensym_func):
         """Create a dummy computation."""
-        backend = xb.get_backend(global_config.backend)
         stage_plan = StagePlan(global_config.compile_random_seed,
                                logical_mesh_shape, 1, 1, AutoShardingOption(),
                                None, 0)

--- a/alpa/pipeline_parallel/primitive_def.py
+++ b/alpa/pipeline_parallel/primitive_def.py
@@ -9,7 +9,6 @@ from jax.tree_util import tree_flatten, tree_unflatten
 
 from alpa.util import new_jaxpr_eqn
 
-
 ########## Public APIs ##########
 
 # Define a Jax primitive to mark start/end of a pipeline computation.

--- a/alpa/pipeline_parallel/primitive_def.py
+++ b/alpa/pipeline_parallel/primitive_def.py
@@ -9,6 +9,7 @@ from jax.tree_util import tree_flatten, tree_unflatten
 
 from alpa.util import new_jaxpr_eqn
 
+
 ########## Public APIs ##########
 
 # Define a Jax primitive to mark start/end of a pipeline computation.

--- a/alpa/pipeline_parallel/stage_profiling.py
+++ b/alpa/pipeline_parallel/stage_profiling.py
@@ -353,7 +353,7 @@ class HloCostModelProfileWorker:
     """A ray actor to estimate the cost of WrappedHLO based on cost model."""
 
     def __init__(self, prof_result, num_devices, num_micro_batches):
-        self.backend = xb.get_backend("gpu")
+        self.backend = xb.get_backend(global_config.backend)
         self.prof_result = prof_result
         self.num_devices = num_devices
         self.num_micro_batches = num_micro_batches

--- a/alpa/shard_parallel/auto_sharding.py
+++ b/alpa/shard_parallel/auto_sharding.py
@@ -381,7 +381,7 @@ def run_spmd_partitioner_pass(
       rewrite_grad_acc_indices: The indices of tensors in output that are
         gradients.
     """
-    assert hlo.is_sharding_annotated()
+    assert hlo.is_sharding_annotated(), f"{hlo.status}"
     compile_options = get_compile_options(
         num_replicas=1,
         num_partitions=num_devices,

--- a/alpa/shard_parallel/auto_sharding.py
+++ b/alpa/shard_parallel/auto_sharding.py
@@ -188,7 +188,7 @@ def run_auto_sharding_pass(
       return_mode: The mode of return value.
         The choices are {"single", "stages", "stage_and_hook_protos"}.
         If it is "single", return a single WrappedHlo, whose status is
-          SPMD_PARTITIONED.
+          SHARDING_ANNOTATED.
         If it is "stages", return WrappedHlo of multiple pipeline stages,
           whose statuses are SHARDING_ANNOTATED.
         If it is "stages_and_hook", return WrappedHlos of multiple pipeline
@@ -343,7 +343,7 @@ def run_auto_sharding_pass(
         timers("auto-sharding").start()
         xe.run_auto_sharding(hlo.get_module(), compile_options)
         timers("auto-sharding").stop()
-    hlo.status = HloStatus.SPMD_PARTITIONED
+    hlo.status = HloStatus.SHARDING_ANNOTATED
 
     if multiple_stages:
         hlo_stage_names, hlo_stages = get_auto_sharded_hlo_stages()

--- a/alpa/shard_parallel/auto_sharding.py
+++ b/alpa/shard_parallel/auto_sharding.py
@@ -419,12 +419,12 @@ def run_backend_compilation(backend: xe.Client,
       num_devices: The total number of devices.
       bypass_device_assignment_check: Whether to compile without exact devices.
     """
-    assert hlo.is_spmd_partitioned()
+    assert hlo.is_spmd_partitioned() or hlo.is_sharding_annotated()
     compile_options = get_compile_options(
         num_replicas=1,
         num_partitions=num_devices,
         device_assignment=np.arange(num_devices).reshape((1, -1)),
-        use_spmd_partitioning=True,
+        use_spmd_partitioning=hlo.is_sharding_annotated(),
         parameter_is_tupled_arguments=False,
         build_random_seed=stage_plan.build_random_seed)
 

--- a/alpa/shard_parallel/auto_sharding.py
+++ b/alpa/shard_parallel/auto_sharding.py
@@ -424,7 +424,7 @@ def run_backend_compilation(backend: xe.Client,
         num_replicas=1,
         num_partitions=num_devices,
         device_assignment=np.arange(num_devices).reshape((1, -1)),
-        use_spmd_partitioning=False,
+        use_spmd_partitioning=True,
         parameter_is_tupled_arguments=False,
         build_random_seed=stage_plan.build_random_seed)
 

--- a/alpa/shard_parallel/compile_executable.py
+++ b/alpa/shard_parallel/compile_executable.py
@@ -120,6 +120,10 @@ def shard_parallel_internal(
     # Compile a XLA executable
     hlo, stage_plan = run_auto_sharding_pass(hlo, logical_mesh_choices[0],
                                              "single", 1, as_option)
+    # This is a walkaround because XLA GpuCompiler has some issue
+    if global_config.backend == "gpu":
+        hlo = run_spmd_partitioner_pass(hlo,
+                                        np.prod(logical_mesh_choices[0].shape))
 
     # Compile a mesh executable
     return NormalMeshDriverExecutable(physical_mesh,

--- a/alpa/shard_parallel/compile_executable.py
+++ b/alpa/shard_parallel/compile_executable.py
@@ -12,6 +12,7 @@ from jax.core import (Jaxpr, ClosedJaxpr, Literal, gensym, get_aval,
 from jax.lax import add_p, div_p
 from jax.tree_util import PyTreeDef
 
+from alpa import global_config
 from alpa.device_mesh import LogicalDeviceMesh, PhysicalDeviceMesh
 from alpa.mesh_executable import (NormalMeshDriverExecutable,
                                   GradAccMeshDriverExecutable)
@@ -75,6 +76,9 @@ def compile_shard_executable(
                                        physical_mesh, logical_mesh_choices,
                                        as_option, *avals)
     else:
+        if global_config.backend == "tpu":
+            raise NotImplementedError(
+                "Gradient accumulation for tpu is not supported")
         return shard_parallel_internal_gradient_accumulation(
             fun, in_tree, out_tree_thunk, static_argnums, donated_invars,
             batch_invars, physical_mesh, logical_mesh_choices,

--- a/alpa/shard_parallel/compile_executable.py
+++ b/alpa/shard_parallel/compile_executable.py
@@ -12,8 +12,8 @@ from jax.core import (Jaxpr, ClosedJaxpr, Literal, gensym, get_aval,
 from jax.lax import add_p, div_p
 from jax.tree_util import PyTreeDef
 
-from alpa import global_config
 from alpa.device_mesh import LogicalDeviceMesh, PhysicalDeviceMesh
+from alpa.global_env import global_config
 from alpa.mesh_executable import (NormalMeshDriverExecutable,
                                   GradAccMeshDriverExecutable)
 from alpa.pipeline_parallel.apply_grad import APPLY_GRAD_MARKER_SUFFIX

--- a/alpa/util.py
+++ b/alpa/util.py
@@ -1254,7 +1254,7 @@ def run_cmd(cmd: str):
 
 
 def list_gpu_info():
-    """List all gpu information by calling nvidia-sim."""
+    """List all gpu information by calling nvidia-smi."""
     ret = subprocess.getoutput("nvidia-smi -L")
     visible_devices = os.environ.get("CUDA_VISIBLE_DEVICES", None)
     if visible_devices:

--- a/alpa/util.py
+++ b/alpa/util.py
@@ -1281,7 +1281,13 @@ def get_num_hosts_and_num_devices(args):
     else:
         if hasattr(args, "local") and args.local:
             num_hosts = 1
-            num_devices_per_host = list_gpu_info().count("UUID")
+            if alpa.global_config.backend == "gpu":
+                num_devices_per_host = list_gpu_info().count("UUID")
+            elif alpa.global_config.backend == "tpu":
+                num_devices_per_host = len(jax.devices("tpu"))
+            else:
+                raise ValueError(
+                    f"Unsupported backend: {alpa.global_config.backend}")
         else:
             ray.init(address="auto")
             num_hosts = len(ray.nodes())

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 
 IS_WINDOWS = sys.platform == "win32"
 ROOT_DIR = os.path.dirname(__file__)
-HAS_CUDA = True
+HAS_CUDA = os.system("nvidia-smi > /dev/null 2>&1") == 0
 
 
 def get_cuda_version(cuda_home):

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ from setuptools import setup, find_packages
 
 IS_WINDOWS = sys.platform == "win32"
 ROOT_DIR = os.path.dirname(__file__)
+IS_CUDA = False
 
 
 def get_cuda_version(cuda_home):
@@ -92,9 +93,13 @@ install_require_list = [
 ]
 
 dev_require_list = [
-    f"cupy-cuda{get_cuda_version_str(no_dot=True)}", "yapf==0.32.0",
-    "pylint==2.14.0", "cmake", "pybind11"
+    "yapf==0.32.0", "pylint==2.14.0", "cmake", "pybind11"
 ]
+
+if IS_CUDA:
+    dev_require_list += [
+        f"cupy-cuda{get_cuda_version_str(no_dot=True)}",
+    ]
 
 doc_require_list = [
     "sphinx", "sphinx-rtd-theme", "sphinx-gallery", "matplotlib"

--- a/setup.py
+++ b/setup.py
@@ -92,9 +92,7 @@ install_require_list = [
     "numba",
 ]
 
-dev_require_list = [
-    "yapf==0.32.0", "pylint==2.14.0", "cmake", "pybind11"
-]
+dev_require_list = ["yapf==0.32.0", "pylint==2.14.0", "cmake", "pybind11"]
 
 if IS_CUDA:
     dev_require_list += [
@@ -151,7 +149,8 @@ if __name__ == "__main__":
         ],
         keywords=("alpa distributed parallel machine-learning model-parallelism"
                   "gpt-3 deep-learning language-model python"),
-        packages=find_packages(exclude=["benchmark", "examples", "playground", "tests"]),
+        packages=find_packages(
+            exclude=["benchmark", "examples", "playground", "tests"]),
         python_requires='>=3.7',
         cmdclass={"install": InstallPlatlib},
         install_requires=install_require_list,

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 
 IS_WINDOWS = sys.platform == "win32"
 ROOT_DIR = os.path.dirname(__file__)
-IS_CUDA = False
+HAS_CUDA = os.system("nvidia-smi > /dev/null 2>&1") == 0
 
 
 def get_cuda_version(cuda_home):
@@ -94,7 +94,7 @@ install_require_list = [
 
 dev_require_list = ["yapf==0.32.0", "pylint==2.14.0", "cmake", "pybind11"]
 
-if IS_CUDA:
+if HAS_CUDA:
     dev_require_list += [
         f"cupy-cuda{get_cuda_version_str(no_dot=True)}",
     ]

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 
 IS_WINDOWS = sys.platform == "win32"
 ROOT_DIR = os.path.dirname(__file__)
-HAS_CUDA = os.system("nvidia-smi > /dev/null 2>&1") == 0
+HAS_CUDA = True
 
 
 def get_cuda_version(cuda_home):

--- a/tests/run_all.py
+++ b/tests/run_all.py
@@ -44,6 +44,8 @@ def run_unittest_files(files, args):
             continue
         if not args.enable_slow_tests and filename in slow_testcases:
             continue
+        if args.run_tpu ^ ("tpu" in filename):
+            continue
 
         def func():
             ret = unittest.main(module=None, argv=["", "-vb"] + [filename])
@@ -98,6 +100,9 @@ if __name__ == "__main__":
                             type=str,
                             default="sorted",
                             choices=["sorted", "random", "reverse_sorted"])
+    arg_parser.add_argument("--run-tpu",
+                            action="store_true",
+                            help="Whether to run tests for tpus.")
     args = arg_parser.parse_args()
 
     files = glob.glob("**/test_*.py", recursive=True)

--- a/tests/runtime/test_create_state.py
+++ b/tests/runtime/test_create_state.py
@@ -26,6 +26,9 @@ class CreateStateTest(unittest.TestCase):
         batch_size = 8
         input_dim = output_dim = hidden_dim = 32
 
+        grad_fn = (jax.grad if isinstance(method, ShardParallel) and
+                   method.num_micro_batches is None else alpa.grad)
+
         class Model(nn.Module):
 
             @nn.compact
@@ -44,7 +47,7 @@ class CreateStateTest(unittest.TestCase):
                 out = state.apply_fn(params, batch["x"])
                 return jnp.mean((out - batch["y"])**2)
 
-            grads = alpa.grad(loss_func)(state.params)
+            grads = grad_fn(loss_func)(state.params)
             new_state = state.apply_gradients(grads=grads)
             return new_state
 

--- a/tests/runtime/test_follow_parallel.py
+++ b/tests/runtime/test_follow_parallel.py
@@ -4,13 +4,11 @@ import unittest
 from flax import linen as nn
 from flax.training.train_state import TrainState
 import jax
-from jax._src.api import make_jaxpr
 import jax.numpy as jnp
 import optax
 
 import alpa
-from alpa import (init, shutdown, parallelize, ShardParallel, PipeshardParallel,
-                  CreateStateParallel)
+from alpa import init, shutdown, parallelize, ShardParallel, PipeshardParallel
 
 
 class FollowParallelTest(unittest.TestCase):
@@ -42,7 +40,7 @@ class FollowParallelTest(unittest.TestCase):
                 out = state.apply_fn(params, batch["x"])
                 return jnp.mean((out - batch["y"])**2)
 
-            grads = alpa.grad(loss_func)(state.params)
+            grads = grad_fn(loss_func)(state.params)
             new_state = state.apply_gradients(grads=grads)
             return new_state
 
@@ -68,8 +66,10 @@ class FollowParallelTest(unittest.TestCase):
 
         if isinstance(method, ShardParallel):
             num_micro_batches = None
+            grad_fn = jax.grad
         else:
             num_micro_batches = 2
+            grad_fn = alpa.grad
 
         state = create_state()
 

--- a/tests/runtime/test_follow_parallel.py
+++ b/tests/runtime/test_follow_parallel.py
@@ -64,12 +64,8 @@ class FollowParallelTest(unittest.TestCase):
             "y": jnp.ones((batch_size * 2, output_dim)),
         }
 
-        if isinstance(method, ShardParallel):
-            num_micro_batches = None
-            grad_fn = jax.grad
-        else:
-            num_micro_batches = 2
-            grad_fn = alpa.grad
+        grad_fn = jax.grad if method.num_micro_batches is None else alpa.grad
+        num_micro_batches = method.num_micro_batches
 
         state = create_state()
 

--- a/tests/shard_parallel/test_mlp.py
+++ b/tests/shard_parallel/test_mlp.py
@@ -12,8 +12,8 @@ from jax.interpreters.pxla import Chunked, NoSharding, Replicated, ShardedAxis
 import optax
 
 from alpa import (parallelize, LocalPhysicalDeviceMesh, AutoShardingOption,
-                  ShardParallel, DataParallel, Zero2Parallel, Zero3Parallel)
-from alpa.util import map_to_shape, count_communication_primitives
+                  ShardParallel, Zero2Parallel, Zero3Parallel)
+from alpa.util import count_communication_primitives
 
 
 def assert_close(x, y, atol=0.01):

--- a/tests/shard_parallel/test_moe.py
+++ b/tests/shard_parallel/test_moe.py
@@ -2,15 +2,13 @@
 
 import unittest
 
-from flax import linen as nn
 import jax
 import jax.numpy as jnp
-from jax.interpreters.pxla import Chunked, NoSharding, Replicated, ShardedAxis
 import numpy as np
 import optax
 
 from alpa import parallelize, ShardParallel, LocalPhysicalDeviceMesh, AutoShardingOption
-from alpa.util import map_to_shape, count_communication_primitives
+from alpa.util import count_communication_primitives
 from alpa.model.moe import FlaxMoELayer, FlaxMoEForLMModule, MoEConfig, TrainState
 
 from tests.shard_parallel.test_mlp import (assert_all_replicated, assert_close,

--- a/tests/tpu/test_create_state_parallel.py
+++ b/tests/tpu/test_create_state_parallel.py
@@ -3,11 +3,11 @@ import unittest
 
 from alpa import global_config
 
-from tests.runtime.test_create_state import CreateStateTest
+import tests.runtime.test_create_state as test_create_state
 from tests.tpu.test_shard_parallel import has_tpu
 
 
-class TpuCreateStateTest(CreateStateTest):
+class TpuCreateStateTest(test_create_state.CreateStateTest):
 
     def setUp(self):
         global_config.backend = "tpu"
@@ -15,6 +15,13 @@ class TpuCreateStateTest(CreateStateTest):
     def tearDown(self):
         return
 
+    @unittest.skip("unsupported yet.")
+    def test_shard_parallel_grad_acc(self):
+        super().test_shard_parallel_grad_acc()
+
+    @unittest.skip("unsupported yet.")
+    def test_pipeshard_parallel(self):
+        super().test_pipeshard_parallel()
 
 def suite():
     suite = unittest.TestSuite()

--- a/tests/tpu/test_create_state_parallel.py
+++ b/tests/tpu/test_create_state_parallel.py
@@ -1,0 +1,28 @@
+"""Test CreateStateParallel on TPU."""
+import unittest
+
+from alpa import global_config
+
+from tests.runtime.test_create_state import CreateStateTest
+from tests.tpu.test_shard_parallel import has_tpu
+
+class TpuCreateStateTest(CreateStateTest):
+
+    def setUp(self):
+        global_config.backend = "tpu"
+
+    def tearDown(self):
+        return
+
+def suite():
+    suite = unittest.TestSuite()
+    if not has_tpu():
+        return suite
+
+    suite.addTest(TpuCreateStateTest("test_shard_parallel"))
+    return suite
+
+
+if __name__ == "__main__":
+    runner = unittest.TextTestRunner()
+    runner.run(suite())

--- a/tests/tpu/test_create_state_parallel.py
+++ b/tests/tpu/test_create_state_parallel.py
@@ -6,6 +6,7 @@ from alpa import global_config
 from tests.runtime.test_create_state import CreateStateTest
 from tests.tpu.test_shard_parallel import has_tpu
 
+
 class TpuCreateStateTest(CreateStateTest):
 
     def setUp(self):
@@ -13,6 +14,7 @@ class TpuCreateStateTest(CreateStateTest):
 
     def tearDown(self):
         return
+
 
 def suite():
     suite = unittest.TestSuite()

--- a/tests/tpu/test_create_state_parallel.py
+++ b/tests/tpu/test_create_state_parallel.py
@@ -23,6 +23,7 @@ class TpuCreateStateTest(test_create_state.CreateStateTest):
     def test_pipeshard_parallel(self):
         super().test_pipeshard_parallel()
 
+
 def suite():
     suite = unittest.TestSuite()
     if not has_tpu():

--- a/tests/tpu/test_follow_parallel.py
+++ b/tests/tpu/test_follow_parallel.py
@@ -6,6 +6,7 @@ from alpa import global_config
 from tests.runtime.test_follow_parallel import FollowParallelTest
 from tests.tpu.test_shard_parallel import has_tpu
 
+
 class TpuFollowParallelTest(FollowParallelTest):
 
     def setUp(self):
@@ -13,6 +14,7 @@ class TpuFollowParallelTest(FollowParallelTest):
 
     def tearDown(self):
         return
+
 
 def suite():
     suite = unittest.TestSuite()

--- a/tests/tpu/test_follow_parallel.py
+++ b/tests/tpu/test_follow_parallel.py
@@ -1,0 +1,28 @@
+"""Test FollowParallel on TPU."""
+import unittest
+
+from alpa import global_config
+
+from tests.runtime.test_follow_parallel import FollowParallelTest
+from tests.tpu.test_shard_parallel import has_tpu
+
+class TpuFollowParallelTest(FollowParallelTest):
+
+    def setUp(self):
+        global_config.backend = "tpu"
+
+    def tearDown(self):
+        return
+
+def suite():
+    suite = unittest.TestSuite()
+    if not has_tpu():
+        return suite
+
+    suite.addTest(TpuFollowParallelTest("test_shard_parallel"))
+    return suite
+
+
+if __name__ == "__main__":
+    runner = unittest.TextTestRunner()
+    runner.run(suite())

--- a/tests/tpu/test_follow_parallel.py
+++ b/tests/tpu/test_follow_parallel.py
@@ -3,17 +3,25 @@ import unittest
 
 from alpa import global_config
 
-from tests.runtime.test_follow_parallel import FollowParallelTest
+import tests.runtime.test_follow_parallel as test_follow_parallel
 from tests.tpu.test_shard_parallel import has_tpu
 
 
-class TpuFollowParallelTest(FollowParallelTest):
+class TpuFollowParallelTest(test_follow_parallel.FollowParallelTest):
 
     def setUp(self):
         global_config.backend = "tpu"
 
     def tearDown(self):
         return
+
+    @unittest.skip("unsupported yet.")
+    def test_shard_parallel_grad_acc(self):
+        super().test_shard_parallel_grad_acc()
+
+    @unittest.skip("unsupported yet.")
+    def test_pipeshard_parallel(self):
+        super().test_pipeshard_parallel()
 
 
 def suite():

--- a/tests/tpu/test_shard_parallel.py
+++ b/tests/tpu/test_shard_parallel.py
@@ -5,8 +5,8 @@ import jax
 
 from alpa import global_config
 
-from tests.shard_parallel.test_mlp import AutoShardingMLPTest
-from tests.shard_parallel.test_moe import AutoShardingMoETest
+import tests.shard_parallel.test_mlp as test_mlp
+import tests.shard_parallel.test_moe as test_moe
 
 with_device = {}
 
@@ -31,19 +31,57 @@ def has_gpu():
     return has_device("gpu")
 
 
-class AutoShardingTpuMlpTest(AutoShardingMLPTest):
+class AutoShardingTpuMlpTest(test_mlp.AutoShardingMLPTest):
 
     def setUp(self):
         global_config.backend = "tpu"
         super().setUp()
 
+    @unittest.skip("unsupported yet")
+    def test_n_layer_mlp_data_parallel_reduce_scatter(self):
+        super().test_n_layer_mlp_data_parallel_reduce_scatter()
 
-class AutoShardingTpuMoeTest(AutoShardingMoETest):
+    @unittest.skip("unsupported yet")
+    def test_n_layer_mlp_model_parallel_reduce_scatter(self):
+        super().test_n_layer_mlp_model_parallel_reduce_scatter()
+
+    @unittest.skip("unsupported yet")
+    def test_n_layer_mlp_2d_mesh_reduce_scatter(self):
+        super().test_n_layer_mlp_2d_mesh_reduce_scatter()
+
+    @unittest.skip("unsupported yet")
+    def test_n_layer_mlp_data_parallel_reduce_scatter_adafactor(self):
+        super().test_n_layer_mlp_data_parallel_reduce_scatter_adafactor()
+
+    @unittest.skip("unsupported yet")
+    def test_n_layer_mlp_data_parallel_reduce_scatter_zero_stage_3(self):
+        super().test_n_layer_mlp_data_parallel_reduce_scatter_zero_stage_3()
+
+class AutoShardingTpuMoeTest(test_moe.AutoShardingMoETest):
 
     def setUp(self):
         global_config.backend = "tpu"
         super().setUp()
 
+    @unittest.skip("unsupported yet")
+    def test_moe_layer_2d_reduce_scatter(self):
+        super().test_moe_layer_2d_reduce_scatter()
+
+    @unittest.skip("unsupported yet")
+    def test_moe_lm_reduce_scatter(self):
+        super().test_moe_lm_reduce_scatter()
+
+    @unittest.skip("unsupported yet")
+    def test_moe_lm_2d_reduce_scatter(self):
+        super().test_moe_lm_2d_reduce_scatter()
+
+    @unittest.skip("unsupported yet")
+    def test_moe_lm_data_parallel_reduce_scatter(self):
+        super().test_moe_lm_data_parallel_reduce_scatter()
+
+    @unittest.skip("unsupported yet")
+    def test_moe_lm_data_parallel_reduce_scatter_zero_3(self):
+        super().test_moe_lm_data_parallel_reduce_scatter_zero_3()
 
 def suite():
     suite = unittest.TestSuite()
@@ -61,6 +99,7 @@ def suite():
     add_mlp("test_n_layer_mlp_2d_mesh")
     add_mlp("test_n_layer_mlp_force_data_parallel")
     add_mlp("test_n_layer_mlp_force_batch_dim_mapping")
+    add_mlp("test_weight_init")
 
     add_moe("test_moe_layer")
     add_moe("test_moe_layer_2d")

--- a/tests/tpu/test_shard_parallel.py
+++ b/tests/tpu/test_shard_parallel.py
@@ -57,6 +57,7 @@ class AutoShardingTpuMlpTest(test_mlp.AutoShardingMLPTest):
     def test_n_layer_mlp_data_parallel_reduce_scatter_zero_stage_3(self):
         super().test_n_layer_mlp_data_parallel_reduce_scatter_zero_stage_3()
 
+
 class AutoShardingTpuMoeTest(test_moe.AutoShardingMoETest):
 
     def setUp(self):

--- a/tests/tpu/test_shard_parallel.py
+++ b/tests/tpu/test_shard_parallel.py
@@ -83,6 +83,7 @@ class AutoShardingTpuMoeTest(test_moe.AutoShardingMoETest):
     def test_moe_lm_data_parallel_reduce_scatter_zero_3(self):
         super().test_moe_lm_data_parallel_reduce_scatter_zero_3()
 
+
 def suite():
     suite = unittest.TestSuite()
     if not has_tpu():

--- a/tests/tpu/test_shard_parallel.py
+++ b/tests/tpu/test_shard_parallel.py
@@ -1,0 +1,74 @@
+"""Test auto sharding with MLP and MoE on TPU."""
+import unittest
+
+import jax
+
+from alpa import global_config
+
+from tests.shard_parallel.test_mlp import AutoShardingMLPTest
+from tests.shard_parallel.test_moe import AutoShardingMoETest
+
+with_device = {}
+
+
+def has_device(name):
+    global with_device
+    if name in with_device:
+        return with_device[name]
+    try:
+        jax.devices(name)
+        with_device[name] = True
+    except RuntimeError:
+        with_device[name] = False
+    return with_device[name]
+
+
+def has_tpu():
+    return has_device("tpu")
+
+
+def has_gpu():
+    return has_device("gpu")
+
+
+class AutoShardingTpuMlpTest(AutoShardingMLPTest):
+
+    def setUp(self):
+        global_config.backend = "tpu"
+        super().setUp()
+
+class AutoShardingTpuMoeTest(AutoShardingMoETest):
+
+    def setUp(self):
+        global_config.backend = "tpu"
+        super().setUp()
+
+def suite():
+    suite = unittest.TestSuite()
+    if not has_tpu():
+        return suite
+
+    def add_mlp(name):
+        suite.addTest(AutoShardingTpuMlpTest(name))
+
+    def add_moe(name):
+        suite.addTest(AutoShardingTpuMoeTest(name))
+
+    add_mlp("test_n_layer_mlp_data_parallel")
+    add_mlp("test_n_layer_mlp_model_parallel")
+    add_mlp("test_n_layer_mlp_2d_mesh")
+    add_mlp("test_n_layer_mlp_force_data_parallel")
+    add_mlp("test_n_layer_mlp_force_batch_dim_mapping")
+
+    add_moe("test_moe_layer")
+    add_moe("test_moe_layer_2d")
+    add_moe("test_moe_lm")
+    add_moe("test_moe_lm_2d")
+    add_moe("test_moe_lm_data_parallel")
+
+    return suite
+
+
+if __name__ == "__main__":
+    runner = unittest.TextTestRunner()
+    runner.run(suite())

--- a/tests/tpu/test_shard_parallel.py
+++ b/tests/tpu/test_shard_parallel.py
@@ -37,11 +37,13 @@ class AutoShardingTpuMlpTest(AutoShardingMLPTest):
         global_config.backend = "tpu"
         super().setUp()
 
+
 class AutoShardingTpuMoeTest(AutoShardingMoETest):
 
     def setUp(self):
         global_config.backend = "tpu"
         super().setUp()
+
 
 def suite():
     suite = unittest.TestSuite()


### PR DESCRIPTION
This PR:
- Add `has_cuda` and `backend` in `global_config`
- Add `IS_CUDA` in `setup.py`
- Change the semantic of `run_auto_sharding_pass` and `run_backend_compilation`: the output of the `run_auto_sharding_pass` and input of `run_backend_compilation` is no longer the spmd-partitioned module, but instead the sharding annotated module. This is because TPU cannot compile an spmd-partitioned module with sharding configurations;
- write testcases specifically for TPUs. The pass that rewrites `AllReduce` to `ReduceScatter` and `AllGather` is after SPMD partitioner, so we cannot do it for the tpu backend.