### PR TITLE
[FIX] Use the ip address of the profile worker as XLA server address & fix available memory memory bug in distributed profiling

### DIFF
--- a/alpa/pipeline_parallel/stage_profiling.py
+++ b/alpa/pipeline_parallel/stage_profiling.py
@@ -769,9 +769,8 @@ def get_merged_stages_memory_stats(
                     f"vs. {size}.")
     initial_size = sum(initial_var_sizes_dict.values())
     peak_memory = 0
-    available_memory = profile_results[0].available_memory
-    assert all(result.available_memory == available_memory
-               for result in profile_results)
+    available_memory = min(
+        result.available_memory for result in profile_results)
     n_stages = len(profile_results)
     n_modules = profile_results[0].n_modules
     if inference_mode:

--- a/alpa/pipeline_parallel/stage_profiling.py
+++ b/alpa/pipeline_parallel/stage_profiling.py
@@ -125,11 +125,8 @@ class StageProfileResult:
         if self.available_memory is None:
             self.available_memory = result.available_memory
         else:
-            assert self.available_memory == result.available_memory, (
-                f"available_memory is not consistent: {self.available_memory} "
-                f"vs {result.available_memory}. This may be caused by "
-                f"mismatch of loaded profile results and newly profiled "
-                f"results.")
+            self.available_memory = min(self.available_memory,
+                                        result.available_memory)
 
     def __str__(self):
         total_initial_var_size = sum(self.initial_var_sizes)


### PR DESCRIPTION
Fix https://github.com/alpa-projects/alpa/issues/776#issuecomment-1315111925