### PR TITLE
Add k8s/infiniband build and deployment guide to Alpa

### DIFF
--- a/benchmark/cupy/profile_communication.py
+++ b/benchmark/cupy/profile_communication.py
@@ -228,6 +228,8 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--efa", action="store_true",
         help="Use AWS EFS on p3.24 or p4.24 instances")
+    parser.add_argument("--ib", action="store_true",
+        help="Use InfiniBand for NCCL communcation")
     parser.add_argument("--debug", action="store_true",
         help="Print nccl debug information")
     args = parser.parse_args()
@@ -244,6 +246,13 @@ if __name__ == "__main__":
                 "FI_PROVIDER": "efa",
                 "FI_EFA_USE_DEVICE_RDMA": "1",
                 "LD_LIBRARY_PATH": os.environ.get("LD_LIBRARY_PATH", ""),  # For libnccl-net.so
+            }
+        elif args.ib:
+            env_vars = {
+                "NCCL_SOCKET_NTHREADS": "4",
+                "NCCL_NSOCKS_PERTHREAD": "4",
+                "NCCL_IB_HCA": "ibp",
+                "LD_LIBRARY_PATH": os.environ.get("LD_LIBRARY_PATH", ""),
             }
         else:
             env_vars = {

--- a/docker/README.md
+++ b/docker/README.md
@@ -2,14 +2,14 @@
 This directory contains Alpa's docker infrastructure. Alpa uses docker to provide environment to build and release Python wheels and to perform unit tests.
 Most docker files in this directory depend on [nvidia-docker](https://github.com/NVIDIA/nvidia-docker/).
 
-Below we provide instructions on 
-- How to build Alpa-modified jaxlib in a docker container 
+Below we provide instructions on
+- How to build Alpa-modified jaxlib in a docker container
 - How to run Alpa in a docker container
 
 More docker examples can be found in the directory of [Alpa CI/CD](../.github/workflows).
 
 ## Build Jaxlib-alpa wheels using Docker
-We provide a Docker image to build the Alpa-modified jaxlib wheels inside a container. 
+We provide a Docker image to build the Alpa-modified jaxlib wheels inside a container.
 
 
 ### Steps
@@ -29,11 +29,11 @@ docker build -t build-jaxlib-image -f build_jaxlib.Dockerfile . --build-arg JAX_
 
 #### Build the wheels inside a container
 ```bash
-# create a subfolder for the specific wheel version. 
+# create a subfolder for the specific wheel version.
 mkdir -p dist/cuda111
 
 # build the wheel in a container using the selected Python and CUDA versions
-docker run --tmpfs /build:exec --rm -v $(pwd)/dist:/dist build-jaxlib-image 3.8 cuda 11.1 master
+docker run --tmpfs /build:exec --rm -v $(pwd)/dist:/dist build-jaxlib-image 3.8 cuda 11.1 main
 
 # Move the output wheel
 mv -f dist/*.whl dist/cuda111/
@@ -44,8 +44,13 @@ Check out the wheel under the folder ``alpa/build/dist/cuda111/``.
 You can run Alpa inside a docker container. Below are steps on how to run Alpa in a docker container in the interactive mode.
 
 First, build a docker image based on the provided dockerfile:
-```bash 
-docker build -t run-alpa-image -f run_alpa.Dockerfile . 
+```bash
+docker build -t run-alpa-image -f run_alpa.Dockerfile .
+```
+
+For cloud provider with InfiniBand (such as CoreWeave) we need to include additional dependencies:
+ ```bash
+docker build -t run-alpa-image -f run_alpa_infiniband.Dockerfile .
 ```
 
 Second, build a container from the image and enter the container's interactive shell:

--- a/docker/build_jaxlib.Dockerfile
+++ b/docker/build_jaxlib.Dockerfile
@@ -2,9 +2,12 @@ FROM gcr.io/tensorflow-testing/nosla-cuda11.1-cudnn8-ubuntu18.04-manylinux2010-m
 
 WORKDIR /
 SHELL ["/bin/bash", "-c"]
+RUN sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
+RUN sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64/7fa2af80.pub
 RUN rm -f /etc/apt/sources.list.d/jonathonf-ubuntu-python-3_6-xenial.list
 RUN apt-get update
 RUN apt-get install -y python3-virtualenv
+
 RUN virtualenv --python=python3.7 python3.7-env
 RUN virtualenv --python=python3.8 python3.8-env
 RUN virtualenv --python=python3.9 python3.9-env

--- a/docker/coreweave/README.md
+++ b/docker/coreweave/README.md
@@ -19,7 +19,7 @@ docker build -t run-alpa-image -f run_alpa_infiniband.Dockerfile .
 This docker file added InfiniBand dependencies in addition to the [default run_alpa.Dockerfile](../run_alpa.Dockerfile).
 
 ## Tag and push your docker image
-Second, tag and push your Alpa docker image to a public repository in docker.com.
+Then tag and push your Alpa docker image to a public repository in docker.com.
 ```bash
 docker tag {image_hash} {your_docker}/{image}:{version}
 ```
@@ -28,7 +28,7 @@ docker push {your_docker}/{image}:{version}
 ```
 
 ## Write cluster.yaml file
-Third, write your deployment script to use the Alpa docker image you just built in a k8s cloud.
+Then write your deployment script to use the Alpa docker image you just built in a k8s cloud.
 The k8s deployment process can be summarized as the following steps in a nutshell:
 
 1. Define service/headnode/worker roles in the k8s deployment for the Ray cluster.

--- a/docker/coreweave/README.md
+++ b/docker/coreweave/README.md
@@ -1,0 +1,137 @@
+# Run Alpa in k8s cloud with InfiniBand (CoreWeave)
+To run Alpa in specialized GPU cloud like [CoreWeave](https://coreweave.com/), we will need a few pieces in addition to [default run Alpa in Docker](../README.md):
+
+1. InfiniBand dependencies in Alpa docker image
+2. K8s deployment YAML file to declare Ray cluster resources
+3. Run NCCL with InfiniBand related environment variables such as `NCCL_IB_HCA`
+
+We will go through each step to show you how to deploy Ray cluster in k8s cloud and run Alpa with InfiniBand.
+
+Note most of the content is re-usable for generic k8s and InfiniBand deployment where CoreWeave is the concrete cloud provider we used as verification.
+
+## Build Alpa docker image
+
+First, build a docker image based on the provided dockerfile:
+```bash
+docker build -t run-alpa-image -f run_alpa_infiniband.Dockerfile .
+```
+
+This docker file added InfiniBand dependencies in addition to the [default run_alpa.Dockerfile](../run_alpa.Dockerfile).
+
+## Tag and push your docker image
+Second, tag and push your Alpa docker image to a public repository in docker.com.
+```bash
+docker tag {image_hash} {your_docker}/{image}:{version}
+```
+```bash
+docker push {your_docker}/{image}:{version}
+```
+
+## Write cluster.yaml file
+Third, write your deployment script to use the Alpa docker image you just built in a k8s cloud.
+The k8s deployment process can be summarized as the following steps in a nutshell:
+
+1. Define service/headnode/worker roles in the k8s deployment for the Ray cluster.
+2. Make physical resource requirements to the k8s cloud regarding GPU/CPU/RAM/InfiniBand/number of replicas.
+3. Pull the Alpa docker image you built with Ray.
+4. For each container, activate Alpa conda environment and run `ray start` to establish Ray runtime across the cluster.
+
+[Example end to end working YAML file](cluster.yaml)
+
+Change the `TODO` in sample YAML file to match your desired namespace, docker image and resource requirements.
+
+## Deploy to k8s
+
+Then we can use simple idempotent commands to start and terminate your Ray cluster to run Alpa.
+```bash
+kubectl apply -f cluster.yaml
+```
+
+```bash
+kubectl delete -f cluster.yaml
+```
+
+## Example end-to-end workflow
+
+Once your cluster is started, you should be able to monitor all pods like this:
+```
+❯ k get pods
+NAME                                    READY   STATUS    RESTARTS   AGE
+deployment-ray-head-d9dc9cf7f-pkqvz     1/1     Running   0          2m25s
+deployment-ray-worker-d66d65c7b-25659   1/1     Running   0          2m24s
+deployment-ray-worker-d66d65c7b-6sbpz   1/1     Running   0          2m24s
+deployment-ray-worker-d66d65c7b-8smzr   1/1     Running   0          2m24s
+```
+
+You can ssh into the headnode for interactive development and job submission.
+```bash
+kubectl exec --stdin --tty deployment-ray-head-d9dc9cf7f-pkqvz -- /bin/bash -i -l
+```
+
+Then activate alpa conda environment:
+```bash
+conda activate alpa
+
+```
+
+And verify your Ray cluster is running as expected.
+```
+(alpa) ray@deployment-ray-head-d9dc9cf7f-pkqvz:~$ ray status
+======== Autoscaler status: 2022-12-29 10:05:41.200229 ========
+Node status
+---------------------------------------------------------------
+Healthy:
+ 1 node_a4328576d9fee799a5e6853acba0a6c1e1d8cb7fbabed6a6bab3649a
+ 1 node_475ed937e3506d7f47ac1abc508e0eb7cde2a270d86a23fad3b9d0b2
+ 1 node_347bc30b1fe0cc5f5730a6f803018fe2f3b6597226be69580995b436
+ 1 node_8725d199fd3ef007abb673be6307a233a6f90f1001d8cd29aa873789
+Pending:
+ (no pending nodes)
+Recent failures:
+ (no failures)
+
+Resources
+---------------------------------------------------------------
+Usage:
+ 0.0/128.0 CPU
+ 0.0/32.0 GPU
+ 0.0/4.0 accelerator_type:A100
+ 0.00/197.961 GiB memory
+ 0.00/86.199 GiB object_store_memory
+ ```
+
+ ## Environment variables for NCCL
+
+ In order to enable InfiniBand for NCCL communication, you will need a few additional env vars, such as `NCCL_IB_HCA=ibp`. You can see the full list of configurations in [NCCL user guide](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/env.html)
+
+ ## Run Alpa's NCCL test
+
+Alpa uses cupy / ray collective / xla to orchestrate NCCL communcation.
+You should be able to run the NCCL test [profile_communication](https://github.com/alpa-projects/alpa/blob/5660516ad3a29e5760673e599fc84aa604589a82/benchmark/cupy/profile_communication.py) in
+
+```bash
+python profile_communication.py --ib
+```
+
+Optionally add `--debug` to show NCCL logs to ensure InfiniBand is indeed used instead of Ethernet, as their AllReduce performance difference is expected to be very significant.
+
+Sample output from a 4 node 8x80GB A100s NVLink cluster:
+
+```
+AllReduce: [[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31]]	Bytes: 2.00000 GB	Time: 0.04278 s	Bandwidth: 90.59 GB/s
+AllReduce: [[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]]	Bytes: 2.00000 GB	Time: 0.03842 s	Bandwidth: 97.59 GB/s
+AllReduce: [[0, 3]]	Bytes: 2.00000 GB	Time: 0.01006 s	Bandwidth: 198.82 GB/s
+AllReduce: [[0, 4], [1, 5], [2, 6], [3, 7]]	Bytes: 2.00000 GB	Time: 0.00994 s	Bandwidth: 201.30 GB/s
+AllReduce: [[0, 2, 4, 6], [1, 3, 5, 7]]	Bytes: 2.00000 GB	Time: 0.01404 s	Bandwidth: 213.71 GB/s
+AllReduce: [[0, 1, 2, 3], [4, 5, 6, 7]]	Bytes: 2.00000 GB	Time: 0.01406 s	Bandwidth: 213.31 GB/s
+AllReduce: [[0, 1, 2, 3, 4, 5, 6, 7]]	Bytes: 2.00000 GB	Time: 0.01623 s	Bandwidth: 215.60 GB/s
+
+SendRecv: [[0, 1]]	Bytes: 2.00000 GB	Time: 0.00814 s	Bandwidth: 245.59 GB/s
+SendRecv: [[0, 31]]	Bytes: 2.00000 GB	Time: 0.15949 s	Bandwidth: 12.54 GB/s
+SendRecv: [[0, 1], [2, 3]]	Bytes: 2.00000 GB	Time: 0.00815 s	Bandwidth: 490.84 GB/s
+SendRecv: [[0, 28], [1, 29]]	Bytes: 2.00000 GB	Time: 0.17521 s	Bandwidth: 22.83 GB/s
+SendRecv: [[0, 30], [1, 31]]	Bytes: 2.00000 GB	Time: 0.17519 s	Bandwidth: 22.83 GB/s
+SendRecv: [[0, 28], [1, 29], [2, 30], [3, 31]]	Bytes: 2.00000 GB	Time: 0.17526 s	Bandwidth: 45.65 GB/s
+SendRecv: [[0, 24], [1, 25], [2, 26], [3, 27]]	Bytes: 2.00000 GB	Time: 0.17486 s	Bandwidth: 45.75 GB/s
+SendRecv: [[0, 24], [1, 25], [2, 26], [3, 27], [4, 28], [5, 29], [6, 30], [7, 31]]	Bytes: 2.00000 GB	Time: 0.17491 s	Bandwidth: 91.48 GB/s
+```

--- a/docker/coreweave/cluster.yaml
+++ b/docker/coreweave/cluster.yaml
@@ -1,0 +1,163 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: tenant-jiaohpc-jd  # TODO: Change to your namespace
+  name: service-ray-cluster
+  labels:
+    app: ray-cluster
+spec:
+  ports:
+  - name: dashboard
+    protocol: TCP
+    port: 8265
+    targetPort: 8265
+  - name: gcs-server
+    protocol: TCP
+    port: 6380
+    targetPort: 6380
+  selector:
+    app: ray-cluster
+    component: ray-head
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: tenant-jiaohpc-jd  # TODO: Change to your namespace
+  name: deployment-ray-head
+  labels:
+    app: ray-cluster
+    ray-node: head
+spec:
+  # Do not change this - Ray currently only supports one head node per cluster.
+  replicas: 1
+  selector:
+    matchLabels:
+      component: ray-head
+      type: ray
+      app: ray-cluster
+  template:
+    metadata:
+      labels:
+        component: ray-head
+        type: ray
+        app: ray-cluster
+    spec:
+      # If the head node goes down, the entire cluster (including all worker
+      # nodes) will go down as well. If you want Kubernetes to bring up a new
+      # head node in this case, set this to "Always," else set it to "Never."
+      restartPolicy: Always
+
+      # This volume allocates shared memory for Ray to use for its plasma
+      # object store. If you do not provide this, Ray will fall back to
+      # /tmp which cause slowdowns if is not a shared memory volume.
+      volumes:
+      - name: dshm
+        emptyDir:
+          medium: Memory
+      containers:
+        - name: ray-head
+          image: jiaodong/alpa:v1  # TODO: Change to your Alpa docker image
+          imagePullPolicy: IfNotPresent
+          # This volume allocates shared memory for Ray to use for its plasma]
+          # --login in required to have access to conda to activate alpa env
+          command: ["/bin/bash", "-l", "-c", "--"]
+          args:
+            - "conda activate alpa && ray start --head --port=6380 --num-cpus=$MY_CPU_REQUEST --dashboard-host=0.0.0.0 --object-manager-port=8076 --node-manager-port=8077 --dashboard-agent-grpc-port=8078 --dashboard-agent-listen-port=8079 --min-worker-port=10002 --max-worker-port=19999 --redis-password='' --block"
+          # This volume allocates shared memory for Ray to use for its plasma
+          # object store. If you do not provide this, Ray will fall back to
+          # /tmp which cause slowdowns if is not a shared memory volume.
+          volumeMounts:
+            - mountPath: /dev/shm
+              name: dshm
+          env:
+            # This is used in the ray start command so that Ray can spawn the
+            # correct number of processes. Omitting this may lead to degraded
+            # performance.
+            - name: MY_CPU_REQUEST
+              valueFrom:
+                resourceFieldRef:
+                  resource: requests.cpu
+          resources:
+            limits:
+              cpu: 32
+              memory: 64Gi
+              nvidia.com/gpu: 8
+              rdma/ib: 1
+      # Refer to CoreWeave's documentation for more details about GPU node types and placement
+      # https://docs.coreweave.com/coreweave-kubernetes/node-types
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gpu.nvidia.com/class
+                operator: In
+                values:
+                  - A100_NVLINK_80GB
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: tenant-jiaohpc-jd  # TODO: Change to your namespace
+  name: deployment-ray-worker
+  labels:
+    app: ray-cluster
+spec:
+  # Change this to scale the number of worker nodes started in the Ray cluster.
+  replicas: 3
+  selector:
+    matchLabels:
+      component: ray-worker
+      type: ray
+      app: ray-cluster
+  template:
+    metadata:
+      labels:
+        component: ray-worker
+        type: ray
+        app: ray-cluster
+    spec:
+      restartPolicy: Always
+      volumes:
+      - name: dshm
+        emptyDir:
+          medium: Memory
+      containers:
+      - name: ray-worker
+        image: jiaodong/alpa:v1  # TODO: Change to your Alpa docker image
+        imagePullPolicy: IfNotPresent
+        # --login in required to have access to conda to activate alpa env
+        command: ["/bin/bash", "-l", "-c", "--"]
+        args:
+          - "conda activate alpa && ray start --num-cpus=$MY_CPU_REQUEST --address=service-ray-cluster:6380 --object-manager-port=8076 --node-manager-port=8077 --dashboard-agent-grpc-port=8078 --dashboard-agent-listen-port=8079 --min-worker-port=10002 --max-worker-port=19999 --block"
+        # This volume allocates shared memory for Ray to use for its plasma
+        # object store. If you do not provide this, Ray will fall back to
+        # /tmp which cause slowdowns if is not a shared memory volume.
+        volumeMounts:
+          - mountPath: /dev/shm
+            name: dshm
+        env:
+          # This is used in the ray start command so that Ray can spawn the
+          # correct number of processes. Omitting this may lead to degraded
+          # performance.
+          - name: MY_CPU_REQUEST
+            valueFrom:
+              resourceFieldRef:
+                resource: requests.cpu
+        resources:
+          limits:
+            cpu: 32
+            memory: 64Gi
+            nvidia.com/gpu: 8
+            rdma/ib: 1
+      # Refer to CoreWeave's documentation for more details about GPU node types and placement
+      # https://docs.coreweave.com/coreweave-kubernetes/node-types
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: gpu.nvidia.com/class
+                operator: In
+                values:
+                  - A100_NVLINK_80GB

--- a/docker/coreweave/run_alpa_infiniband.Dockerfile
+++ b/docker/coreweave/run_alpa_infiniband.Dockerfile
@@ -1,0 +1,93 @@
+# base docker image
+FROM nvidia/cuda:11.3.0-cudnn8-devel-ubuntu20.04
+
+# init workdir
+RUN mkdir -p /build
+WORKDIR /build
+
+# InfiniBand (IB) dependencies adopoted from CoreWeave's github
+# https://github.com/coreweave/nccl-tests
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get -qq update && \
+    apt-get -qq install -y --allow-change-held-packages --no-install-recommends \
+    build-essential libtool autoconf automake autotools-dev unzip \
+    ca-certificates \
+    wget curl openssh-server vim environment-modules \
+    iputils-ping net-tools \
+    libnuma1 libsubunit0 libpci-dev \
+    libpmix-dev \
+    datacenter-gpu-manager
+
+# Mellanox OFED (latest)
+RUN wget -qO - https://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox | apt-key add -
+RUN cd /etc/apt/sources.list.d/ && wget https://linux.mellanox.com/public/repo/mlnx_ofed/latest/ubuntu18.04/mellanox_mlnx_ofed.list
+
+RUN apt-get -qq update \
+    && apt-get -qq install -y --no-install-recommends \
+    ibverbs-utils libibverbs-dev libibumad3 libibumad-dev librdmacm-dev rdmacm-utils infiniband-diags ibverbs-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+# HPC-X (2.12)
+ENV HPCX_VERSION=2.12
+RUN cd /tmp && \
+    wget -q -O - http://blobstore.s3.ord1.coreweave.com/drivers/hpcx-v${HPCX_VERSION}-gcc-MLNX_OFED_LINUX-5-ubuntu20.04-cuda11-gdrcopy2-nccl${HPCX_VERSION}-x86_64.tbz | tar xjf - && \
+    mv hpcx-v${HPCX_VERSION}-gcc-MLNX_OFED_LINUX-5-ubuntu20.04-cuda11-gdrcopy2-nccl${HPCX_VERSION}-x86_64 /opt/hpcx
+
+# GDRCopy userspace components (2.3)
+RUN cd /tmp && \
+    wget -q https://developer.download.nvidia.com/compute/redist/gdrcopy/CUDA%2011.4/x86/Ubuntu20.04/gdrcopy-tests_2.3-1_amd64.cuda11_4.Ubuntu20_04.deb && \
+    wget -q https://developer.download.nvidia.com/compute/redist/gdrcopy/CUDA%2011.4/x86/Ubuntu20.04/libgdrapi_2.3-1_amd64.Ubuntu20_04.deb && \
+    dpkg -i *.deb && \
+    rm *.deb
+
+# Begin auto-generated paths
+ENV HPCX_DIR=/opt/hpcx
+ENV HPCX_UCX_DIR=/opt/hpcx/ucx
+ENV HPCX_UCC_DIR=/opt/hpcx/ucc
+ENV HPCX_SHARP_DIR=/opt/hpcx/sharp
+ENV HPCX_NCCL_RDMA_SHARP_PLUGIN_DIR=/opt/hpcx/nccl_rdma_sharp_plugin
+ENV HPCX_HCOLL_DIR=/opt/hpcx/hcoll
+ENV HPCX_MPI_DIR=/opt/hpcx/ompi
+ENV HPCX_OSHMEM_DIR=/opt/hpcx/ompi
+ENV HPCX_MPI_TESTS_DIR=/opt/hpcx/ompi/tests
+ENV HPCX_OSU_DIR=/opt/hpcx/ompi/tests/osu-micro-benchmarks-5.8
+ENV HPCX_OSU_CUDA_DIR=/opt/hpcx/ompi/tests/osu-micro-benchmarks-5.8-cuda
+ENV HPCX_IPM_DIR=/opt/hpcx/ompi/tests/ipm-2.0.6
+ENV HPCX_CLUSTERKIT_DIR=/opt/hpcx/clusterkit
+ENV OMPI_HOME=/opt/hpcx/ompi
+ENV MPI_HOME=/opt/hpcx/ompi
+ENV OSHMEM_HOME=/opt/hpcx/ompi
+ENV OPAL_PREFIX=/opt/hpcx/ompi
+ENV PATH=/opt/hpcx/clusterkit/bin:/opt/hpcx/hcoll/bin:/opt/hpcx/ucc/bin:/opt/hpcx/ucx/bin:/opt/hpcx/ompi/bin:$PATH
+ENV LD_LIBRARY_PATH=/opt/hpcx/nccl_rdma_sharp_plugin/lib:/opt/hpcx/ucc/lib/ucc:/opt/hpcx/ucc/lib:/opt/hpcx/ucx/lib/ucx:/opt/hpcx/ucx/lib:/opt/hpcx/sharp/lib:/opt/hpcx/hcoll/lib:/opt/hpcx/ompi/lib:$LD_LIBRARY_PATH
+ENV LIBRARY_PATH=/opt/hpcx/nccl_rdma_sharp_plugin/lib:/opt/hpcx/ompi/lib:/opt/hpcx/sharp/lib:/opt/hpcx/ucc/lib:/opt/hpcx/ucx/lib:/opt/hpcx/hcoll/lib:/opt/hpcx/ompi/lib:/usr/local/cuda/lib64/stubs
+ENV OLD_CPATH=
+ENV CPATH=/opt/hpcx/ompi/include:/opt/hpcx/ucc/include:/opt/hpcx/ucx/include:/opt/hpcx/sharp/include:/opt/hpcx/hcoll/include:
+ENV PKG_CONFIG_PATH=/opt/hpcx/hcoll/lib/pkgconfig:/opt/hpcx/sharp/lib/pkgconfig:/opt/hpcx/ucx/lib/pkgconfig:/opt/hpcx/ompi/lib/pkgconfig:
+# End of auto-generated paths
+
+# install common tool & conda
+RUN apt update && \
+    apt install wget -y && \
+    apt install git -y && \
+    apt install vim -y && \
+    wget --quiet https://repo.anaconda.com/archive/Anaconda3-2022.05-Linux-x86_64.sh -O ~/anaconda.sh && \
+    /bin/bash ~/anaconda.sh -b -p /opt/conda && \
+    rm ~/anaconda.sh && \
+    mkdir -p /opt/conda/envs/alpa && \
+    ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
+    echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc && \
+    echo "conda activate base" >> ~/.bashrc
+
+# install conda alpa env
+RUN . /opt/conda/etc/profile.d/conda.sh && \
+    conda create --name alpa python=3.8 -y && \
+    conda activate alpa && \
+    apt install coinor-cbc -y && \
+    pip3 install --upgrade pip && \
+    pip3 install cupy-cuda113 && \
+    pip3 install alpa && \
+    pip3 install jaxlib==0.3.22+cuda113.cudnn820 -f https://alpa-projects.github.io/wheels.html
+
+# Execute in Alpa conda env
+ENV PATH /opt/conda/envs/alpa/bin:$PATH

--- a/docker/run_alpa.Dockerfile
+++ b/docker/run_alpa.Dockerfile
@@ -26,4 +26,4 @@ RUN . /opt/conda/etc/profile.d/conda.sh && \
     pip3 install --upgrade pip && \
     pip3 install cupy-cuda113 && \
     pip3 install alpa && \
-    pip3 install jaxlib==0.3.15+cuda113.cudnn820 -f https://alpa-projects.github.io/wheels.html
+    pip3 install jaxlib==0.3.22+cuda113.cudnn820 -f https://alpa-projects.github.io/wheels.html


### PR DESCRIPTION
Add complete guide to deploy Alpa on CoreWeave cloud (k8s with infiniband). See added documentation page for more details.

In addition, this PR makes a few changes to current Alpa codebase:
- Changed `profile_communication.py` to add an `ib` flag
- Changed docker documentation page to use `main` branch instead of `master`
- Changed default wheel from `jaxlib==0.3.15` to `jaxlib==0.3.22`.
- Added keys to `docker/build_jaxlib.Dockerfile`