### PR TITLE
Add input/output sharding specs to dump_debug_info()

### DIFF
--- a/alpa/mesh_executable.py
+++ b/alpa/mesh_executable.py
@@ -414,9 +414,9 @@ class NormalMeshDriverExecutable(MeshDriverExecutable):
             f.write(f"total_allocation_size: "
                     f"{self.get_total_allocation_size()/(1024**3):.3f} GB\n")
         with open(f"{prefix}_input_placement_specs.txt", "w") as f:
-            f.write(str(self.get_input_placement_specs()) + "\n\n")
+            f.write(str(self.get_input_placement_specs()))
         with open(f"{prefix}_output_placement_specs.txt", "w") as f:
-            f.write(str(self.get_output_placement_specs()) + "\n\n")
+            f.write(str(self.get_output_placement_specs()))
 
 
 def delete_donated_buffers(buffer_dict, uuids, donated_invars):
@@ -816,9 +816,9 @@ class GradAccMeshDriverExecutable(MeshDriverExecutable):
             f.write(f"total_allocation_size: "
                     f"{self.get_total_allocation_size()/(1024**3):.3f} GB\n")
         with open(f"{prefix}_input_placement_specs.txt", "w") as f:
-            f.write(str(self.get_input_placement_specs()) + "\n\n")
+            f.write(str(self.get_input_placement_specs()))
         with open(f"{prefix}_output_placement_specs.txt", "w") as f:
-            f.write(str(self.get_output_placement_specs()) + "\n\n")
+            f.write(str(self.get_output_placement_specs()))
 
 
 class GradAccMeshWorkerExecutable(MeshWorkerExecutable):

--- a/alpa/mesh_executable.py
+++ b/alpa/mesh_executable.py
@@ -418,6 +418,7 @@ class NormalMeshDriverExecutable(MeshDriverExecutable):
         with open(f"{prefix}_output_placement_specs.txt", "w") as f:
             f.write(str(self.get_output_placement_specs()) + "\n\n")
 
+
 def delete_donated_buffers(buffer_dict, uuids, donated_invars):
     """Delete the donated buffers from the local buffer dictionary."""
     for uuid, is_donated in zip(uuids, donated_invars):

--- a/alpa/mesh_executable.py
+++ b/alpa/mesh_executable.py
@@ -415,6 +415,8 @@ class NormalMeshDriverExecutable(MeshDriverExecutable):
                     f"{self.get_total_allocation_size()/(1024**3):.3f} GB\n")
         with open(f"{prefix}_input_placement_specs.txt", "w") as f:
             f.write(str(self.get_input_placement_specs()) + "\n\n")
+        with open(f"{prefix}_output_placement_specs.txt", "w") as f:
+            f.write(str(self.get_output_placement_specs()) + "\n\n")
 
 def delete_donated_buffers(buffer_dict, uuids, donated_invars):
     """Delete the donated buffers from the local buffer dictionary."""
@@ -813,7 +815,9 @@ class GradAccMeshDriverExecutable(MeshDriverExecutable):
             f.write(f"total_allocation_size: "
                     f"{self.get_total_allocation_size()/(1024**3):.3f} GB\n")
         with open(f"{prefix}_input_placement_specs.txt", "w") as f:
-                f.write(str(self.get_input_placement_specs()) + "\n\n")
+            f.write(str(self.get_input_placement_specs()) + "\n\n")
+        with open(f"{prefix}_output_placement_specs.txt", "w") as f:
+            f.write(str(self.get_output_placement_specs()) + "\n\n")
 
 
 class GradAccMeshWorkerExecutable(MeshWorkerExecutable):

--- a/alpa/mesh_executable.py
+++ b/alpa/mesh_executable.py
@@ -413,7 +413,8 @@ class NormalMeshDriverExecutable(MeshDriverExecutable):
         with open(f"{prefix}.mem_usage.txt", "w") as f:
             f.write(f"total_allocation_size: "
                     f"{self.get_total_allocation_size()/(1024**3):.3f} GB\n")
-
+        with open(f"{prefix}_input_placement_specs.txt", "w") as f:
+            f.write(str(self.get_input_placement_specs()) + "\n\n")
 
 def delete_donated_buffers(buffer_dict, uuids, donated_invars):
     """Delete the donated buffers from the local buffer dictionary."""
@@ -811,6 +812,8 @@ class GradAccMeshDriverExecutable(MeshDriverExecutable):
         with open(f"{prefix}.mem_usage.txt", "w") as f:
             f.write(f"total_allocation_size: "
                     f"{self.get_total_allocation_size()/(1024**3):.3f} GB\n")
+        with open(f"{prefix}_input_placement_specs.txt", "w") as f:
+                f.write(str(self.get_input_placement_specs()) + "\n\n")
 
 
 class GradAccMeshWorkerExecutable(MeshWorkerExecutable):

--- a/alpa/pipeline_parallel/pipeshard_executable.py
+++ b/alpa/pipeline_parallel/pipeshard_executable.py
@@ -378,6 +378,8 @@ class PipeshardDriverExecutable:
 
         with open(f"{prefix}_input_placement_specs.txt", "w") as f:
             f.write(str(self.get_input_placement_specs()) + "\n\n")
+        with open(f"{prefix}_output_placement_specs.txt", "w") as f:
+            f.write(str(self.get_output_placement_specs()) + "\n\n")
 
     def dump_stage_execution_trace(self, filename: str):
         exec_info = self.get_stage_execution_info()

--- a/alpa/pipeline_parallel/pipeshard_executable.py
+++ b/alpa/pipeline_parallel/pipeshard_executable.py
@@ -377,9 +377,9 @@ class PipeshardDriverExecutable:
                 f.write(str(task) + "\n\n")
 
         with open(f"{prefix}_input_placement_specs.txt", "w") as f:
-            f.write(str(self.get_input_placement_specs()) + "\n\n")
+            f.write(str(self.get_input_placement_specs()))
         with open(f"{prefix}_output_placement_specs.txt", "w") as f:
-            f.write(str(self.get_output_placement_specs()) + "\n\n")
+            f.write(str(self.get_output_placement_specs()))
 
     def dump_stage_execution_trace(self, filename: str):
         exec_info = self.get_stage_execution_info()

--- a/alpa/pipeline_parallel/pipeshard_executable.py
+++ b/alpa/pipeline_parallel/pipeshard_executable.py
@@ -376,6 +376,9 @@ class PipeshardDriverExecutable:
             for task in self.resharding_tasks:
                 f.write(str(task) + "\n\n")
 
+        with open(f"{prefix}_input_placement_specs.txt", "w") as f:
+            f.write(str(self.get_input_placement_specs()) + "\n\n")
+
     def dump_stage_execution_trace(self, filename: str):
         exec_info = self.get_stage_execution_info()
         dump_stage_execution_trace_internal(exec_info, filename)


### PR DESCRIPTION
Having input/output placement specs help to debug sharding strategies in our t5 development. Example output for a shard parallel output:

```
(TrainState(step=PlacementSpec(aval=ShapedArray(int32[]), mesh_ids=(0,), sharding_specs=(ShardingSpec((), (Replicated(replicas=2),)),)), apply_fn=<bound method Module.apply of MLPModel(	
    # attributes	
    num_layers = 4	
    hidden_size = 16	
    use_bias = True	
    add_manual_pipeline_marker = False	
)>, params=FrozenDict({	
    params: {	
        Dense_0: {	
            bias: PlacementSpec(aval=ShapedArray(float32[16]), mesh_ids=(0,), sharding_specs=(ShardingSpec((Chunked(2),), (ShardedAxis(axis=0),)),)),	
            kernel: PlacementSpec(aval=ShapedArray(float32[16,16]), mesh_ids=(0,), sharding_specs=(ShardingSpec((NoSharding(), Chunked(2)), (ShardedAxis(axis=0),)),)),	
        },	
        Dense_1: {	
            bias: PlacementSpec(aval=ShapedArray(float32[16]), mesh_ids=(0,), sharding_specs=(ShardingSpec((Chunked(2),), (ShardedAxis(axis=0),)),)),	
            kernel: PlacementSpec(aval=ShapedArray(float32[16,16]), mesh_ids=(0,), sharding_specs=(ShardingSpec((Chunked(2), NoSharding()), (ShardedAxis(axis=0),)),)),	
        },	
        Dense_2: {	
            bias: PlacementSpec(aval=ShapedArray(float32[16]), mesh_ids=(1,), sharding_specs=(ShardingSpec((Chunked(2),), (ShardedAxis(axis=0),)),)),	
            kernel: PlacementSpec(aval=ShapedArray(float32[16,16]), mesh_ids=(1,), sharding_specs=(ShardingSpec((NoSharding(), Chunked(2)), (ShardedAxis(axis=0),)),)),	
        },	
        Dense_3: {	
            bias: PlacementSpec(aval=ShapedArray(float32[16]), mesh_ids=(1,), sharding_specs=(ShardingSpec((NoSharding(),), (Replicated(replicas=2),)),)),	
            kernel: PlacementSpec(aval=ShapedArray(float32[16,16]), mesh_ids=(1,), sharding_specs=(ShardingSpec((Chunked(2), NoSharding()), (ShardedAxis(axis=0),)),)),	
        },	
    },	
}), tx=GradientTransformation(init=<function chain.<locals>.init_fn at 0x7fa0841d55e0>, update=<function chain.<locals>.update_fn at 0x7fa0841d5f70>), opt_state=(TraceState(trace=FrozenDict({	
    params: {	
        Dense_0: {	
            bias: PlacementSpec(aval=ShapedArray(float32[16]), mesh_ids=(0,), sharding_specs=(ShardingSpec((Chunked(2),), (ShardedAxis(axis=0),)),)),	
            kernel: PlacementSpec(aval=ShapedArray(float32[16,16]), mesh_ids=(0,), sharding_specs=(ShardingSpec((NoSharding(), Chunked(2)), (ShardedAxis(axis=0),)),)),	
        },	
        Dense_1: {	
            bias: PlacementSpec(aval=ShapedArray(float32[16]), mesh_ids=(0,), sharding_specs=(ShardingSpec((Chunked(2),), (ShardedAxis(axis=0),)),)),	
            kernel: PlacementSpec(aval=ShapedArray(float32[16,16]), mesh_ids=(0,), sharding_specs=(ShardingSpec((Chunked(2), NoSharding()), (ShardedAxis(axis=0),)),)),	
        },	
        Dense_2: {	
            bias: PlacementSpec(aval=ShapedArray(float32[16]), mesh_ids=(1,), sharding_specs=(ShardingSpec((Chunked(2),), (ShardedAxis(axis=0),)),)),	
            kernel: PlacementSpec(aval=ShapedArray(float32[16,16]), mesh_ids=(1,), sharding_specs=(ShardingSpec((NoSharding(), Chunked(2)), (ShardedAxis(axis=0),)),)),	
        },	
        Dense_3: {	
            bias: PlacementSpec(aval=ShapedArray(float32[16]), mesh_ids=(1,), sharding_specs=(ShardingSpec((NoSharding(),), (Replicated(replicas=2),)),)),	
            kernel: PlacementSpec(aval=ShapedArray(float32[16,16]), mesh_ids=(1,), sharding_specs=(ShardingSpec((Chunked(2), NoSharding()), (ShardedAxis(axis=0),)),)),	
        },	
    },	
})), EmptyState()), master_copy=None, dynamic_scale=None), {'x': PlacementSpec(aval=ShapedArray(float32[16,16]), mesh_ids=(0,), sharding_specs=(ShardingSpec((NoSharding(), NoSharding()), (Replicated(replicas=2),)),)), 'y': PlacementSpec(aval=ShapedArray(float32[16,16]), mesh_ids=(1,), sharding_specs=(ShardingSpec((NoSharding(), NoSharding()), (Replicated(replicas=2),)),))})
```