### PR TITLE
[FIX] fix the function of nccl_mode

### DIFF
--- a/alpa/collective/collective.py
+++ b/alpa/collective/collective.py
@@ -41,7 +41,7 @@ except ImportError:
 def nccl_available():
     if global_config.nccl_mode == "cupy":
         if not _CUPY_NCCL_AVAILABLE:
-            logger.warning("NCCL seems unavailable. Please install Cupy "
+            logger.warning("Cupy's NCCL seems unavailable. Please install Cupy "
                            "following the guide at: "
                            "https://docs.cupy.dev/en/stable/install.html.")
         return _CUPY_NCCL_AVAILABLE

--- a/alpa/collective/worker_nccl_util.py
+++ b/alpa/collective/worker_nccl_util.py
@@ -1,8 +1,10 @@
+"""Unified Nccl APIs for cross-mesh resharding."""
 from typing import Sequence
 
 import alpa.collective.worker_nccl_util_cupy as cupy_impl
 import alpa.collective.worker_nccl_util_xla as xla_impl
 from alpa.global_env import global_config
+
 
 def _switch_impl(cupy_fn, xla_fn, *args):
     if global_config.nccl_mode == "cupy":
@@ -17,6 +19,7 @@ def send_tile(worker, uuid: int, device_id: int, offset: Sequence[slice],
               dst_rank: int, dst_gpu_idx: int, group_name: str):
     return _switch_impl(cupy_impl.send_tile, xla_impl.send_tile, worker, uuid,
                         device_id, offset, dst_rank, dst_gpu_idx, group_name)
+
 
 def recv_tile(worker, uuid: int, device_id: int,
               indices_in_dst_tile: Sequence[slice], src_rank: int,
@@ -33,10 +36,12 @@ def broadcast(worker, uuid: int, comm_key: str, world_size: int,
                         comm_key, world_size, devices_ids, devices_global_rank,
                         tensor_slices, group_name)
 
+
 def allgather(worker, uuid: int, device_ids: Sequence[int],
               tensor_slices: Sequence[Sequence[slice]], output_slice):
     return _switch_impl(cupy_impl.allgather, xla_impl.allgather, worker, uuid,
                         device_ids, tensor_slices, output_slice)
+
 
 def to_signal_buffer(jax_tensor):
     return _switch_impl(cupy_impl.to_signal_buffer, xla_impl.to_signal_buffer,

--- a/alpa/collective/worker_nccl_util.py
+++ b/alpa/collective/worker_nccl_util.py
@@ -1,0 +1,43 @@
+from typing import Sequence
+
+import alpa.collective.worker_nccl_util_cupy as cupy_impl
+import alpa.collective.worker_nccl_util_xla as xla_impl
+from alpa.global_env import global_config
+
+def _switch_impl(cupy_fn, xla_fn, *args):
+    if global_config.nccl_mode == "cupy":
+        return cupy_fn(*args)
+    elif global_config.nccl_mode == "xla_extension":
+        return xla_fn(*args)
+    else:
+        raise ValueError(f"nccl mode {global_config.nccl_mode} is illegal")
+
+
+def send_tile(worker, uuid: int, device_id: int, offset: Sequence[slice],
+              dst_rank: int, dst_gpu_idx: int, group_name: str):
+    return _switch_impl(cupy_impl.send_tile, xla_impl.send_tile, worker, uuid,
+                        device_id, offset, dst_rank, dst_gpu_idx, group_name)
+
+def recv_tile(worker, uuid: int, device_id: int,
+              indices_in_dst_tile: Sequence[slice], src_rank: int,
+              src_gpu_idx: int, group_name: str):
+    return _switch_impl(cupy_impl.recv_tile, xla_impl.recv_tile, worker, uuid,
+                        device_id, indices_in_dst_tile, src_rank, src_gpu_idx,
+                        group_name)
+
+
+def broadcast(worker, uuid: int, comm_key: str, world_size: int,
+              devices_ids: Sequence[int], devices_global_rank: Sequence[int],
+              tensor_slices: Sequence[Sequence[slice]], group_name: str):
+    return _switch_impl(cupy_impl.broadcast, xla_impl.broadcast, worker, uuid,
+                        comm_key, world_size, devices_ids, devices_global_rank,
+                        tensor_slices, group_name)
+
+def allgather(worker, uuid: int, device_ids: Sequence[int],
+              tensor_slices: Sequence[Sequence[slice]], output_slice):
+    return _switch_impl(cupy_impl.allgather, xla_impl.allgather, worker, uuid,
+                        device_ids, tensor_slices, output_slice)
+
+def to_signal_buffer(jax_tensor):
+    return _switch_impl(cupy_impl.to_signal_buffer, xla_impl.to_signal_buffer,
+                        jax_tensor)

--- a/alpa/collective/worker_nccl_util_cupy.py
+++ b/alpa/collective/worker_nccl_util_cupy.py
@@ -129,7 +129,7 @@ def recv_tile(worker, uuid: int, device_id: int,
 
 
 def allgather(worker, uuid: int, device_ids: Sequence[int],
-              tensor_slices: Sequence[slice], output_slice):
+              tensor_slices: Sequence[Sequence[slice]], output_slice):
     cupy_buffers = []
     communicators = worker.allgather_communicators[repr(sorted(device_ids))]
     relative_idx = dict(zip(sorted(device_ids), range(len(device_ids))))

--- a/alpa/collective/worker_nccl_util_xla.py
+++ b/alpa/collective/worker_nccl_util_xla.py
@@ -97,7 +97,7 @@ def recv_tile(worker, uuid: int, device_id: int,
 
 
 def allgather(worker, uuid: int, device_ids: Sequence[int],
-              tensor_slices: Sequence[slice], output_slice):
+              tensor_slices: Sequence[Sequence[slice]], output_slice):
     # FIXME: handle the case that local device ids are the same but global ids
     # are different
     communicators = worker.allgather_communicators[repr(sorted(device_ids))]

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -61,7 +61,7 @@ from alpa.util import (benchmark_func, list_gpu_info, OrderedSet,
 ray_worker = try_import_ray_worker()
 
 if global_config.backend == "gpu" and global_config.has_cuda:
-    import alpa.collective.worker_nccl_util
+    from alpa.collective import worker_nccl_util
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -61,11 +61,7 @@ from alpa.util import (benchmark_func, list_gpu_info, OrderedSet,
 ray_worker = try_import_ray_worker()
 
 if global_config.backend == "gpu" and global_config.has_cuda:
-    if global_config.nccl_mode == "cupy":
-        import alpa.collective.worker_nccl_util_cupy as worker_nccl_util
-    else:
-        assert global_config.nccl_mode == "xla_extension"
-        import alpa.collective.worker_nccl_util_xla as worker_nccl_util
+    import alpa.collective.worker_nccl_util
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)

--- a/tests/pipeline_parallel/test_cross_mesh_resharding.py
+++ b/tests/pipeline_parallel/test_cross_mesh_resharding.py
@@ -208,7 +208,8 @@ class ReshardingTest(unittest.TestCase):
         src_mesh.shutdown()
         dst_mesh.shutdown()
 
-    def test_4gpu_send_recv(self):
+    def _test_4gpu_send_recv(self, nccl_mode):
+        global_config.nccl_mode = nccl_mode
         src_shape = (1, 2)
         dst_shape = (1, 2)
         tensor_shape = (4, 8, 16)
@@ -235,7 +236,8 @@ class ReshardingTest(unittest.TestCase):
         self.run_resharding_task(src_shape, dst_shape, src_spec, dst_spec,
                                  tensor_shape, False)
 
-    def test_4gpu_allgather(self):
+    def _test_4gpu_allgather(self, nccl_mode):
+        global_config.nccl_mode = nccl_mode
         src_shape = (1, 2)
         dst_shape = (1, 2)
         tensor_shape = (4, 8, 16)
@@ -261,8 +263,8 @@ class ReshardingTest(unittest.TestCase):
         self.run_resharding_task(src_shape, dst_shape, src_spec, dst_spec,
                                  tensor_shape)
 
-    @unittest.skipIf(jax.device_count('gpu') < 8, "no enough device")
-    def test_8gpu_2_dim_allgather(self):
+    def _test_8gpu_2_dim_allgather(self, nccl_mode):
+        global_config.nccl_mode = nccl_mode
         src_shape = (1, 4)
         dst_shape = (1, 4)
         tensor_shape = (6, 8, 16)
@@ -275,7 +277,8 @@ class ReshardingTest(unittest.TestCase):
         self.run_resharding_task(src_shape, dst_shape, src_spec, dst_spec,
                                  tensor_shape)
 
-    def test_4gpu_broadcast(self):
+    def _test_4gpu_broadcast(self, nccl_mode):
+        global_config.nccl_mode = nccl_mode
         src_shape = (1, 2)
         dst_shape = (1, 2)
         tensor_shape = (4, 8, 16)
@@ -309,7 +312,8 @@ class ReshardingTest(unittest.TestCase):
                                  resharding_mode="broadcast")
 
     @unittest.skipIf(jax.device_count('gpu') < 8, "no enough device")
-    def test_8gpu_broadcast(self):
+    def _test_8gpu_broadcast(self, nccl_mode):
+        global_config.nccl_mode = nccl_mode
         src_shape = (1, 4)
         dst_shape = (1, 4)
         tensor_shape = (2, 64, 64)
@@ -340,6 +344,26 @@ class ReshardingTest(unittest.TestCase):
                                  dst_spec,
                                  tensor_shape,
                                  resharding_mode="broadcast")
+
+    def test_4gpu_send_recv(self):
+        self._test_4gpu_send_recv("cupy")
+        self._test_4gpu_send_recv("xla_extension")
+
+    def test_4gpu_allgather(self):
+        self._test_4gpu_allgather("cupy")
+        self._test_4gpu_allgather("xla_extension")
+
+    @unittest.skipIf(jax.device_count('gpu') < 8, "no enough device")
+    def test_8gpu_2_dim_allgather(self):
+        self._test_8gpu_2_dim_allgather("cupy")
+
+    def test_4gpu_broadcast(self):
+        self._test_4gpu_broadcast("cupy")
+        self._test_4gpu_broadcast("xla_extension")
+
+    @unittest.skipIf(jax.device_count('gpu') < 8, "no enough device")
+    def test_8gpu_broadcast(self):
+        self._test_8gpu_broadcast("cupy")
 
 
 def suite():


### PR DESCRIPTION
The `global_config.nccl_mode` is intended to control the nccl used by cross-mesh communication. However, currently it does so by selecting which class to import, which makes it impossible to make effects when the user changes it after importing alpa. This pr aims to solve it.