### PR TITLE
[FIX] restore_checkpoint without mesh group

### DIFF
--- a/alpa/serialization.py
+++ b/alpa/serialization.py
@@ -168,7 +168,6 @@ def restore_checkpoint(ckpt_dir: Union[str, os.PathLike], step: int,
         elif mesh_group is None:
             dist_arr = DistributedArray.load(os.path.join(ckpt_dir, path),
                                              info.aval, physical_mesh,
-                                             physical_mesh,
                                              info.sharding_specs[0])
             flat_load_state.append(dist_arr)
         elif len(info.mesh_ids) == 1:

--- a/alpa/serialization.py
+++ b/alpa/serialization.py
@@ -15,7 +15,7 @@ import msgpack
 import numpy as np
 
 from alpa.device_mesh import (DistributedArray, ReplicatedDistributedArray,
-                              get_global_virtual_physical_mesh)
+                              get_global_virtual_physical_mesh, get_global_physical_mesh)
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -156,7 +156,6 @@ def restore_checkpoint(ckpt_dir: Union[str, os.PathLike], step: int,
     flat_info = tree_leaves(placement_specs)
     flat_load_state = []
     mesh_group = get_global_virtual_physical_mesh().launched_physical_mesh_group
-    assert mesh_group is not None
 
     for path, info in zip(state_paths, flat_info):
         if info is None:
@@ -165,7 +164,7 @@ def restore_checkpoint(ckpt_dir: Union[str, os.PathLike], step: int,
         if len(info.mesh_ids) == 1:
             dist_arr = DistributedArray.load(os.path.join(ckpt_dir,
                                                           path), info.aval,
-                                             mesh_group[info.mesh_ids[0]],
+                                             mesh_group[info.mesh_ids[0]] if mesh_group else get_global_physical_mesh(),
                                              info.sharding_specs[0])
             flat_load_state.append(dist_arr)
         else:

--- a/alpa/serialization.py
+++ b/alpa/serialization.py
@@ -166,8 +166,8 @@ def restore_checkpoint(ckpt_dir: Union[str, os.PathLike], step: int,
             logger.warning("Variable is not used, skip loading it")
             flat_load_state.append(None)
         elif mesh_group is None:
-            dist_arr = DistributedArray.load(os.path.join(ckpt_dir,
-                                                          path), info.aval,
+            dist_arr = DistributedArray.load(os.path.join(ckpt_dir, path),
+                                             info.aval, physical_mesh,
                                              physical_mesh,
                                              info.sharding_specs[0])
             flat_load_state.append(dist_arr)

--- a/alpa/serialization.py
+++ b/alpa/serialization.py
@@ -15,7 +15,7 @@ import msgpack
 import numpy as np
 
 from alpa.device_mesh import (DistributedArray, ReplicatedDistributedArray,
-                              get_global_virtual_physical_mesh, 
+                              get_global_virtual_physical_mesh,
                               get_global_physical_mesh)
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
`alpa.restore_checkpoint` only works when a `PhysicalDeviceMeshGroup` (eg. `VirtualPhysicalMesh`) exists in cases such as `PipeshardParallel`. 
However, `ShardParallel` uses `PhysicalDeviceMesh`, meaning `get_global_virtual_physical_mesh().launched_physical_mesh_group` will return None. 

This PR bypasses the mesh_group in these cases to allow `ShardParallel` checkpoints to be restored to the physical mesh.