### PR TITLE
[FIX] misc fix for t5x

### DIFF
--- a/alpa/parallel_method.py
+++ b/alpa/parallel_method.py
@@ -301,15 +301,17 @@ def get_3d_parallel_method(num_micro_batches: int,
             submesh_physical_shapes=[physical_mesh_shape] * pp,
             submesh_logical_shapes=[logical_mesh_shape] * pp,
             submesh_autosharding_option_dicts=[{}] * pp)
-    return PipeshardParallel(devices=virtual_mesh,
-                             num_micro_batches=num_micro_batches,
-                             default_auto_sharding_option=AutoShardingOption(
-                                 prefer_reduce_scatter=True,
-                                 force_batch_dim_to_mesh_dim=0,
-                             ),
-                             layer_option=layer_option,
-                             stage_option=stage_option,
-                             manual_sharding_option=manual_sharding_option)
+    return PipeshardParallel(
+        devices=virtual_mesh,
+        num_micro_batches=num_micro_batches,
+        default_auto_sharding_option=AutoShardingOption(
+            enable_auto_sharding=manual_sharding_option is None,
+            prefer_reduce_scatter=True,
+            force_batch_dim_to_mesh_dim=0,
+        ),
+        layer_option=layer_option,
+        stage_option=stage_option,
+        manual_sharding_option=manual_sharding_option)
 
 
 class LocalPipelineParallel(ParallelMethod):

--- a/alpa/pipeline_parallel/apply_grad.py
+++ b/alpa/pipeline_parallel/apply_grad.py
@@ -314,7 +314,7 @@ def _remove_replicated_marked_var(closed_jaxpr: ClosedJaxpr):
             eqn_map = {}
             new_invars = []
             new_outvars = []
-            if eqn.params["mark_type"] == "grad":
+            if eqn.params['mark_type'] == 'grad':
                 mb_idx = len(new_eqns)
             for inv, outv in zip(eqn.invars, eqn.outvars):
                 if isinstance(outv, DropVar):

--- a/alpa/pipeline_parallel/apply_grad.py
+++ b/alpa/pipeline_parallel/apply_grad.py
@@ -299,9 +299,47 @@ def _rewrite_cross_layer_grad(compute_eqns, microbatch_bound, apply_eqns,
                                eqns=new_compute_eqns + [new_microbatch_bound] +
                                new_apply_eqns,
                                outvars=new_global_outvars)
-    return closed_jaxpr, [
-        new_compute_eqns, [new_microbatch_bound], new_apply_eqns
+    return closed_jaxpr
+
+
+def _remove_replicated_marked_var(closed_jaxpr: ClosedJaxpr):
+    """Some variables are marked multiple times with the same marker.
+    This pass removes them.
+    """
+    new_eqns = []
+    var_map = {}
+    mb_idx = None
+    for eqn in closed_jaxpr.eqns:
+        if eqn.primitive == pipeline_p:
+            eqn_map = {}
+            new_invars = []
+            new_outvars = []
+            if eqn.params["mark_type"] == "grad":
+                mb_idx = len(new_eqns)
+            for inv, outv in zip(eqn.invars, eqn.outvars):
+                if isinstance(outv, DropVar):
+                    continue
+                if isinstance(inv, Var):
+                    if inv in var_map:
+                        var_map[outv] = var_map[inv]
+                        continue
+                    elif inv in eqn_map:
+                        var_map[outv] = eqn_map[inv]
+                        continue
+                if isinstance(inv, Var):
+                    eqn_map[inv] = outv
+                new_invars.append(inv)
+                new_outvars.append(outv)
+            new_eqns.append(clone_jaxpr_eqn(eqn, new_invars, new_outvars))
+            continue
+        new_invars = [get_var_mapping(var_map, v) for v in eqn.invars]
+        new_eqns.append(clone_jaxpr_eqn(eqn, new_invars))
+    sliced_eqns = new_eqns[:mb_idx], [new_eqns[mb_idx]], new_eqns[mb_idx + 1:]
+    new_outvars = [
+        get_var_mapping(var_map, v) for v in closed_jaxpr.jaxpr.outvars
     ]
+    return clone_jaxpr(closed_jaxpr, outvars=new_outvars,
+                       eqns=new_eqns), sliced_eqns
 
 
 def jaxpr_have_apply_grad(closed_jaxpr: ClosedJaxpr):
@@ -342,8 +380,9 @@ def split_compute_grad_and_apply_grad(closed_jaxpr: ClosedJaxpr, gensym_fn,
     ]
     # Some equations are not marked. This pass moves them either into apply grad
     # or a layer.
-    closed_jaxpr, sliced_eqns = _rewrite_cross_layer_grad(
-        *sliced_eqns, gensym_fn, closed_jaxpr)
+    closed_jaxpr = _rewrite_cross_layer_grad(*sliced_eqns, gensym_fn,
+                                             closed_jaxpr)
+    closed_jaxpr, sliced_eqns = _remove_replicated_marked_var(closed_jaxpr)
     # Reconstruct jaxpr
     sliced_jaxprs = slices_to_jaxpr(closed_jaxpr, sliced_eqns)
     compute_grad, _, apply_grad = sliced_jaxprs  # pylint: disable=unbalanced-tuple-unpacking

--- a/alpa/pipeline_parallel/compile_executable.py
+++ b/alpa/pipeline_parallel/compile_executable.py
@@ -307,12 +307,12 @@ def split_and_process_layers(closed_jaxpr, full_batch_closed_jaxpr,
        start of accumulate gradient.
 
     """
-    global_outvars = closed_jaxpr.jaxpr.outvars
 
     # Split the jaxpr into compute_grad and apply_grad
     (closed_jaxpr, compute_grad_jaxpr, apply_grad_jaxpr,
      microbatch_bound) = split_compute_grad_and_apply_grad(
          closed_jaxpr, gensym_func, num_microbatch, inference_mode)
+    global_outvars = closed_jaxpr.jaxpr.outvars
 
     # Transform compute_grad to accumulate_grad
     # FIXME(yonghao): use apply grad jaxpr returned by this function

--- a/alpa/pipeline_parallel/runtime_emitter.py
+++ b/alpa/pipeline_parallel/runtime_emitter.py
@@ -1159,10 +1159,12 @@ class OverlapFriendlyPipelineInstEmitter(PipelineInstEmitter):
         # Reorder send and merge
         for stage_idx, stage in enumerate(self.stages):
             send_vars = self.stage_send_vars[stage_idx]
-            def_order = {
+            var_def_order = {
                 k: i for i, k in enumerate(outvar_def_order[stage_idx])
             }
-            send_vars = sorted(send_vars, key=lambda x: (def_order[x[1]], x[0]))
+            send_vars = sorted(send_vars,
+                               key=lambda i, v, _, order=var_def_order:
+                               (order[v], i))
             final_send_seq = []
             for recv_stage_idx, v, spec in send_vars:
                 if (len(final_send_seq) != 0 and

--- a/alpa/pipeline_parallel/runtime_emitter.py
+++ b/alpa/pipeline_parallel/runtime_emitter.py
@@ -186,7 +186,12 @@ class PipelineInstEmitterHelper:
 
     def get_var_mesh_uuid(self, var, batch_idx, mesh_idx) -> int:
         key = self._get_var_key(var, batch_idx)
-        return self.env[key][mesh_idx]
+        try:
+            return self.env[key][mesh_idx]
+        except KeyError as e:
+            print(key, var, batch_idx, mesh_idx)
+            print(self.env[key])
+            raise e
 
     def get_var_meshes(self, var, batch_idx) -> Dict[int, int]:
         key = self._get_var_key(var, batch_idx)
@@ -1117,7 +1122,6 @@ class OverlapFriendlyPipelineInstEmitter(PipelineInstEmitter):
         # Dict[int, Dict[int, Tuple(List, List)]]
         # src_mesh_idx -> (dst_mesh_idx -> (Vars, Sharding Specs))
         self.stage_send_vars = [[] for _ in range(len(self.stages))]
-        self.send_var_sets = [{} for _ in range(len(self.stages))]
         self._get_stage_send_vars(outvar_def_order)
 
     def _get_stage_send_vars(self, outvar_def_order):
@@ -1132,6 +1136,8 @@ class OverlapFriendlyPipelineInstEmitter(PipelineInstEmitter):
             for var_idx, var in enumerate(stage.invars):
                 if (var in global_invar_set or var in self.grad_dummy_invars or
                         mesh_idx in var_at_mesh[var]):
+                    if str(var) == "cus":
+                        print("skip at mesh", stage_idx, mesh_idx)
                     continue
                 else:
                     # Currently we use the first mesh, since there is almost no
@@ -1149,22 +1155,23 @@ class OverlapFriendlyPipelineInstEmitter(PipelineInstEmitter):
             for var in stage.outvars:
                 var_defined.setdefault(var, OrderedSet()).add(stage_idx)
                 var_at_mesh.setdefault(var, OrderedSet()).add(mesh_idx)
+        print(self.stage_send_vars[0])
         # Reorder send and merge
         for stage_idx, stage in enumerate(self.stages):
             send_vars = self.stage_send_vars[stage_idx]
-            var_send_as = {v: (idx, spec) for (idx, v, spec) in send_vars}
+            def_order = {
+                k: i for i, k in enumerate(outvar_def_order[stage_idx])
+            }
+            send_vars = sorted(send_vars, key=lambda x: (def_order[x[1]], x[0]))
             final_send_seq = []
-            for v in outvar_def_order[stage_idx]:
-                if v in var_send_as:
-                    recv_stage_idx, spec = var_send_as[v]
-                    if (len(final_send_seq) != 0 and
-                        (final_send_seq[-1][0] == recv_stage_idx)):
-                        final_send_seq[-1][1].append(v)
-                        final_send_seq[-1][2].append(spec)
-                    else:
-                        final_send_seq.append((recv_stage_idx, [v], [spec]))
+            for recv_stage_idx, v, spec in send_vars:
+                if (len(final_send_seq) != 0 and
+                    (final_send_seq[-1][0] == recv_stage_idx)):
+                    final_send_seq[-1][1].append(v)
+                    final_send_seq[-1][2].append(spec)
+                else:
+                    final_send_seq.append((recv_stage_idx, [v], [spec]))
             self.stage_send_vars[stage_idx] = final_send_seq
-            self.send_var_sets[stage_idx] = set(var_send_as.keys())
 
     def _compile_exec_one_tick(self, sched, donation_mapping, instruction_lists,
                                executable_uuids, executable_config_lists):


### PR DESCRIPTION
1. Prune pipeline markers to avoid redundant in/out vars;
2. Fix 1f1b overlap friendly schedule when sending a var to multiple meshes