### PR TITLE
[FIX] explicit stage num with uniform stage divided by flops

### DIFF
--- a/alpa/pipeline_parallel/apply_grad.py
+++ b/alpa/pipeline_parallel/apply_grad.py
@@ -919,7 +919,7 @@ class ApplyGradRewriter:
             at_mesh = OrderedSet()
             for invar in _filter_literal(eqn.invars):
                 at_mesh.update(self.var_mesh.setdefault(invar, OrderedSet()))
-            # TODO(yonghao): round robin this and use the result in later positions
+            # TODO(yonghao): round robin this and use it in later positions
             if len(at_mesh) == 0 and eqn_idx not in has_color:
                 at_mesh = OrderedSet([0])
             if len(at_mesh) == 1:

--- a/alpa/pipeline_parallel/apply_grad.py
+++ b/alpa/pipeline_parallel/apply_grad.py
@@ -893,24 +893,37 @@ class ApplyGradRewriter:
         self.eqn_mesh = {}
         self.var_use = {}
         self.var_def = {}
+        for eqn_idx, eqn in enumerate(self.eqns):
+            for invar in _filter_literal(eqn.invars):
+                self.var_use.setdefault(invar, OrderedSet()).add(eqn_idx)
+            for outvar in _filter_droped(eqn.outvars):
+                self.var_def[outvar] = eqn_idx
+        has_color = OrderedSet(
+            [k for k in self.var_mesh if len(self.var_mesh[k]) > 0])
+        q = list(has_color)
+        while len(q) > 0:
+            if q[0] in self.var_use:
+                used_eqns = self.var_use[q[0]]
+                has_color.update(used_eqns)
+                for e_id in used_eqns.difference(has_color):
+                    q.append(e_id)
+            q = q[1:]
+
         # Propagate the first round
         for eqn_idx, eqn in enumerate(self.eqns):
             at_mesh = OrderedSet()
-            for invar in eqn.invars:
-                if isinstance(invar, Var):
-                    at_mesh.update(self.var_mesh.setdefault(
-                        invar, OrderedSet()))
-                    self.var_use.setdefault(invar, OrderedSet()).add(eqn_idx)
+            for invar in _filter_literal(eqn.invars):
+                at_mesh.update(self.var_mesh.setdefault(invar, OrderedSet()))
+            # TODO(yonghao): round robin this and use the result in later positions
+            if len(at_mesh) == 0 and eqn_idx not in has_color:
+                at_mesh = OrderedSet([0])
             if len(at_mesh) == 1:
-                for invar in eqn.invars:
-                    if isinstance(invar, Var):
-                        self.var_mesh.setdefault(invar,
-                                                 OrderedSet()).update(at_mesh)
+                for invar in _filter_literal(eqn.invars):
+                    self.var_mesh.setdefault(invar,
+                                             OrderedSet()).update(at_mesh)
             self.eqn_mesh[eqn_idx] = list(at_mesh)
-            for outvar in eqn.outvars:
-                if not isinstance(outvar, DropVar):
-                    self.var_mesh[outvar] = OrderedSet(at_mesh)
-                    self.var_def[outvar] = eqn_idx
+            for outvar in _filter_droped(eqn.outvars):
+                self.var_mesh[outvar] = OrderedSet(at_mesh)
 
     def _reducable_chain_lookup(self, eqn_idx, num_mesh):
         """

--- a/alpa/pipeline_parallel/apply_grad.py
+++ b/alpa/pipeline_parallel/apply_grad.py
@@ -898,12 +898,17 @@ class ApplyGradRewriter:
                 self.var_use.setdefault(invar, OrderedSet()).add(eqn_idx)
             for outvar in _filter_droped(eqn.outvars):
                 self.var_def[outvar] = eqn_idx
-        has_color = OrderedSet(
-            [k for k in self.var_mesh if len(self.var_mesh[k]) > 0])
+        has_color = OrderedSet([
+            self.var_def[k]
+            for k in self.var_mesh
+            if (len(self.var_mesh[k]) > 0 and k in self.var_def)
+        ])
         q = list(has_color)
         while len(q) > 0:
-            if q[0] in self.var_use:
-                used_eqns = self.var_use[q[0]]
+            for outv in _filter_droped(self.eqns[q[0]].outvars):
+                if outv not in self.var_use:
+                    continue
+                used_eqns = self.var_use[outv]
                 has_color.update(used_eqns)
                 for e_id in used_eqns.difference(has_color):
                     q.append(e_id)


### PR DESCRIPTION
The previous `UniformStageOption` uses "`flops_if_cut_here` is the closest to `average_flops_per_stage`" to divide a stage, however, this tends to divide a stage slightly smaller than the average. The shift accumulates and thus the last stage may not end at the last layer, but some layers before. This pr fixes the bug by cutting at "`flops_till_now` is the closest to `average_flops_per_stage * stage_idx`"