### PR TITLE
Let NCCL ID store fate share with CollectiveGroup.

### DIFF
--- a/alpa/collective/collective_group/base_collective_group.py
+++ b/alpa/collective/collective_group/base_collective_group.py
@@ -112,7 +112,6 @@ class Rendezvous:
 
     def destroy_store(self):
         """Delete the named actor."""
-        ray.kill(self._store)
         self._store = None
 
 

--- a/alpa/collective/collective_group/nccl_collective_group.py
+++ b/alpa/collective/collective_group/nccl_collective_group.py
@@ -569,8 +569,7 @@ class NCCLGroup(BaseGroup):
         group_uid = nccl_util.get_nccl_unique_id()
         return group_uid
 
-    @staticmethod
-    def _generate_nccl_uid(key):
+    def _generate_nccl_uid(self, key):
         """Generate an NCCL unique ID for initializing communicators.
 
         The method will also create a KV store using Ray named actor and store
@@ -587,9 +586,9 @@ class NCCLGroup(BaseGroup):
         store_name = get_store_name(key)
         # Avoid a potential circular dependency in ray/actor.py
         from alpa.collective.util import NCCLUniqueIDStore  # pylint: disable=import-outside-toplevel
-        store = NCCLUniqueIDStore.options(
-            name=store_name, lifetime="detached").remote(store_name)
-        ray.get([store.set_id.remote(group_uid)])
+        self._store = NCCLUniqueIDStore.options(
+            name=store_name).remote(store_name)
+        ray.get([self._store.set_id.remote(group_uid)])
         return group_uid
 
     def _collective(self,

--- a/alpa/collective/collective_group/xla_nccl_collective_group.py
+++ b/alpa/collective/collective_group/xla_nccl_collective_group.py
@@ -347,8 +347,7 @@ class XLANCCLGroup(BaseGroup):
         group_uid = xla_nccl_util.get_nccl_unique_id()
         return group_uid
 
-    @staticmethod
-    def _generate_nccl_uid(key):
+    def _generate_nccl_uid(self, key):
         """Generate an NCCL unique ID for initializing communicators.
 
         The method will also create a KV store using Ray named actor and store
@@ -365,9 +364,9 @@ class XLANCCLGroup(BaseGroup):
         store_name = get_store_name(key)
         # Avoid a potential circular dependency in ray/actor.py
         from alpa.collective.util import NCCLUniqueIDStore  # pylint: disable=import-outside-toplevel
-        store = NCCLUniqueIDStore.options(
-            name=store_name, lifetime="detached").remote(store_name)
-        ray.get([store.set_id.remote(group_uid)])
+        self._store = NCCLUniqueIDStore.options(
+            name=store_name).remote(store_name)
+        ray.get([self._store.set_id.remote(group_uid)])
         return group_uid
 
     # unimplemented


### PR DESCRIPTION
Right now the id actor is detached and deleted by "supposedly" the last user of the actor.
However when execution order is not determined, this will crash the entire workload if the killed named actor is accessed again.
This change make the actor fate-share with worker rank 0. so Rendezvous would not need to kill it.

Closes #907