### PR TITLE
Fix CI docker build

### DIFF
--- a/docker/unittest.Dockerfile
+++ b/docker/unittest.Dockerfile
@@ -3,6 +3,9 @@ FROM gcr.io/tensorflow-testing/nosla-cuda11.1-cudnn8-ubuntu18.04-manylinux2010-m
 WORKDIR /
 SHELL ["/bin/bash", "-c"]
 RUN rm -f /etc/apt/sources.list.d/jonathonf-ubuntu-python-3_6-xenial.list
+# Fetch latest pub key so apt-get works.
+RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
+RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64/7fa2af80.pub
 RUN apt-get update
 RUN apt-get install -y python3-virtualenv
 RUN virtualenv --python=python3.7 python3.7-env


### PR DESCRIPTION
Fetch latest pub key for ubuntu18.04 image, so apt-get will work.