### PR TITLE
[Simple] Remove deprecated numpy.int/float

### DIFF
--- a/alpa/collective/collective_group/gloo_util.py
+++ b/alpa/collective/collective_group/gloo_util.py
@@ -21,7 +21,6 @@ GLOO_REDUCE_OP_MAP = {
 
 NUMPY_GLOO_DTYPE_MAP = {
     # INT types
-    numpy.int: pygloo.glooDataType_t.glooInt64,
     numpy.uint8: pygloo.glooDataType_t.glooUint8,
     numpy.uint32: pygloo.glooDataType_t.glooUint32,
     numpy.uint64: pygloo.glooDataType_t.glooUint64,
@@ -30,7 +29,6 @@ NUMPY_GLOO_DTYPE_MAP = {
     numpy.int64: pygloo.glooDataType_t.glooInt64,
     # FLOAT types
     numpy.half: pygloo.glooDataType_t.glooFloat16,
-    numpy.float: pygloo.glooDataType_t.glooFloat64,
     numpy.float16: pygloo.glooDataType_t.glooFloat16,
     numpy.float32: pygloo.glooDataType_t.glooFloat32,
     numpy.float64: pygloo.glooDataType_t.glooFloat64,

--- a/alpa/collective/collective_group/nccl_util.py
+++ b/alpa/collective/collective_group/nccl_util.py
@@ -29,7 +29,6 @@ if global_config.has_cuda:
     # cupy types are the same with numpy types
     NUMPY_NCCL_DTYPE_MAP = {
         # INT types
-        numpy.int: nccl.NCCL_INT64,
         numpy.uint8: nccl.NCCL_UINT8,
         numpy.uint32: nccl.NCCL_UINT32,
         numpy.uint64: nccl.NCCL_UINT64,
@@ -38,8 +37,6 @@ if global_config.has_cuda:
         numpy.int64: nccl.NCCL_INT64,
         # FLOAT types
         numpy.half: nccl.NCCL_HALF,
-        # note that numpy.float is float64.
-        numpy.float: nccl.NCCL_FLOAT64,
         numpy.float16: nccl.NCCL_FLOAT16,
         numpy.float32: nccl.NCCL_FLOAT32,
         numpy.float64: nccl.NCCL_FLOAT64,


### PR DESCRIPTION
I got this error while installing alpa from source:
```
In [1]: import alpa
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[1], line 1
----> 1 import alpa

File ~/src/alpa/alpa/__init__.py:3
      1 """Alpa is a system for training large-scale neural networks."""
      2 # Import all public packages
----> 3 from . import api
      4 from . import collective
      5 from . import create_state_parallel

File ~/src/alpa/alpa/api.py:13
     10 from jax.experimental.maps import FrozenDict
     11 from jax.tree_util import tree_flatten, tree_unflatten, PyTreeDef
---> 13 from alpa.device_mesh import init_global_cluster, shutdown_global_cluster
     14 from alpa.parallel_method import ParallelMethod, ShardParallel
     15 from alpa.pipeline_parallel.primitive_def import mark_gradient

File ~/src/alpa/alpa/device_mesh.py:49
     46 from ray.util.placement_group import remove_placement_group
     48 from alpa import mesh_profiling
---> 49 import alpa.collective as col
     50 from alpa.global_env import global_config
     51 from alpa.monkey_patch import set_override_backend

File ~/src/alpa/alpa/collective/__init__.py:3
      1 """Alpa's wrapper for NCCL collective operations."""
----> 3 from alpa.collective.collective import (
      4     nccl_available, gloo_available, is_group_initialized, init_collective_group,
      5     destroy_collective_group, create_collective_group, get_rank,
      6     get_collective_group_size, allreduce, allreduce_multigpu, barrier, reduce,
      7     reduce_multigpu, broadcast, broadcast_partialgpu, broadcast_multigpu,
      8     allgather, allgather_multigpu, reducescatter, reducescatter_multigpu, send,
      9     send_multigpu, recv, recv_multigpu, check_and_get_group, record_events,
     10     wait_events, comm_wait_compute, compute_wait_comm)
     12 __all__ = [
     13     "nccl_available", "gloo_available", "is_group_initialized",
     14     "init_collective_group", "destroy_collective_group",
   (...)
     20     "record_events", "wait_events", "comm_wait_compute", "compute_wait_comm"
     21 ]

File ~/src/alpa/alpa/collective/collective.py:23
     20 logger = logging.getLogger(__name__)
     22 try:
---> 23     from alpa.collective.collective_group.nccl_collective_group import (
     24         NCCLGroup as CupyNcclGroup)
     25 except ImportError:
     26     _CUPY_NCCL_AVAILABLE = False

File ~/src/alpa/alpa/collective/collective_group/nccl_collective_group.py:9
      6 from jax._src.lib import xla_extension as xe
      8 from alpa.collective.const import ENV
----> 9 from alpa.collective.collective_group import nccl_util
     10 from alpa.collective.collective_group.base_collective_group import (BaseGroup,
     11                                                                     Rendezvous)
     12 from alpa.collective.const import get_store_name

File ~/src/alpa/alpa/collective/collective_group/nccl_util.py:32
     22     NCCL_REDUCE_OP_MAP = {
     23         ReduceOp.SUM: nccl.NCCL_SUM,
     24         ReduceOp.PRODUCT: nccl.NCCL_PROD,
     25         ReduceOp.MIN: nccl.NCCL_MIN,
     26         ReduceOp.MAX: nccl.NCCL_MAX,
     27     }
     29     # cupy types are the same with numpy types
     30     NUMPY_NCCL_DTYPE_MAP = {
     31         # INT types
---> 32         numpy.int: nccl.NCCL_INT64,
     33         numpy.uint8: nccl.NCCL_UINT8,
     34         numpy.uint32: nccl.NCCL_UINT32,
     35         numpy.uint64: nccl.NCCL_UINT64,
     36         numpy.int8: nccl.NCCL_INT8,
     37         numpy.int32: nccl.NCCL_INT32,
     38         numpy.int64: nccl.NCCL_INT64,
     39         # FLOAT types
     40         numpy.half: nccl.NCCL_HALF,
     41         # note that numpy.float is float64.
     42         numpy.float: nccl.NCCL_FLOAT64,
     43         numpy.float16: nccl.NCCL_FLOAT16,
     44         numpy.float32: nccl.NCCL_FLOAT32,
     45         numpy.float64: nccl.NCCL_FLOAT64,
     46         numpy.double: nccl.NCCL_DOUBLE
     47     }
     49 if torch_available():
     50     import torch

File ~/anaconda3/envs/alpa/lib/python3.8/site-packages/numpy/__init__.py:305, in __getattr__(attr)
    300     warnings.warn(
    301         f"In the future `np.{attr}` will be defined as the "
    302         "corresponding NumPy scalar.", FutureWarning, stacklevel=2)
    304 if attr in __former_attrs__:
--> 305     raise AttributeError(__former_attrs__[attr])
    307 # Importing Tester requires importing all of UnitTest which is not a
    308 # cheap import Since it is mainly used in test suits, we lazy import it
    309 # here to save on the order of 10 ms of import time for most users
    310 #
    311 # The previous way Tester was imported also had a side effect of adding
    312 # the full `numpy.testing` namespace
    313 if attr == 'testing':

AttributeError: module 'numpy' has no attribute 'int'.
`np.int` was a deprecated alias for the builtin `int`. To avoid this error in existing code, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```