### PR TITLE
removed mapping of numpy.int and numpy.float to nccl and gloo types

### DIFF
--- a/alpa/collective/collective_group/gloo_util.py
+++ b/alpa/collective/collective_group/gloo_util.py
@@ -21,7 +21,6 @@ GLOO_REDUCE_OP_MAP = {
 
 NUMPY_GLOO_DTYPE_MAP = {
     # INT types
-    numpy.int: pygloo.glooDataType_t.glooInt64,
     numpy.uint8: pygloo.glooDataType_t.glooUint8,
     numpy.uint32: pygloo.glooDataType_t.glooUint32,
     numpy.uint64: pygloo.glooDataType_t.glooUint64,
@@ -30,7 +29,6 @@ NUMPY_GLOO_DTYPE_MAP = {
     numpy.int64: pygloo.glooDataType_t.glooInt64,
     # FLOAT types
     numpy.half: pygloo.glooDataType_t.glooFloat16,
-    numpy.float: pygloo.glooDataType_t.glooFloat64,
     numpy.float16: pygloo.glooDataType_t.glooFloat16,
     numpy.float32: pygloo.glooDataType_t.glooFloat32,
     numpy.float64: pygloo.glooDataType_t.glooFloat64,

--- a/alpa/collective/collective_group/nccl_util.py
+++ b/alpa/collective/collective_group/nccl_util.py
@@ -29,7 +29,6 @@ if global_config.has_cuda:
     # cupy types are the same with numpy types
     NUMPY_NCCL_DTYPE_MAP = {
         # INT types
-        numpy.int: nccl.NCCL_INT64,
         numpy.uint8: nccl.NCCL_UINT8,
         numpy.uint32: nccl.NCCL_UINT32,
         numpy.uint64: nccl.NCCL_UINT64,
@@ -39,7 +38,6 @@ if global_config.has_cuda:
         # FLOAT types
         numpy.half: nccl.NCCL_HALF,
         # note that numpy.float is float64.
-        numpy.float: nccl.NCCL_FLOAT64,
         numpy.float16: nccl.NCCL_FLOAT16,
         numpy.float32: nccl.NCCL_FLOAT32,
         numpy.float64: nccl.NCCL_FLOAT64,


### PR DESCRIPTION
removed from mapping because they're deprecated