### PR TITLE
[FIX] Replace DeviceArray by Array

### DIFF
--- a/alpa/collective/worker_nccl_util_cupy.py
+++ b/alpa/collective/worker_nccl_util_cupy.py
@@ -23,8 +23,7 @@ logger.setLevel(logging.INFO)
 
 
 # Note: in this device mesh code, we will use 3 types of tensors:
-# (1) JAX high-level _DeviceArray, which is index-able, has __cuda_array__
-#     interface
+# (1) JAX high-level Array, which is index-able
 # (2) XLA low-level PyLocalBuffer, which is not index-able
 # (3) cupy array, which is an intermediate format for ray collective
 def send_tile(worker, uuid: int, device_id: int, offset: Sequence[slice],
@@ -246,7 +245,7 @@ def cupy_to_xla_buffer(tensor):
 
 
 def jax_tensor_to_cupy(tensors, take_ownership=False):
-    """Convert a Jax DeviceArray to cupy tensor; zero copy."""
+    """Convert a Jax Array to cupy tensor; zero copy."""
     if isinstance(tensors, list):
         return list(map(jax_tensor_to_cupy, tensors))
     return cupy.fromDlpack(to_dlpack(tensors, take_ownership=take_ownership))

--- a/alpa/collective/worker_nccl_util_xla.py
+++ b/alpa/collective/worker_nccl_util_xla.py
@@ -71,7 +71,7 @@ def recv_tile(worker, uuid: int, device_id: int,
                           n_elements=n_elements)
     else:
         tmp_buffer = device_put(jnp.ones(slice_shape, dtype=buffer.dtype),
-                                worker.local_devices[device_id])._arrays[0]
+                                worker.local_devices[device_id])
         to_recv = jax_tensor_to_xla_buffer(tmp_buffer)
         n_elements = np.prod(slice_shape)
         # let recv stream wait for d2d stream
@@ -147,7 +147,7 @@ def broadcast(worker, uuid, comm_key, world_size, devices_ids,
                                        start_indices, slice_shape)
             else:
                 tmp = device_put(jnp.ones(slice_shape, dtype=buffer.dtype),
-                                 worker.local_devices[device_id])._arrays[0]
+                                 worker.local_devices[device_id])
             # let communicate stream wait for compute stream
             is_send = global_rank == 0
             col.comm_wait_compute(group_name, is_send, True, device_id)

--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -901,7 +901,7 @@ class LocalPhysicalDeviceMesh(PhysicalDeviceMesh):
                     bufs.append(
                         pxla.shard_arg(arg, self.devices, indices, None))
 
-            if isinstance(arg, xe.DeviceArray) and donated:
+            if isinstance(arg, (xe.ArrayImpl, xe.DeviceArray)) and donated:
                 arg.delete()
 
         return bufs

--- a/alpa/global_env.py
+++ b/alpa/global_env.py
@@ -77,8 +77,9 @@ class GlobalConfig:
         self.resharding_mode = "broadcast"
         # Which nccl to use. Possible choices: {"cupy",
         # "xla_extension"}
-        # FIXME: cupy is broken. Test after ArrayImpl-DeviceArray-Buffer
-        # relationship is fixed.
+        # FIXME: cupy is broken for an unknown device mismatch. The error msg
+        # show that two tensors are on devices with the same id, but jax still
+        # treats them mismatched.
         self.nccl_mode = "xla_extension"
         self.enable_overlapping = False
         # Cross mesh resharding load balancing mode.

--- a/alpa/model/model_util.py
+++ b/alpa/model/model_util.py
@@ -21,7 +21,7 @@ Array = Any
 
 def is_tensor(x):
     """
-    Tests if ``x`` is a :obj:`torch.Tensor`, :obj:`tf.Tensor`, obj:`jaxlib.xla_extension.DeviceArray` or
+    Tests if ``x`` is a :obj:`torch.Tensor`, :obj:`tf.Tensor`, obj:`jax.Tensor` or
     :obj:`np.ndarray`.
     """
     #if is_torch_fx_proxy(x):
@@ -42,7 +42,7 @@ def is_tensor(x):
         import jaxlib.xla_extension as jax_xla
         from jax.core import Tracer
 
-        if isinstance(x, (jax_xla.DeviceArray, Tracer)):
+        if isinstance(x, (jax.Array, Tracer)):
             return True
 
     return isinstance(x, np.ndarray)
@@ -161,22 +161,22 @@ class FlaxBaseModelOutput(ModelOutput):
     """
     Base class for model's outputs, with potential hidden states and attentions.
     Args:
-        last_hidden_state (:obj:`jax_xla.DeviceArray` of shape :obj:`(batch_size, sequence_length, hidden_size)`):
+        last_hidden_state (:obj:`jax.Array` of shape :obj:`(batch_size, sequence_length, hidden_size)`):
             Sequence of hidden-states at the output of the last layer of the model.
-        hidden_states (:obj:`tuple(jax_xla.DeviceArray)`, `optional`, returned when ``output_hidden_states=True`` is passed or when ``config.output_hidden_states=True``):
-            Tuple of :obj:`jax_xla.DeviceArray` (one for the output of the embeddings + one for the output of each
+        hidden_states (:obj:`tuple(jax.Array)`, `optional`, returned when ``output_hidden_states=True`` is passed or when ``config.output_hidden_states=True``):
+            Tuple of :obj:`jax.Array` (one for the output of the embeddings + one for the output of each
             layer) of shape :obj:`(batch_size, sequence_length, hidden_size)`.
             Hidden-states of the model at the output of each layer plus the initial embedding outputs.
-        attentions (:obj:`tuple(jax_xla.DeviceArray)`, `optional`, returned when ``output_attentions=True`` is passed or when ``config.output_attentions=True``):
-            Tuple of :obj:`jax_xla.DeviceArray` (one for each layer) of shape :obj:`(batch_size, num_heads,
+        attentions (:obj:`tuple(jax.Array)`, `optional`, returned when ``output_attentions=True`` is passed or when ``config.output_attentions=True``):
+            Tuple of :obj:`jax.Array` (one for each layer) of shape :obj:`(batch_size, num_heads,
             sequence_length, sequence_length)`.
             Attentions weights after the attention softmax, used to compute the weighted average in the self-attention
             heads.
     """
 
-    last_hidden_state: jax_xla.DeviceArray = None
-    hidden_states: Optional[Tuple[jax_xla.DeviceArray]] = None
-    attentions: Optional[Tuple[jax_xla.DeviceArray]] = None
+    last_hidden_state: jax.Array = None
+    hidden_states: Optional[Tuple[jax.Array]] = None
+    attentions: Optional[Tuple[jax.Array]] = None
 
 
 @flax.struct.dataclass
@@ -184,27 +184,27 @@ class FlaxBaseModelOutputWithPooling(ModelOutput):
     """
     Base class for model's outputs that also contains a pooling of the last hidden states.
     Args:
-        last_hidden_state (:obj:`jax_xla.DeviceArray` of shape :obj:`(batch_size, sequence_length, hidden_size)`):
+        last_hidden_state (:obj:`jax.Array` of shape :obj:`(batch_size, sequence_length, hidden_size)`):
             Sequence of hidden-states at the output of the last layer of the model.
-        pooler_output (:obj:`jax_xla.DeviceArray` of shape :obj:`(batch_size, hidden_size)`):
+        pooler_output (:obj:`jax.Array` of shape :obj:`(batch_size, hidden_size)`):
             Last layer hidden-state of the first token of the sequence (classification token) further processed by a
             Linear layer and a Tanh activation function. The Linear layer weights are trained from the next sentence
             prediction (classification) objective during pretraining.
-        hidden_states (:obj:`tuple(jax_xla.DeviceArray)`, `optional`, returned when ``output_hidden_states=True`` is passed or when ``config.output_hidden_states=True``):
-            Tuple of :obj:`jax_xla.DeviceArray` (one for the output of the embeddings + one for the output of each
+        hidden_states (:obj:`tuple(jax.Array)`, `optional`, returned when ``output_hidden_states=True`` is passed or when ``config.output_hidden_states=True``):
+            Tuple of :obj:`jax.Array` (one for the output of the embeddings + one for the output of each
             layer) of shape :obj:`(batch_size, sequence_length, hidden_size)`.
             Hidden-states of the model at the output of each layer plus the initial embedding outputs.
-        attentions (:obj:`tuple(jax_xla.DeviceArray)`, `optional`, returned when ``output_attentions=True`` is passed or when ``config.output_attentions=True``):
-            Tuple of :obj:`jax_xla.DeviceArray` (one for each layer) of shape :obj:`(batch_size, num_heads,
+        attentions (:obj:`tuple(jax.Array)`, `optional`, returned when ``output_attentions=True`` is passed or when ``config.output_attentions=True``):
+            Tuple of :obj:`jax.Array` (one for each layer) of shape :obj:`(batch_size, num_heads,
             sequence_length, sequence_length)`.
             Attentions weights after the attention softmax, used to compute the weighted average in the self-attention
             heads.
     """
 
-    last_hidden_state: jax_xla.DeviceArray = None
-    pooler_output: jax_xla.DeviceArray = None
-    hidden_states: Optional[Tuple[jax_xla.DeviceArray]] = None
-    attentions: Optional[Tuple[jax_xla.DeviceArray]] = None
+    last_hidden_state: jax.Array = None
+    pooler_output: jax.Array = None
+    hidden_states: Optional[Tuple[jax.Array]] = None
+    attentions: Optional[Tuple[jax.Array]] = None
 
 
 @flax.struct.dataclass
@@ -212,26 +212,26 @@ class FlaxBertForPreTrainingOutput(ModelOutput):
     """
     Output type of :class:`~transformers.BertForPreTraining`.
     Args:
-        prediction_logits (:obj:`jax_xla.DeviceArray` of shape :obj:`(batch_size, sequence_length, config.vocab_size)`):
+        prediction_logits (:obj:`jax.Array` of shape :obj:`(batch_size, sequence_length, config.vocab_size)`):
             Prediction scores of the language modeling head (scores for each vocabulary token before SoftMax).
-        seq_relationship_logits (:obj:`jax_xla.DeviceArray` of shape :obj:`(batch_size, 2)`):
+        seq_relationship_logits (:obj:`jax.Array` of shape :obj:`(batch_size, 2)`):
             Prediction scores of the next sequence prediction (classification) head (scores of True/False continuation
             before SoftMax).
-        hidden_states (:obj:`tuple(jax_xla.DeviceArray)`, `optional`, returned when ``output_hidden_states=True`` is passed or when ``config.output_hidden_states=True``):
-            Tuple of :obj:`jax_xla.DeviceArray` (one for the output of the embeddings + one for the output of each
+        hidden_states (:obj:`tuple(jax.Array)`, `optional`, returned when ``output_hidden_states=True`` is passed or when ``config.output_hidden_states=True``):
+            Tuple of :obj:`jax.Array` (one for the output of the embeddings + one for the output of each
             layer) of shape :obj:`(batch_size, sequence_length, hidden_size)`.
             Hidden-states of the model at the output of each layer plus the initial embedding outputs.
-        attentions (:obj:`tuple(jax_xla.DeviceArray)`, `optional`, returned when ``output_attentions=True`` is passed or when ``config.output_attentions=True``):
-            Tuple of :obj:`jax_xla.DeviceArray` (one for each layer) of shape :obj:`(batch_size, num_heads,
+        attentions (:obj:`tuple(jax.Array)`, `optional`, returned when ``output_attentions=True`` is passed or when ``config.output_attentions=True``):
+            Tuple of :obj:`jax.Array` (one for each layer) of shape :obj:`(batch_size, num_heads,
             sequence_length, sequence_length)`.
             Attentions weights after the attention softmax, used to compute the weighted average in the self-attention
             heads.
     """
 
-    prediction_logits: jax_xla.DeviceArray = None
-    seq_relationship_logits: jax_xla.DeviceArray = None
-    hidden_states: Optional[Tuple[jax_xla.DeviceArray]] = None
-    attentions: Optional[Tuple[jax_xla.DeviceArray]] = None
+    prediction_logits: jax.Array = None
+    seq_relationship_logits: jax.Array = None
+    hidden_states: Optional[Tuple[jax.Array]] = None
+    attentions: Optional[Tuple[jax.Array]] = None
 
 
 @flax.struct.dataclass
@@ -239,22 +239,22 @@ class FlaxMaskedLMOutput(ModelOutput):
     """
     Base class for masked language models outputs.
     Args:
-        logits (:obj:`jax_xla.DeviceArray` of shape :obj:`(batch_size, sequence_length, config.vocab_size)`):
+        logits (:obj:`jax.Array` of shape :obj:`(batch_size, sequence_length, config.vocab_size)`):
             Prediction scores of the language modeling head (scores for each vocabulary token before SoftMax).
-        hidden_states (:obj:`tuple(jax_xla.DeviceArray)`, `optional`, returned when ``output_hidden_states=True`` is passed or when ``config.output_hidden_states=True``):
-            Tuple of :obj:`jax_xla.DeviceArray` (one for the output of the embeddings + one for the output of each
+        hidden_states (:obj:`tuple(jax.Array)`, `optional`, returned when ``output_hidden_states=True`` is passed or when ``config.output_hidden_states=True``):
+            Tuple of :obj:`jax.Array` (one for the output of the embeddings + one for the output of each
             layer) of shape :obj:`(batch_size, sequence_length, hidden_size)`.
             Hidden-states of the model at the output of each layer plus the initial embedding outputs.
-        attentions (:obj:`tuple(jax_xla.DeviceArray)`, `optional`, returned when ``output_attentions=True`` is passed or when ``config.output_attentions=True``):
-            Tuple of :obj:`jax_xla.DeviceArray` (one for each layer) of shape :obj:`(batch_size, num_heads,
+        attentions (:obj:`tuple(jax.Array)`, `optional`, returned when ``output_attentions=True`` is passed or when ``config.output_attentions=True``):
+            Tuple of :obj:`jax.Array` (one for each layer) of shape :obj:`(batch_size, num_heads,
             sequence_length, sequence_length)`.
             Attentions weights after the attention softmax, used to compute the weighted average in the self-attention
             heads.
     """
 
-    logits: jax_xla.DeviceArray = None
-    hidden_states: Optional[Tuple[jax_xla.DeviceArray]] = None
-    attentions: Optional[Tuple[jax_xla.DeviceArray]] = None
+    logits: jax.Array = None
+    hidden_states: Optional[Tuple[jax.Array]] = None
+    attentions: Optional[Tuple[jax.Array]] = None
 
 
 @flax.struct.dataclass

--- a/alpa/pipeline_parallel/local_pipeline.py
+++ b/alpa/pipeline_parallel/local_pipeline.py
@@ -5,7 +5,6 @@ import jax
 from jax import linear_util as lu
 from jax.core import Var, ClosedJaxpr, Literal, gensym
 from jax.interpreters import partial_eval as pe
-from jax.interpreters.xla import DeviceArray
 
 from alpa.pipeline_parallel.computation import (
     PipelineComputation, XlaPipelineComputation,
@@ -16,7 +15,7 @@ from alpa.pipeline_parallel.computation import (
 class LocalPipelineRunner:
     """Single-device local pipeline runner."""
 
-    def __init__(self, name: str, global_invals: Sequence[DeviceArray]):
+    def __init__(self, name: str, global_invals: Dict[Var, jax.Array]):
         self.name = name
         self.env = {}
         self.global_invals = global_invals

--- a/alpa/serialization.py
+++ b/alpa/serialization.py
@@ -10,6 +10,7 @@ from typing import Union
 
 from flax.serialization import to_state_dict, from_state_dict
 import jax
+from jax._src import array
 from jax._src.tree_util import tree_flatten, tree_leaves, tree_unflatten, PyTreeDef
 import msgpack
 import numpy as np
@@ -117,12 +118,12 @@ def save_checkpoint(ckpt_dir: Union[str, os.PathLike],
         else:
             arr_cache_path = os.path.join(local_cache_dir, arr_dir)
         if isinstance(x, (DistributedArray, ReplicatedDistributedArray,
-                          np.ndarray, jax.xla.DeviceArray)):
+                          np.ndarray, array.ArrayImpl)):
             if isinstance(x, DistributedArray):
                 x.save(arr_path, arr_cache_path)
             elif isinstance(x, ReplicatedDistributedArray):
                 x.replica.save(arr_path, arr_cache_path)
-            elif isinstance(x, (np.ndarray, jax.xla.DeviceArray)):
+            elif isinstance(x, (np.ndarray, array.ArrayImpl)):
                 _save_unsharded_array(arr_path, x)
             flat_metadata.append(arr_dir)
         else:

--- a/alpa/util.py
+++ b/alpa/util.py
@@ -1182,7 +1182,7 @@ def infer_offset_and_n_elements(tensor_slice):
 
 def xla_buffer_to_jax_tensor(xla_buf):
     """
-    Convert an xla buffer to a JAX DeviceArray.
+    Convert an xla buffer to a JAX Array.
 
     So we can index over the data buffer.
     """
@@ -1227,6 +1227,9 @@ def jax_tensor_index(src_tensor, indices, size):
 
 
 def make_jax_array(aval, buf, committed=False):
+    """
+    Wrap a buffer to a jax array. Modified from _single_device_array_from_buf.
+    """
     return array.ArrayImpl(aval, SingleDeviceSharding(buf.device()), [buf],
                            committed=committed, _skip_checks=True)
 


### PR DESCRIPTION
Shifting from jax 0.3 to 0.4, tensor at the jax level uses `ArrayImpl` to replace `DeviceArray`. The `DeviceArray` class now represents the xla level bare buffer.
This pr is the initial fix for that shift. In the future, we should deprecate all use of `DeviceArray` and `ShardedDeviceArray`, and instead use `ArrayImpl` because it will be the only api in jax.