### PR TITLE
[FEATURE] pass global config to worker and set manual sharding of intermediates

### DIFF
--- a/alpa/device_mesh.py
+++ b/alpa/device_mesh.py
@@ -111,7 +111,7 @@ class MeshHostWorker:
 
     def __init__(self, server_address: str, num_hosts: int, host_id: int,
                  mesh_id: int, move_worker: DaemonMoveWorker,
-                 runtime_random_seed: int):
+                 runtime_random_seed: int, worker_global_config: dict):
         self.num_hosts = num_hosts
         self.host_id = host_id
         self.mesh_id = mesh_id
@@ -124,6 +124,9 @@ class MeshHostWorker:
         self.distributed_client.connect()
         logger.debug(
             f"{host_id}: Success to connect to xla runtime at {server_address}")
+
+        # Set global config to follow the driver
+        global_config.update_worker_config(worker_global_config)
         if global_config.backend == "gpu":
             self.backend = xla_client.make_gpu_client(self.distributed_client,
                                                       node_id=host_id)
@@ -1139,7 +1142,8 @@ class DistributedPhysicalDeviceMesh(PhysicalDeviceMesh):
                                      "env_vars": env_vars
                                  }).remote(server_address, self.num_hosts, i,
                                            self.mesh_id, move_worker,
-                                           global_config.runtime_random_seed)
+                                           global_config.runtime_random_seed,
+                                           global_config)
             workers.append(worker)
         return service_server, workers
 

--- a/alpa/global_env.py
+++ b/alpa/global_env.py
@@ -105,6 +105,36 @@ class GlobalConfig:
         backend_to_ray = {"gpu": "GPU"}
         return backend_to_ray[self.backend]
 
+    def update_worker_config(self, cfg: "GlobalConfig"):
+        """Update the worker config based on the host one"""
+        self.backend = cfg.backend
+        # Random seed used for compilation
+        self.compile_random_seed = cfg.compile_random_seed
+        # Random seed used for runtime
+        self.runtime_random_seed = cfg.runtime_random_seed
+        # XLA server port range
+        self.xla_server_port_start = cfg.xla_server_port_start
+        self.xla_server_port_end = cfg.xla_server_port_end
+        # XLA gpu kernel auto-tuning level
+        self.xla_gpu_autotune_level = cfg.xla_gpu_autotune_level
+        # Whether to use AWS EFA network interface
+        self.use_aws_efa = cfg.use_aws_efa
+        ########## Options of pipeline runtime ##########
+        # Whether to sync before and after the executable for accurate internal
+        # timer
+        self.pipeline_sync_for_timer = cfg.pipeline_sync_for_timer
+        # Whether to use single-byte signal tensor for send/recv.
+        # This is a debug option.
+        self.pipeline_use_signal_send_recv = cfg.pipeline_use_signal_send_recv
+        # Whether to use the scatter-gater/local-all-gather optimization.
+        self.use_local_allgather = cfg.use_local_allgather
+        # Cross mesh resharding mode. Possible choices: {"send_recv",
+        # "broadcast"}
+        self.resharding_mode = cfg.resharding_mode
+        self.nccl_mode = cfg.nccl_mode
+        self.enable_overlapping = cfg.enable_overlapping
+        self.collect_trace = cfg.collect_trace
+
 
 global_config = GlobalConfig()
 

--- a/alpa/pipeline_parallel/compile_executable.py
+++ b/alpa/pipeline_parallel/compile_executable.py
@@ -15,9 +15,7 @@ from alpa.global_env import global_config
 from alpa.pipeline_parallel.pipeshard_executable import PipeshardDriverExecutable
 from alpa.pipeline_parallel.runtime_emitter import (
     OverlapFriendlyPipelineInstEmitter, PipelineInstEmitter)
-from alpa.pipeline_parallel.schedules import (GpipeSchedule,
-                                              OverlapFriendlyPipeDreamSchedule,
-                                              PipeDreamFlush, InferenceSchedule)
+from alpa.pipeline_parallel.schedules import create_pipeline_schedule
 from alpa.pipeline_parallel.computation import (
     create_donation_mapping, generate_computations_from_modules,
     generate_sharded_xla_computations,
@@ -38,6 +36,7 @@ from alpa.shard_parallel.auto_sharding import (AutoShardingOption,
 from alpa.shard_parallel.manual_sharding import (ManualShardingOption,
                                                  ParsedManualShardingOption,
                                                  get_flatten_axis_resources,
+                                                 get_intermediate_parsed_spec,
                                                  parsed_spec_to_opsharding)
 from alpa.util import (get_var_mapping, trace_jaxpr_with_micro_batch,
                        OrderedSet, GradFuncTransformContext)
@@ -198,31 +197,14 @@ def compile_pipeshard_executable_internal(
     debug_compilation_time("apply grad")
 
     # Generate pipeline schedule and placement
-    dependency = gen_dependency_with_stages(jax_pipeline_stages,
-                                            sliced_apply_grad_stages)
-    if pipeline_schedule == "gpipe":
-        schedule = GpipeSchedule(dependency=dependency,
-                                 meshes=sliced_virtual_meshes,
-                                 apply_grad_placement=apply_grad_placement,
-                                 num_batch=num_microbatch)
-    elif pipeline_schedule == "1f1b":
-        schedule = PipeDreamFlush(dependency=dependency,
-                                  meshes=sliced_virtual_meshes,
-                                  apply_grad_placement=apply_grad_placement,
-                                  num_batch=num_microbatch)
-    elif pipeline_schedule == "inference":
-        schedule = InferenceSchedule(dependency=dependency,
-                                     meshes=sliced_virtual_meshes,
-                                     apply_grad_placement=apply_grad_placement,
-                                     num_batch=num_microbatch)
-    elif pipeline_schedule == "1f1b_overlap_friendly":
-        schedule = OverlapFriendlyPipeDreamSchedule(
-            dependency=dependency,
-            meshes=sliced_virtual_meshes,
-            apply_grad_placement=apply_grad_placement,
-            num_batch=num_microbatch)
-    else:
-        raise ValueError(f"Invalid schedule: {pipeline_schedule}")
+    dependency, fwd_intermediates = gen_dependency_with_stages(
+        jax_pipeline_stages, num_meshes, sliced_apply_grad_stages)
+    schedule = create_pipeline_schedule(
+        pipeline_schedule,
+        dependency=dependency,
+        meshes=sliced_virtual_meshes,
+        apply_grad_placement=apply_grad_placement,
+        num_batch=num_microbatch)
 
     # Forcibly set the sharding specs of global invars and outvars.
     # FIXME(yonghao): the invar can appear on multiple meshes and thus different
@@ -245,7 +227,7 @@ def compile_pipeshard_executable_internal(
          output_sharding_dicts) = get_manual_input_output_sharding_specs(
              jax_all_stages, manual_stage_option.submesh_logical_shapes,
              parsed_manual_sharding_option, global_invars, global_outvars,
-             schedule.stage_mesh_mapping)
+             schedule.stage_mesh_mapping, fwd_intermediates)
     else:
         input_sharding_dicts = [input_sharding_dict] * num_meshes
         output_sharding_dicts = [output_sharding_dict] * num_meshes
@@ -353,7 +335,7 @@ def split_and_process_layers(closed_jaxpr, full_batch_closed_jaxpr,
 
 def get_manual_input_output_sharding_specs(stages, mesh_shapes, ms_option,
                                            global_invars, global_outvars,
-                                           stage_to_mesh):
+                                           stage_to_mesh, fwd_intermediates):
     """
     Split user assigned input and output PartitionSpec into sharding specs for
     each pipeline stage.
@@ -363,6 +345,7 @@ def get_manual_input_output_sharding_specs(stages, mesh_shapes, ms_option,
     var_to_pspec = {}
     handle_invar = False
     handle_outvar = False
+    # Add global input and output's parsed partition spec.
     if ms_option.in_parsed_pspec is not None:
         var_to_pspec.update(dict(zip(global_invars, ms_option.in_parsed_pspec)))
         handle_invar = True
@@ -370,12 +353,22 @@ def get_manual_input_output_sharding_specs(stages, mesh_shapes, ms_option,
         var_to_pspec.update(
             dict(zip(global_outvars, ms_option.out_parsed_pspec)))
         handle_outvar = True
+    # Add pipeline intermediate's parsed partition spec.
+    intermediate_to_pspec = {}
+    if ms_option.pipeline_intermediate_axes is not None:
+        for v in fwd_intermediates:
+            intermediate_to_pspec[v] = get_intermediate_parsed_spec(
+                ms_option.pipeline_intermediate_axes, len(v.aval.shape))
+
     submesh_axis_names = ms_option.submesh_axis_names
     if submesh_axis_names is None:
         submesh_axis_names = [ms_option.mesh_axis_names] * len(mesh_shapes)
 
     def get_vars_to_sharding_specs(variables, mesh_shape, mesh_axis_names):
-        parsed_specs = [var_to_pspec[v] for v in variables]
+        parsed_specs = [
+            (var_to_pspec[v] if v in var_to_pspec else intermediate_to_pspec[v])
+            for v in variables
+        ]
         avals = [v.aval for v in variables]
         var_op_shardings = parsed_spec_to_opsharding(parsed_specs, avals,
                                                      mesh_shape,
@@ -398,8 +391,13 @@ def get_manual_input_output_sharding_specs(stages, mesh_shapes, ms_option,
         # invars
         if handle_invar:
             invar_in_global = [var for var in stage.invars if var in invar_set]
+            # add intermediate vars
+            intermediate_var = [
+                var for var in stage.invars if var in fwd_intermediates
+            ]
+            invars = invar_in_global + intermediate_var
             stage_invar_shardings = get_vars_to_sharding_specs(
-                invar_in_global, mesh_shape, mesh_axis_names)
+                invars, mesh_shape, mesh_axis_names)
         else:
             stage_invar_shardings = {}
         # outvars
@@ -458,13 +456,17 @@ def shard_each_stage(jax_all_stages, virtual_meshes, schedule, num_meshes,
         compile_intermediate = [None] * num_meshes
     total_flops = 0
     for mesh_idx in range(num_meshes):
-        input_sharding_dict = input_sharding_dicts[mesh_idx]
-        output_sharding_dict = output_sharding_dicts[mesh_idx]
         virtual_mesh = virtual_meshes[mesh_idx]
         logical_mesh = virtual_mesh.get_logical_mesh(
             logical_mesh_shapes[mesh_idx])
         autosharding_option = dataclasses.replace(
             default_as_option, **autosharding_option_dicts[mesh_idx])
+
+        # Predefined shardings. stage_input_sharding should have shardings for
+        # all parameters, while the sharding dict can have only a portion of
+        # all parameters.
+        input_sharding_dict = input_sharding_dicts[mesh_idx]
+        output_sharding_dict = output_sharding_dicts[mesh_idx]
         stage_input_sharding = stage_input_shardings[mesh_idx]
 
         # Setup dummy stages

--- a/alpa/pipeline_parallel/compile_executable.py
+++ b/alpa/pipeline_parallel/compile_executable.py
@@ -357,6 +357,9 @@ def get_manual_input_output_sharding_specs(stages, mesh_shapes, ms_option,
     intermediate_to_pspec = {}
     if ms_option.pipeline_intermediate_axes is not None:
         for v in fwd_intermediates:
+            # TODO: This is a simple heuristic: we simply replicate 1d tensors.
+            if len(v.aval.shape) <= 1:
+                continue
             intermediate_to_pspec[v] = get_intermediate_parsed_spec(
                 ms_option.pipeline_intermediate_axes, len(v.aval.shape))
 
@@ -393,7 +396,7 @@ def get_manual_input_output_sharding_specs(stages, mesh_shapes, ms_option,
             invar_in_global = [var for var in stage.invars if var in invar_set]
             # add intermediate vars
             intermediate_var = [
-                var for var in stage.invars if var in fwd_intermediates
+                var for var in stage.invars if var in intermediate_to_pspec
             ]
             invars = invar_in_global + intermediate_var
             stage_invar_shardings = get_vars_to_sharding_specs(

--- a/tests/pipeline_parallel/test_manual_sharding.py
+++ b/tests/pipeline_parallel/test_manual_sharding.py
@@ -136,10 +136,103 @@ class PipeshardManualShardingTest(unittest.TestCase):
         assert sorted(l1_apl_param) == sorted(l1_param_shape + l1_param_shape)
         assert sorted(l1_apl_root) == sorted(l1_param_shape)
 
+    def test_set_intermediate(self):
+
+        def fn(params, batch):
+            x, tgt = batch
+
+            def loss_fn(params):
+                w0, b0, w1, b1, w2, b2, w3, b3 = params
+                y = jax.nn.relu(x @ w0 + b0)
+                z = jax.nn.relu(y @ w1 + b1)
+                mark_pipeline_boundary()
+                u = jax.nn.relu(z @ w2 + b2)
+                v = jax.nn.softmax(u @ w3 + b3)
+                return jnp.mean((v - tgt)**2)
+
+            grads = alpa.grad(loss_fn)(params)
+            new_params = tree_map(lambda p, g: p - g, params, grads)
+            return new_params
+
+        # data
+        batch_size = 64
+        hiddens = [6, 8, 10, 12, 14]
+        params = itertools.chain(*[(jnp.ones((hiddens[i], hiddens[i + 1])),
+                                    jnp.ones((hiddens[i + 1],)))
+                                   for i in range(len(hiddens) - 1)])
+        params = tuple(params)
+        x = jnp.ones((batch_size, hiddens[0]))
+        tgt = jnp.ones((batch_size, hiddens[-1]))
+        batch = (x, tgt)
+
+        # partitions
+        mp_start = PartitionSpec(None, "model")
+        mp_end = PartitionSpec("model", None)
+        bias_partitioned = PartitionSpec("model")
+        replicated = None
+        dp = PartitionSpec("data", None)
+
+        param_axis_resources = (mp_start, bias_partitioned, mp_end,
+                                replicated) + (replicated, replicated,
+                                               replicated, replicated)
+        # We don't set target sharded here. Otherwise it gives hint for the spmd
+        # partitioner.
+        batch_axis_resources = (replicated, replicated)
+        in_axis_resources = (param_axis_resources, batch_axis_resources)
+        s_option = ManualStageOption([[0], [1]], [(1, 2)] * 2, [(1, 2)] * 2,
+                                     [{}] * 2)
+        submesh_axis_names = (("dummy", "model"), ("dummy", "data"))
+        pipeline_intermediate_axes = (("data", 0),)
+        ms_option = ManualShardingOption(
+            None,
+            submesh_axis_names,
+            in_axis_resources,
+            pipeline_intermediate_axes=pipeline_intermediate_axes)
+        text = self._get_fn_manual_sharding_with(fn, 2, s_option, ms_option,
+                                                 params, batch)
+        # Layer 1. It should have the correct intermediate shape.
+        l0_fwd, l1_fwd, l1_bwd, l0_bwd, _, _ = text
+        l1_param_shape = ("f32[10,12]", "f32[12]", "f32[12,14]", "f32[14]")
+        intermediate_sharded = ("f32[16,10]",)
+        l1_fwd_param = HloParser.parse_param_shapes(
+            HloParser.get_param_line(l1_fwd))
+        assert self._is_superset_with_x_more(
+            l1_fwd_param, intermediate_sharded + l1_param_shape, 1)
+
+        l1_bwd_param = HloParser.parse_param_shapes(
+            HloParser.get_param_line(l1_bwd))
+        l1_bwd_root = HloParser.parse_root_shapes(
+            HloParser.get_root_line(l1_bwd))
+        # the donated accumulated gradient are at first
+        assert sorted(l1_bwd_param[:4]) == sorted(l1_param_shape)
+        assert sorted(l1_bwd_root) == sorted(intermediate_sharded +
+                                             l1_param_shape)
+
+        # Layer 0. It should not have any data parallelization.
+        l0_param_shape = ("f32[6,4]", "f32[4]", "f32[4,10]", "f32[10]")
+        l0_batch_shape = ("f32[32,6]",)
+        intermediate_replicated = ("f32[32,10]")
+        l0_fwd_param = HloParser.parse_param_shapes(
+            HloParser.get_param_line(l0_fwd))
+        l0_fwd_root = HloParser.parse_root_shapes(
+            HloParser.get_root_line(l0_fwd))
+        assert sorted(l0_fwd_param) == sorted(l0_param_shape + l0_batch_shape)
+        l0_bwd_param = HloParser.parse_param_shapes(
+            HloParser.get_param_line(l0_bwd))
+        l0_bwd_root = HloParser.parse_root_shapes(
+            HloParser.get_root_line(l0_bwd))
+        # the donated accumulated gradient are at first
+        assert sorted(l0_bwd_param[:4]) == sorted(l0_param_shape)
+        assert sorted(l0_bwd_root) == sorted(l0_param_shape)
+
+        assert intermediate_replicated in l0_bwd_param
+        assert intermediate_replicated in l0_fwd_root
+
 
 def suite():
     suite = unittest.TestSuite()
     suite.addTest(PipeshardManualShardingTest("test_set_input_output"))
+    suite.addTest(PipeshardManualShardingTest("test_set_intermediate"))
     return suite
 
 


### PR DESCRIPTION
1. Pass the `global_config` to `MeshHostWorker`'s constructor. This allows a user to specify nccl related configs and more;
2. Set manual sharding of intermediate tensors. Prior to this, we can only set data parallelism for intermediate stages with global inputs like `attention_mask`.